### PR TITLE
Rework "point-of-no-return" call to action.

### DIFF
--- a/src/screens/ModelPage/ModelPage.js
+++ b/src/screens/ModelPage/ModelPage.js
@@ -48,11 +48,8 @@ const CallToAction = ({ model, intervention }) => {
         return INTERVENTIONS.SHELTER_IN_PLACE;
       case INTERVENTIONS.SOCIAL_DISTANCING:
         return INTERVENTIONS.SHELTER_IN_PLACE;
-      case INTERVENTIONS.SHELTER_IN_PLACE:
-        // TODO: Are we okay recommending lockdown?
-        return INTERVENTIONS.LOCKDOWN;
       default:
-        return 'Stricter intervention';
+        return 'stricter intervention';
     }
   }
 
@@ -63,7 +60,7 @@ const CallToAction = ({ model, intervention }) => {
   ) {
     actionText = `${intervention} projected to successfully delay hospital overload by greater than 3 months.`;
   } else {
-    actionText = `To prevent hospital overload, you must implement ${suggestedIntervention()} by:`;
+    actionText = `To prevent hospital overload, ${suggestedIntervention()} must be implemented by:`;
     const earlyDate = new Date(model.dateOverwhelmed.getTime() - 14 * DAYS);
     const lateDate = new Date(model.dateOverwhelmed.getTime() - 9 * DAYS);
     actionDateRange = (


### PR DESCRIPTION
* We now have dynamic phrasing depending on current intervention and whether hospital overload is expected within 3 months.  See https://docs.google.com/document/d/1MA-hitauZ82XCRI_XZUY0G1fdsa9WkAsiWPOVaKNOJI/edit#
* Refactored entire Callout element into a dedicated CallToAction component (which subsumed the existing LastDatesToAct component).

New version for okay states:
![image](https://user-images.githubusercontent.com/206364/77474234-04d84c80-6dd4-11ea-823a-ce3eef74db3e.png)

New version for not-okay states:
![image](https://user-images.githubusercontent.com/206364/77475882-b8dad700-6dd6-11ea-828d-882baf769900.png)


As implemented it does not ever recommend "Social Distancing".  This is open for discussion.