### PR TITLE
[WIP - do not review] Add CTA button to directly take user to their state page

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -48,6 +48,8 @@
       gtag('config', 'G-HFCDC7K5G1');
     </script>
 
+    <script src="https://cdn.jsdelivr.net/gh/bigdatacloudapi/js-reverse-geocode-client@latest/bigdatacloud_reverse_geocode.min.js" type="text/javascript"></script>
+
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/App.css
+++ b/src/App.css
@@ -66,6 +66,7 @@ tr {
 
 .Map path {
   pointer-events: all;
+  transition: fill 0.8s ease-out;
 }
 
 .Map path:hover {

--- a/src/App.css
+++ b/src/App.css
@@ -66,7 +66,7 @@ tr {
 
 .Map path {
   pointer-events: all;
-  transition: fill 0.8s ease-out;
+  transition: fill 0.5s ease-out;
 }
 
 .Map path:hover {

--- a/src/components/Map/Map.js
+++ b/src/components/Map/Map.js
@@ -3,7 +3,6 @@ import '../../App.css'; /* optional for styling like the :hover pseudo-class */
 import USAMap from 'react-usa-map';
 import { Redirect } from 'react-router-dom';
 import Grid from '@material-ui/core/Grid';
-import { LocationOn } from '@material-ui/icons';
 import {
   STATES,
   STATE_TO_INTERVENTION,
@@ -12,7 +11,11 @@ import {
   INTERVENTION_EFFICACY_ORDER_ASC,
 } from 'enums';
 import { Legend, LegendItem } from './Legend';
-import { CallToAction } from './Map.style';
+import {
+  LocatingText,
+  MapInstruction,
+  MapInstructionMobile,
+} from './Map.style';
 
 const ROULETTE_LOADING_INTERVAL = 200;
 
@@ -149,16 +152,32 @@ function Map() {
     });
   }
 
+  function mobileMapInstruction() {
+    const tapInstruction = `${
+      seeMyStateButtonHidden ? 'Tap' : ' or tap'
+    } the map to see projections`;
+    return [
+      !seeMyStateButtonHidden && (
+        <span className="stateLink" onClick={seeMyStateButtonHandler}>
+          See your state
+        </span>
+      ),
+      <span> {tapInstruction} </span>,
+    ];
+  }
+
   return (
     <div className="Map">
-      {!seeMyStateButtonHidden && (
-        <CallToAction disabled={isLocating} onClick={seeMyStateButtonHandler}>
-          <div className={isLocating ? 'pulse' : ''}>
-            {isLocating ? 'Locating...' : 'see my state'}
-          </div>
-          {!isLocating && <LocationOn fontSize="inherit" />}
-        </CallToAction>
-      )}
+      <MapInstruction>
+        Click the map to see projections for your state
+      </MapInstruction>
+      <MapInstructionMobile>
+        {isLocating ? (
+          <LocatingText>Locating...</LocatingText>
+        ) : (
+          mobileMapInstruction()
+        )}
+      </MapInstructionMobile>
       <Grid container spacing={2}>
         <Grid item xs="12" md="8">
           <USAMap width="100%" height="auto" customize={statesCustomConfig} />

--- a/src/components/Map/Map.js
+++ b/src/components/Map/Map.js
@@ -1,8 +1,9 @@
-import React, { useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import '../../App.css'; /* optional for styling like the :hover pseudo-class */
 import USAMap from 'react-usa-map';
 import { Redirect } from 'react-router-dom';
 import Grid from '@material-ui/core/Grid';
+import { LocationOn } from '@material-ui/icons';
 import {
   STATES,
   STATE_TO_INTERVENTION,
@@ -11,17 +12,98 @@ import {
   INTERVENTION_EFFICACY_ORDER_ASC,
 } from 'enums';
 import { Legend, LegendItem } from './Legend';
+import { CallToAction } from './Map.style';
+
+const ROULETTE_LOADING_INTERVAL = 200;
 
 function Map() {
   let [redirectTarget, setRedirectTarget] = useState();
+  let [highlightedState, setHighlightedState] = useState();
+  let [isLocating, setIsLocating] = useState(false);
+  let [seeMyStateButtonHidden, setSeeMyStateButtonHidden] = useState(true);
+  let [geolocatedStateCode, setGeolocatedStateCode] = useState(null);
+
+  const reverseGeocoder = new window.BDCReverseGeocode();
+
+  const fetchStateCode = useCallback(() => {
+    function reverseGeocodeStateFromLocation(position) {
+      return new Promise((resolve, reject) => {
+        reverseGeocoder.getClientLocation(
+          {
+            latitude: position.coords.latitude,
+            longitude: position.coords.longitude,
+          },
+          function (result) {
+            if (!result) {
+              reject();
+              return;
+            }
+            resolve(result);
+          },
+        );
+      });
+    }
+
+    return new Promise((resolve, reject) => {
+      getClientLocation()
+        .then(reverseGeocodeStateFromLocation)
+        .then(geocodeResult => {
+          const stateName = geocodeResult.principalSubdivision;
+          const stateCode = Object.keys(STATES).find(
+            key => STATES[key] === stateName,
+          );
+          setGeolocatedStateCode(stateCode);
+          resolve(stateCode);
+        })
+        .catch(error => {
+          setIsLocating(false);
+          setHighlightedState(null);
+          setSeeMyStateButtonHidden(true);
+        });
+    });
+  }, [reverseGeocoder]);
+
+  useEffect(() => {
+    function checkLocationPermission() {
+      navigator.permissions
+        .query({ name: 'geolocation' })
+        .then(function (result) {
+          switch (result.state) {
+            case 'granted':
+              fetchStateCode();
+              setSeeMyStateButtonHidden(false);
+              break;
+            case 'denied':
+              setSeeMyStateButtonHidden(true);
+              break;
+            default:
+              setSeeMyStateButtonHidden(false);
+          }
+        });
+    }
+    checkLocationPermission();
+
+    let rouletteAnimationTimer = null;
+    if (isLocating) {
+      const animationInterval = ROULETTE_LOADING_INTERVAL;
+      rouletteAnimationTimer = setInterval(() => {
+        const stateKeys = Object.keys(STATES);
+        const keyIndex = Math.floor(Math.random() * stateKeys.length);
+        setHighlightedState(stateKeys[keyIndex]);
+      }, animationInterval);
+    } else {
+      clearTimeout(rouletteAnimationTimer);
+    }
+    return () => {
+      clearTimeout(rouletteAnimationTimer);
+    };
+  }, [isLocating, fetchStateCode]);
 
   if (redirectTarget) {
     return <Redirect push to={redirectTarget} />;
   }
 
   const legendConfig = {};
-
-  //comment
 
   const statesCustomConfig = Object.keys(STATES).reduce((config, currState) => {
     const intervention = STATE_TO_INTERVENTION[currState];
@@ -34,7 +116,11 @@ function Map() {
     return {
       ...config,
       [currState]: {
-        fill: interventionColor,
+        fill: `${
+          currState === highlightedState
+            ? `${interventionColor.slice(0, -1)},0.5)`
+            : interventionColor
+        }`,
         clickHandler: event => {
           setRedirectTarget(`/state/${currState}`);
         },
@@ -42,8 +128,37 @@ function Map() {
     };
   }, {});
 
+  function seeMyStateButtonHandler() {
+    setIsLocating(true);
+
+    if (geolocatedStateCode) {
+      setRedirectTarget(`/state/${geolocatedStateCode}`);
+      return;
+    }
+
+    fetchStateCode().then(stateCode =>
+      setRedirectTarget(`/state/${stateCode}`),
+    );
+  }
+
+  function getClientLocation() {
+    return new Promise((resolve, reject) => {
+      navigator.geolocation.getCurrentPosition(resolve, reject, {
+        enableHighAccuracy: false,
+      });
+    });
+  }
+
   return (
     <div className="Map">
+      {!seeMyStateButtonHidden && (
+        <CallToAction disabled={isLocating} onClick={seeMyStateButtonHandler}>
+          <div className={isLocating ? 'pulse' : ''}>
+            {isLocating ? 'Locating...' : 'see my state'}
+          </div>
+          {!isLocating && <LocationOn fontSize="inherit" />}
+        </CallToAction>
+      )}
       <Grid container spacing={2}>
         <Grid item xs="12" md="8">
           <USAMap width="100%" height="auto" customize={statesCustomConfig} />

--- a/src/components/Map/Map.js
+++ b/src/components/Map/Map.js
@@ -21,6 +21,8 @@ function Map() {
 
   const legendConfig = {};
 
+  //comment
+
   const statesCustomConfig = Object.keys(STATES).reduce((config, currState) => {
     const intervention = STATE_TO_INTERVENTION[currState];
     const interventionColor = INTERVENTION_COLOR_MAP[intervention];

--- a/src/components/Map/Map.style.js
+++ b/src/components/Map/Map.style.js
@@ -1,0 +1,45 @@
+import styled from 'styled-components';
+
+export const CallToActionButton = styled.button`
+  background-color: rgba(60,121,201);
+  color: white;
+  padding: 0.66rem 2rem;
+  border-radius: 4px;
+  font-size: 16px;
+  cursor: pointer;
+  border: none;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.24);
+  transition: all 0.2s;
+
+  :hover {
+    background-color: rgba(70,131,210);
+    box-shadow: 0 4px 12px rgba(0,0,0,0.19), 0 3px 3px rgba(0,0,0,0.23);
+  }
+
+  @media (max-width: 600px) {
+    padding: 0.5rem 2rem;
+  	margin-bottom: 0.25rem;
+
+    h6 {
+      font-size: 14px;
+    }
+
+  }
+`;
+
+export const MapInstructionsContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem 5rem;
+
+  div {
+  	margin-left: .5rem;
+  }
+
+  @media (max-width: 600px) {
+  	flex-direction: column;
+  	padding: 1.5rem 1rem;
+  }
+`;

--- a/src/components/Map/Map.style.js
+++ b/src/components/Map/Map.style.js
@@ -16,6 +16,17 @@ export const CallToActionButton = styled.button`
     box-shadow: 0 4px 12px rgba(0,0,0,0.19), 0 3px 3px rgba(0,0,0,0.23);
   }
 
+  @keyframes opacityPulse {
+    0%   { opacity: 1; }
+    50%  { opacity: 0.6; }
+    100% { opacity: 1; }
+  }
+
+  h6.pulse {
+    animation: opacityPulse 1.5s linear;
+    animation-iteration-count: infinite; 
+  }
+
   @media (max-width: 600px) {
     padding: 0.5rem 2rem;
   	margin-bottom: 0.25rem;

--- a/src/components/Map/Map.style.js
+++ b/src/components/Map/Map.style.js
@@ -1,8 +1,6 @@
 import styled from 'styled-components';
 
-export const CallToAction = styled.div`
-  display: none;
-
+export const LocatingText = styled.div`
   @keyframes opacityPulse {
     0% {
       opacity: 1;
@@ -15,20 +13,28 @@ export const CallToAction = styled.div`
     }
   }
 
-  div.pulse {
-    animation: opacityPulse 1.5s linear;
-    animation-iteration-count: infinite;
-  }
+  animation: opacityPulse 1.5s linear;
+  animation-iteration-count: infinite;
+`;
+
+export const MapInstruction = styled.div`
+  padding: 1rem 0.5rem;
 
   @media (max-width: 600px) {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 14px;
-    transition: all 0.2s;
+    display: none;
+  }
+`;
 
-    div {
-      padding-right: 4px;
+export const MapInstructionMobile = styled.div`
+  display: none;
+  padding: 1rem 0.5rem;
+
+  @media (max-width: 600px) {
+    display: block;
+
+    span.stateLink {
+      color: blue;
+      cursor: pointer;
     }
   }
 `;

--- a/src/components/Map/Map.style.js
+++ b/src/components/Map/Map.style.js
@@ -1,56 +1,34 @@
 import styled from 'styled-components';
 
-export const CallToActionButton = styled.button`
-  background-color: rgba(60,121,201);
-  color: white;
-  padding: 0.66rem 2rem;
-  border-radius: 4px;
-  font-size: 16px;
-  cursor: pointer;
-  border: none;
-  box-shadow: 0 1px 3px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.24);
-  transition: all 0.2s;
-
-  :hover {
-    background-color: rgba(70,131,210);
-    box-shadow: 0 4px 12px rgba(0,0,0,0.19), 0 3px 3px rgba(0,0,0,0.23);
-  }
+export const CallToAction = styled.div`
+  display: none;
 
   @keyframes opacityPulse {
-    0%   { opacity: 1; }
-    50%  { opacity: 0.6; }
-    100% { opacity: 1; }
-  }
-
-  h6.pulse {
-    animation: opacityPulse 1.5s linear;
-    animation-iteration-count: infinite; 
-  }
-
-  @media (max-width: 600px) {
-    padding: 0.5rem 2rem;
-  	margin-bottom: 0.25rem;
-
-    h6 {
-      font-size: 14px;
+    0% {
+      opacity: 1;
     }
-
+    50% {
+      opacity: 0.6;
+    }
+    100% {
+      opacity: 1;
+    }
   }
-`;
 
-export const MapInstructionsContainer = styled.div`
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  justify-content: center;
-  padding: 2rem 5rem;
-
-  div {
-  	margin-left: .5rem;
+  div.pulse {
+    animation: opacityPulse 1.5s linear;
+    animation-iteration-count: infinite;
   }
 
   @media (max-width: 600px) {
-  	flex-direction: column;
-  	padding: 1.5rem 1rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 14px;
+    transition: all 0.2s;
+
+    div {
+      padding-right: 4px;
+    }
   }
 `;

--- a/src/screens/About/About.js
+++ b/src/screens/About/About.js
@@ -159,11 +159,23 @@ const About = ({ children }) => {
               </Link>
             </li>
             <li>Communications Leaders</li>
-              <ul>  
-                 <li><a href="https://docs.google.com/document/d/17wx0L0cuV5mJHmyx7Lw6RHg5XGxBALzY671AWAysyXo/edit?ts=5e7a3d2f">Marketing Lead</a></li>
-                 <li><a href="https://docs.google.com/document/d/1MfGXLoqNuLcmnQiqBeNWNjLL-QWBHrDebCpOgkx6soI/edit?ts=5e7926dd">PR Lead</a></li>
-                 <li><a href="https://docs.google.com/document/d/1SHSx8C8j11UNpxyLVYGgnv106ho2cHg41f5AStgVPkU/edit?ts=5e792bd0">Community Manager / Social Media Lead</a></li>
-              </ul>
+            <ul>
+              <li>
+                <a href="https://docs.google.com/document/d/17wx0L0cuV5mJHmyx7Lw6RHg5XGxBALzY671AWAysyXo/edit?ts=5e7a3d2f">
+                  Marketing Lead
+                </a>
+              </li>
+              <li>
+                <a href="https://docs.google.com/document/d/1MfGXLoqNuLcmnQiqBeNWNjLL-QWBHrDebCpOgkx6soI/edit?ts=5e7926dd">
+                  PR Lead
+                </a>
+              </li>
+              <li>
+                <a href="https://docs.google.com/document/d/1SHSx8C8j11UNpxyLVYGgnv106ho2cHg41f5AStgVPkU/edit?ts=5e792bd0">
+                  Community Manager / Social Media Lead
+                </a>
+              </li>
+            </ul>
           </ul>
         </Typography>
         <Typography variant="body1" component="p">

--- a/src/screens/HomePage/HomePage.js
+++ b/src/screens/HomePage/HomePage.js
@@ -12,7 +12,7 @@ export default function HomePage() {
   return (
     <>
       <Header />
-      <main style={{ textAlign: 'center', paddingTop: 20, paddingBottom: 50 }}>
+      <main style={{ textAlign: 'center', paddingBottom: 50 }}>
         <div className="App" style={{ maxWidth: 900, margin: 'auto' }}>
           <Map />
           <div

--- a/src/screens/HomePage/HomePage.js
+++ b/src/screens/HomePage/HomePage.js
@@ -12,7 +12,7 @@ export default function HomePage() {
   return (
     <>
       <Header />
-      <main style={{ textAlign: 'center', paddingBottom: 50 }}>
+      <main style={{ textAlign: 'center', paddingTop: 20, paddingBottom: 50 }}>
         <div className="App" style={{ maxWidth: 900, margin: 'auto' }}>
           <Map />
           <div

--- a/src/screens/HomePage/HomePage.js
+++ b/src/screens/HomePage/HomePage.js
@@ -14,7 +14,6 @@ export default function HomePage() {
       <Header />
       <main style={{ textAlign: 'center', paddingBottom: 50 }}>
         <div className="App" style={{ maxWidth: 900, margin: 'auto' }}>
-          <p>Click the map to see projections for your state.</p>
           <Map />
           <div
             style={{

--- a/src/utils/model.js
+++ b/src/utils/model.js
@@ -62,13 +62,13 @@ export class Model {
     this.durationDays = parameters.durationDays || null /* permanent */;
     this.delayDays = parameters.delayDays || 0;
 
-    let _parseInt = (number) => {
+    let _parseInt = number => {
       // remove , in strings
-      if (typeof(number) == 'string') {
-        number = number.replace(/,/g, '')
+      if (typeof number == 'string') {
+        number = number.replace(/,/g, '');
       }
       return number ? parseInt(number) : 0;
-    }
+    };
 
     this.dates = data.map(row => new Date(row[COLUMNS.date]));
     this.dayZero = this.dates[0];


### PR DESCRIPTION
This PR does a couple of things:

1. States pulse slightly when the user is not hovering, to make it clear that the map is interactive. This might conflict slightly with the changes to the map colors, so happy to merge these changes after.

2. Adds a "See my state" button. When tapped, it prompts the user for their browser location, then reverse geocodes for their US state using [this api](https://www.bigdatacloud.com/geocoding-apis/free-reverse-geocode-to-city-api) which is free and unlimited for client-side use. I think this is important functionality, because it is difficult to tap on the smaller states on mobile. It's also a nice and clear call to action for people that won't read the instructional text. 

Here is what it looks like on desktop and mobile:  

This change: desktop
<img width="1101" alt="Screen Shot 2020-03-22 at 10 30 30 PM" src="https://user-images.githubusercontent.com/11700818/77287967-0d296e00-6c94-11ea-94f7-31ebf87bce72.png">
  

This change: mobile
<img width="386" alt="Screen Shot 2020-03-22 at 10 30 23 PM" src="https://user-images.githubusercontent.com/11700818/77287973-0f8bc800-6c94-11ea-8680-ccee89c4902f.png">
  

The style guide has black buttons, but I wanted to make the primary CTA inviting so I made it blue. Happy to change that if anyone has design guidance. 

Style guide button: desktop
<img width="1103" alt="Screen Shot 2020-03-22 at 10 31 28 PM" src="https://user-images.githubusercontent.com/11700818/77288180-80cb7b00-6c94-11ea-98e2-0c3ce8e32219.png">

