### PR TITLE
Make state route dynaic based on id

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import CssBaseline from '@material-ui/core/CssBaseline';
 import { ThemeProvider, StylesProvider } from '@material-ui/core/styles';
-import { BrowserRouter, Route, Switch } from 'react-router-dom';
+import { BrowserRouter, Route, Redirect, Switch } from 'react-router-dom';
 
 import ModelPage from 'screens/ModelPage';
 import HomePage from 'screens/HomePage';
-import ComingSoon from 'screens/ComingSoon/ComingSoon';
+// import ComingSoon from 'screens/ComingSoon/ComingSoon';
 import AppBar from 'components/AppBar/AppBar';
 import Footer from 'components/Footer/Footer';
 import theme from 'assets/theme';
@@ -19,16 +19,13 @@ export default function App() {
         <BrowserRouter>
           <AppBar />
           <Switch>
-            <Route path="/faq" component={ComingSoon} />
-            <Route path="/about" component={ComingSoon} />
-            <Route path="/donate" component={ComingSoon} />
-            {Object.keys(STATES).map(s => (
-              <Route path={`/${s}`}>
-                <ModelPage location={`${s}`} locationName={STATES[s]} />
-              </Route>
-            ))}
-            <Route path="/">
-              <HomePage />
+            <Route exact path="/" component={HomePage} />
+            <Route path="/state/:id" component={ModelPage} />
+            {/* <Route path="/faq" component={ComingSoon} /> */}
+            {/* <Route path="/about" component={ComingSoon} /> */}
+            {/* <Route path="/donate" component={ComingSoon} /> */}
+            <Route path="/*">
+              <Redirect to="/" />
             </Route>
           </Switch>
           <Footer />

--- a/src/components/Map/Map.js
+++ b/src/components/Map/Map.js
@@ -1,11 +1,10 @@
 import React, { Component, useState } from 'react';
-import './../../App.css'; /* optional for styling like the :hover pseudo-class */
-import USAMap from "react-usa-map";
-import { Redirect } from "react-router-dom";
+import 'App.css'; /* optional for styling like the :hover pseudo-class */
+import USAMap from 'react-usa-map';
+import { Redirect } from 'react-router-dom';
+import { STATES } from 'utils/constants';
 
-const STATES = ["AL", "AK", "AZ", "AR", "CA", "CO", "CT", "DE", "FL", "GA", "HI", "ID", "IL", "IN", "IA", "KS", "KY", "LA", "ME", "MD", "MA", "MI", "MN", "MS", "MO", "MT", "NE", "NV", "NH", "NJ", "NM", "NY", "NC", "ND", "OH", "OK", "OR", "PA", "RI", "SC", "SD", "TN", "TX", "UT", "VT", "VA", "WA", "WV", "WI", "WY"];
-
-function Map () {
+function Map() {
   let [redirectTarget, setRedirectTarget] = useState();
 
   if (redirectTarget) {
@@ -13,27 +12,26 @@ function Map () {
   }
 
   /* mandatory */
-  let mapHandler = (event) => {
-    alert("No model yet");
+  let mapHandler = event => {
+    alert('No model yet');
   };
 
-  /* optional customization of filling per state and calling custom callbacks per state */
-  let statesCustomConfig = () => {
-    let config = {};
-    for (var i=0; i<STATES.length; i++) {
-      let state = STATES[i];
-      config[state] = {
-          fill: "rgba(1,1,1,0.7)",
+  const statesCustomConfig = () =>
+    Object.keys(STATES).reduce((config, currState) => {
+      return {
+        ...config,
+        [currState]: {
+          fill: 'rgba(1,1,1,0.7)',
           clickHandler: event => {
-            setRedirectTarget(`/${state}`);
-          }};
-    }
-    return config;
-  };
+            setRedirectTarget(`/state/${currState}`);
+          },
+        },
+      };
+    }, {});
 
   return (
     <div className="App">
-      <USAMap width="100%" height="auto" customize={statesCustomConfig()}   />
+      <USAMap width="100%" height="auto" customize={statesCustomConfig()} />
     </div>
   );
 }

--- a/src/screens/ModelPage.js
+++ b/src/screens/ModelPage.js
@@ -1,12 +1,16 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useParams } from 'react-router-dom';
 import { Line } from 'react-chartjs-2';
 import 'chartjs-plugin-annotation';
 import Header from 'components/Header/Header';
+import { STATES } from 'utils/constants';
 
 import { useModelDatas, Model } from 'utils/model';
 
-function ModelPage({ location, locationName }) {
+function ModelPage() {
+  const { id: location } = useParams();
+  const locationName = STATES[location];
+
   let modelDatas = useModelDatas(location);
 
   if (!modelDatas) {
@@ -20,8 +24,7 @@ function ModelPage({ location, locationName }) {
   });
   let distancing = {
     now: new Model(modelDatas[1], {
-      intervention:
-        'NorCal “Shelter-in-place”',
+      intervention: 'NorCal “Shelter-in-place”',
       durationDays: 90,
       r0: 1.2,
     }),
@@ -68,11 +71,15 @@ function ModelPage({ location, locationName }) {
   // Prep datasets for graphs
   // short label: 'Distancing Today for 2 Months', 'Wuhan Level Containment for 1 Month'
   let scenarioComparisonOverTime = duration => [
-    baseline.getDataset("hospitalizations", duration, "red"),
-    distancing.now.getDataset("hospitalizations", duration, "blue"),
-    distancingPoorEnforcement.now.getDataset("hospitalizations", duration, "orange"),
-    contain.now.getDataset("hospitalizations", duration, "green"),
-    baseline.getDataset("beds", duration, "black", "Hospital Beds")
+    baseline.getDataset('hospitalizations', duration, 'red'),
+    distancing.now.getDataset('hospitalizations', duration, 'blue'),
+    distancingPoorEnforcement.now.getDataset(
+      'hospitalizations',
+      duration,
+      'orange',
+    ),
+    contain.now.getDataset('hospitalizations', duration, 'green'),
+    baseline.getDataset('beds', duration, 'black', 'Hospital Beds'),
   ];
   let scenarioComparison = scenarioComparisonOverTime(100);
 
@@ -162,7 +169,14 @@ function ModelPage({ location, locationName }) {
             </li>
           </ul>
         </Panel>
-        <h3 style={{ textAlign: 'center', paddingTop:20, paddingBottom:20, border: '1px solid #ccc'  }}>
+        <h3
+          style={{
+            textAlign: 'center',
+            paddingTop: 20,
+            paddingBottom: 20,
+            border: '1px solid #ccc',
+          }}
+        >
           <a href="https://forms.gle/Dn2cjNMJxKyrwY4J9">Sign up</a> to stay up
           to date on our tool as we improve it's data-set, models, and
           capabilities.
@@ -173,25 +187,17 @@ function ModelPage({ location, locationName }) {
 }
 
 function Panel({ children, title }) {
-  return (
-    <div
-      style={{
-      }}
-    >
-      {children}
-    </div>
-  );
+  return <div style={{}}>{children}</div>;
 }
 
 function formatNumber(num) {
   if (num > 1000) {
     return (Math.round(num / 1000) * 1000).toLocaleString();
   } else if (num > 0) {
-    return "<1000";
+    return '<1000';
   } else {
     return 0;
   }
-
 }
 
 function formatBucketedNumber(num, total) {
@@ -320,7 +326,7 @@ function OutcomesTable({ models, asterisk, timeHorizon, title, colors }) {
 function OutcomesRow({ model, label, timeHorizon, color }) {
   return (
     <tr>
-      <td style={{fontWeight: 'bold', color}}>{label}</td>
+      <td style={{ fontWeight: 'bold', color }}>{label}</td>
       <td>
         {formatBucketedNumber(
           timeHorizon
@@ -331,8 +337,8 @@ function OutcomesRow({ model, label, timeHorizon, color }) {
       </td>
       {timeHorizon ? (
         <td>
-          {model.dateOverwhelmed && (model.dateOverwhelmed <
-          model.dateAfter(timeHorizon))
+          {model.dateOverwhelmed &&
+          model.dateOverwhelmed < model.dateAfter(timeHorizon)
             ? model.dateOverwhelmed.toDateString()
             : model.dateOverwhelmed
             ? 'outside time bound'


### PR DESCRIPTION
This PR
- redirects all unknown routes to `/`
- makes the `/state/:id` route dynamic, taking the stats abbreviation as an ID.  Currently, there's no error handling (for example, if you manually typed `/state/westeros` but for now, I think that's an edge case we can bump