### PR TITLE
Add Facebook share to mobile menu

### DIFF
--- a/src/components/AppBar/AppBar.js
+++ b/src/components/AppBar/AppBar.js
@@ -131,6 +131,13 @@ const _AppBar = () => {
           </StyledTabs>
         </StyledDesktopMenu>
         <StyledMobileMenu>
+          <FacebookShareButton
+            url={shareURL}
+            title={shareTitle}
+            style={{ alignItems: 'center', display: 'flex', paddingRight: 8 }}
+          >
+            <FacebookIcon size={32} round={true} />
+          </FacebookShareButton>
           <TwitterShareButton
             url={shareURL}
             title={shareTitle}


### PR DESCRIPTION
Adds the Facebook share button to the mobile menu as well (whoops).

<img width="266" alt="Screen Shot 2020-03-22 at 3 29 14 PM" src="https://user-images.githubusercontent.com/11700818/77262243-f2360a00-6c51-11ea-85d6-3e7add27ceb3.png">
