### PR TITLE
Add social media share buttons

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -32,6 +32,10 @@
     <meta property="og:type" content="website">
     <meta property="og:image" content="https://covidactnow.org/covidactnow1.png">
     <meta property="og:image" content="https://covidactnow.org/covidactnow2.png">
+    <meta name="twitter:title" content="This model predicts the last day each state can act before the point of no return">
+    <meta name="twitter:description" content="The only thing that matters right now is the speed of your response">
+    <meta name="twitter:image" content="https://covidactnow.org/covidactnow2.png">
+    <meta name="twitter:card" content="summary_large_image">
     <title>Coronavirus Act Now</title>
 
     <!-- Global site tag (gtag.js) - Google Analytics -->
@@ -47,6 +51,9 @@
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div id="fb-root"></div>
+    <script async defer crossorigin="anonymous" src="https://connect.facebook.net/en_US/sdk.js#xfbml=1&version=v6.0"></script>
+    
     <div id="root"></div>
     <!--
       This HTML file is a template.

--- a/public/index.html
+++ b/public/index.html
@@ -51,9 +51,6 @@
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
-    <div id="fb-root"></div>
-    <script async defer crossorigin="anonymous" src="https://connect.facebook.net/en_US/sdk.js#xfbml=1&version=v6.0"></script>
-    
     <div id="root"></div>
     <!--
       This HTML file is a template.

--- a/src/components/AppBar/AppBar.js
+++ b/src/components/AppBar/AppBar.js
@@ -19,6 +19,7 @@ import {
 } from './AppBar.style';
 import {
   EmailShareButton,
+  FacebookIcon,
   FacebookShareButton,
   InstapaperShareButton,
   LinkedinShareButton,
@@ -67,8 +68,15 @@ const _AppBar = () => {
           </MenuTitle>
         </Left>
         <StyledDesktopMenu>
+          <FacebookShareButton
+            url={shareURL}
+            quote={shareTitle}
+            style={{ alignItems: 'center', display: 'flex', paddingRight: 28 }}>
+            <FacebookIcon size={32} round={true} />
+          </FacebookShareButton>
           <TwitterShareButton
-            url="https://covidactnow.org"
+            url={shareURL}
+            title={shareTitle}
             style={{ alignItems: 'center', display: 'flex' }}>
             <TwitterIcon size={32} round={true} />
           </TwitterShareButton>
@@ -81,7 +89,8 @@ const _AppBar = () => {
         </StyledDesktopMenu>
         <StyledMobileMenu>
             <TwitterShareButton
-              url="https://covidactnow.org"
+              url={shareURL}
+              title={shareTitle}
               style={{ alignItems: 'center', display: 'flex' }}>
               <TwitterIcon size={32} round={true} />
             </TwitterShareButton>

--- a/src/components/AppBar/AppBar.js
+++ b/src/components/AppBar/AppBar.js
@@ -47,6 +47,9 @@ const _AppBar = () => {
     history.push(route)
   };
 
+  const shareURL = "https://covidactnow.org"
+  const shareTitle = "See a forecast for how long each US state has until COVID-19 overwhelms hospitals and how interventions could flatten the curve:"
+
   return (
     <AppBar position="sticky">
       <Wrapper>

--- a/src/screens/ModelPage/ModelPage.js
+++ b/src/screens/ModelPage/ModelPage.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { useParams } from 'react-router-dom';
 import { Line } from 'react-chartjs-2';
 import 'chartjs-plugin-annotation';

--- a/src/screens/ModelPage/ModelPage.js
+++ b/src/screens/ModelPage/ModelPage.js
@@ -1,14 +1,23 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 import { Line } from 'react-chartjs-2';
 import 'chartjs-plugin-annotation';
+
+import {
+  FacebookShareButton,
+  TwitterShareButton,
+  LinkedinShareButton,
+  FacebookIcon,
+  TwitterIcon,
+  LinkedinIcon,
+} from "react-share";
 
 import Footer from 'components/Footer/Footer';
 import Header from 'components/Header/Header';
 import Chart from 'components/Chart/Chart';
 import Callout from 'components/Callout/Callout';
 import Newsletter from 'components/Newsletter/Newsletter';
-import { Wrapper, Content } from './ModelPage.style';
+import { Wrapper, Content, ShareContainer, ShareSpacer } from './ModelPage.style';
 import { STATES } from 'enums';
 
 import { useModelDatas, Model } from 'utils/model';
@@ -46,6 +55,7 @@ let lowercaseStates = [
   'TX',
   'WA',
 ];
+
 function ModelPage() {
   const { id: location } = useParams();
   const locationName = STATES[location];
@@ -56,6 +66,9 @@ function ModelPage() {
     locationNameForDataLoad = location.toLowerCase();
   }
   let modelDatas = useModelDatas(locationNameForDataLoad);
+  const shareURL = "https://covidactnow.org";
+  const shareQuote = `This is when ${locationName}'s hospital system will be overloaded by COVID-19:`;
+  const hashtag = "#COVIDActNow"
 
   if (!modelDatas) {
     return <Header locationName={locationName} />;
@@ -147,13 +160,27 @@ function ModelPage() {
           </Callout>
 
           <Callout borderColor="black">
-            {/*<div style={{  }}>
-              Share Alaska's COVID trends:
-            </div>*/}
-            <div class="fb-share-button" data-href="https://covidactnow.org" data-layout="button" data-size="large"><a target="_blank" href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fcovidactnow.org%2F&amp;src=sdkpreparse" class="fb-xfbml-parse-ignore">Share</a></div>
-            <a href="https://twitter.com/share?ref_src=twsrc%5Etfw" class="twitter-share-button" data-size="large" data-show-count="false">Tweet</a><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-            <script src="https://platform.linkedin.com/in.js" type="text/javascript">lang: en_US</script>
-            <script type="IN/Share" data-url="https://www.linkedin.com"></script>
+            <ShareContainer>
+
+              <div style={{paddingRight: 28, fontWeight: "bold"}}>{`Share ${locationName}'s COVID-19 trends:`}</div>
+
+              <FacebookShareButton url={shareURL} quote={shareQuote} hashtag={hashtag}>
+                <FacebookIcon size={40} round={false} borderRadius={5} />
+              </FacebookShareButton>
+
+              <ShareSpacer />
+
+              <TwitterShareButton url={shareURL} title={shareQuote} >
+                <TwitterIcon size={40} round={false} borderRadius={5} />
+              </TwitterShareButton>
+
+              <ShareSpacer />
+
+              <LinkedinShareButton url={shareURL} title={shareQuote} hashtags={[hashtag]}>
+                <LinkedinIcon size={40} round={false} borderRadius={5} />
+              </LinkedinShareButton>
+
+            </ShareContainer>
           </Callout>
 
           <OutcomesTable

--- a/src/screens/ModelPage/ModelPage.js
+++ b/src/screens/ModelPage/ModelPage.js
@@ -146,6 +146,16 @@ function ModelPage() {
             <LastDatesToAct model={baseline} />
           </Callout>
 
+          <Callout borderColor="black">
+            {/*<div style={{  }}>
+              Share Alaska's COVID trends:
+            </div>*/}
+            <div class="fb-share-button" data-href="https://covidactnow.org" data-layout="button" data-size="large"><a target="_blank" href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fcovidactnow.org%2F&amp;src=sdkpreparse" class="fb-xfbml-parse-ignore">Share</a></div>
+            <a href="https://twitter.com/share?ref_src=twsrc%5Etfw" class="twitter-share-button" data-size="large" data-show-count="false">Tweet</a><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+            <script src="https://platform.linkedin.com/in.js" type="text/javascript">lang: en_US</script>
+            <script type="IN/Share" data-url="https://www.linkedin.com"></script>
+          </Callout>
+
           <OutcomesTable
             title="Predicted Outcomes after 3 Months"
             models={[

--- a/src/screens/ModelPage/ModelPage.style.js
+++ b/src/screens/ModelPage/ModelPage.style.js
@@ -12,3 +12,14 @@ export const Content = styled.div`
     padding: 0;
   }
 `;
+
+export const ShareSpacer = styled.div`
+	padding-right: 32px;
+`;
+
+export const ShareContainer = styled.div`
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+	justify-content: center;
+`;


### PR DESCRIPTION
Fixes https://github.com/covid-projections/covid-projections/issues/71

Adds Facebook share button to top bar.

Adds Facebook, Twitter, and Linkedin share buttons to state pages. We could integrate with the SDKs directly, but that introduces some design inconsistencies and it also adds a lot of weight and 3rd-party tracking to the page.

<img width="688" alt="Screen Shot 2020-03-21 at 10 01 28 PM" src="https://user-images.githubusercontent.com/11700818/77242839-252fbd80-6bc0-11ea-9b7a-30dd178e28ef.png">
