### PR TITLE
Remove remaining warnings from CRA

### DIFF
--- a/src/components/AppBar/AppBar.js
+++ b/src/components/AppBar/AppBar.js
@@ -41,7 +41,8 @@ const _AppBar = () => {
   });
   const locationName = match && match.params ? STATES[match.params.id] : '';
 
-  const goTo = route => {
+  const goTo = route => e => {
+    e.preventDefault();
     setOpen(false);
     setPanelIdx(String(panels.indexOf(route)));
 
@@ -63,15 +64,15 @@ const _AppBar = () => {
       <Wrapper>
         <Left>
           {pathname.includes('state') ? (
-            <ArrowBack onClick={() => goTo('/')} />
+            <ArrowBack onClick={goTo('/')} />
           ) : (
-            <Logo onClick={() => goTo('/')} />
+            <Logo onClick={goTo('/')} />
           )}
           <MenuTitle>
             <Typography
               variant="button"
               component={Link}
-              onClick={() => goTo('/')}
+              onClick={goTo('/')}
               style={{ textDecoration: 'none', color: 'black' }}
             >
               COVID ACT NOW
@@ -99,25 +100,25 @@ const _AppBar = () => {
               label="Map"
               value="0"
               disableRipple
-              onClick={() => goTo('/')}
+              onClick={goTo('/')}
             />
             <StyledTab
               label="About"
               value="1"
               disableRipple
-              onClick={() => goTo('/about')}
+              onClick={goTo('/about')}
             />
             <StyledTab
               label="Model"
               value="2"
               disableRipple
-              onClick={() => goTo('/model')}
+              onClick={goTo('/model')}
             />
             <StyledTab
               label="Endorsements"
               value="3"
               disableRipple
-              onClick={() => goTo('/endorsements')}
+              onClick={goTo('/endorsements')}
             />
           </StyledTabs>
         </StyledDesktopMenu>

--- a/src/components/AppBar/MobileMenu.js
+++ b/src/components/AppBar/MobileMenu.js
@@ -1,21 +1,21 @@
 import React from 'react';
-import { 
+import {
   StyledMenu,
 } from './AppBar.style';
 
 const MobileMenu = ({ open, goTo }) => {
   return (
     <StyledMenu open={open}>
-      <a onClick={() => goTo('/')}>
+      <a onClick={goTo('/')} href="/">
         Map
       </a>
-      <a onClick={() => goTo('/about')}>
+      <a onClick={goTo('/about')} href="/about">
         About
       </a>
-      <a onClick={() => goTo('/model')}>
+      <a onClick={goTo('/model')} href="/model">
         Model
       </a>
-      <a onClick={() => goTo('/endorsements')}>
+      <a onClick={goTo('/endorsements')} href="/endorsements">
         Endorsements
       </a>
     </StyledMenu>

--- a/src/utils/model.js
+++ b/src/utils/model.js
@@ -17,13 +17,13 @@ async function fetchAll(urls) {
 export function useModelDatas(location) {
   const [modelDatas, setModelDatas] = useState(null);
 
-  async function fetchData() {
-    let urls = Array.from({ length: 8 }, (x, i) => `/data/${location}.${i}.json`);
-    let loadedModelDatas = await fetchAll(urls);
-    setModelDatas(loadedModelDatas);
-  }
 
   useEffect(() => {
+    async function fetchData() {
+      let urls = Array.from({ length: 8 }, (x, i) => `/data/${location}.${i}.json`);
+      let loadedModelDatas = await fetchAll(urls);
+      setModelDatas(loadedModelDatas);
+    }
     fetchData();
   }, [location]);
   return modelDatas;
@@ -78,7 +78,7 @@ export class Model {
     let overwhelmedIdx = this.dates.findIndex(
       (num, idx) => this.hospitalizations[idx] > this.beds[idx],
     );
-    if (overwhelmedIdx == -1) {
+    if (overwhelmedIdx === -1) {
       this.dateOverwhelmed = null;
     } else {
       let overwhelmedBy =


### PR DESCRIPTION
Fixed a few link a11y issues. Main difference is that `goTo` now returns an event handler, rather than needing to be called as part of an event handler. This is done so that `goTo` can call `event.preventDefault()`. 

Terminal output from `yarn start` is now clean. Browser console still has some warnings and errors, but many are from dependencies and are probably not worth chasing down right now.