### PR TITLE
Add table with intervention and hospital capacity status

### DIFF
--- a/src/assets/images/capacityIcons.js
+++ b/src/assets/images/capacityIcons.js
@@ -1,0 +1,85 @@
+import React from 'react';
+import { INTERVENTION_COLOR_MAP, INTERVENTIONS } from 'enums';
+
+const WarnLimitedAction = () => (
+  <svg
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M12 2C6.48 2 2 6.48 2 12C2 17.52 6.48 22 12 22C17.52 22 22 17.52 22 12C22 6.48 17.52 2 12 2ZM13 17H11V15H13V17ZM13 13H11V7H13V13Z"
+      fill={INTERVENTION_COLOR_MAP[INTERVENTIONS.LIMITED_ACTION]}
+    />
+  </svg>
+);
+
+const WarnSocialDistancing = () => (
+  <svg
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M12 2C6.48 2 2 6.48 2 12C2 17.52 6.48 22 12 22C17.52 22 22 17.52 22 12C22 6.48 17.52 2 12 2ZM13 17H11V15H13V17ZM13 13H11V7H13V13Z"
+      fill={INTERVENTION_COLOR_MAP[INTERVENTIONS.SOCIAL_DISTANCING]}
+    />
+  </svg>
+);
+
+const WarnLockdown = () => (
+  <svg
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M12 2C6.48 2 2 6.48 2 12C2 17.52 6.48 22 12 22C17.52 22 22 17.52 22 12C22 6.48 17.52 2 12 2ZM13 17H11V15H13V17ZM13 13H11V7H13V13Z"
+      fill={INTERVENTION_COLOR_MAP[INTERVENTIONS.LOCKDOWN]}
+    />
+  </svg>
+);
+
+const CheckShelterInPlace = () => (
+  <svg
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M12 2C6.48 2 2 6.48 2 12C2 17.52 6.48 22 12 22C17.52 22 22 17.52 22 12C22 6.48 17.52 2 12 2ZM10 17L5 12L6.41 10.59L10 14.17L17.59 6.58L19 8L10 17Z"
+      fill={INTERVENTION_COLOR_MAP[INTERVENTIONS.SHELTER_IN_PLACE]}
+    />
+  </svg>
+);
+
+const WarnShelterInPlaceWorstCase = () => (
+  <svg
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M12 2C6.48 2 2 6.48 2 12C2 17.52 6.48 22 12 22C17.52 22 22 17.52 22 12C22 6.48 17.52 2 12 2ZM13 17H11V15H13V17ZM13 13H11V7H13V13Z"
+      fill={INTERVENTION_COLOR_MAP[INTERVENTIONS.SHELTER_IN_PLACE_WORST_CASE]}
+    />
+  </svg>
+);
+
+export {
+  WarnLimitedAction,
+  WarnSocialDistancing,
+  WarnShelterInPlaceWorstCase,
+  CheckShelterInPlace,
+  WarnLockdown,
+};

--- a/src/assets/images/interventionIcon.js
+++ b/src/assets/images/interventionIcon.js
@@ -1,0 +1,21 @@
+import React from 'react';
+
+export default ({ color }) => (
+  <svg
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <circle
+      cx="12"
+      cy="12"
+      r="10"
+      stroke="black"
+      strokeOpacity="0.7"
+      strokeWidth="2"
+    />
+    <circle cx="12" cy="12" r="6" fill={color} />
+  </svg>
+);

--- a/src/components/Map/Map.js
+++ b/src/components/Map/Map.js
@@ -16,6 +16,8 @@ function Map() {
   let [redirectTarget, setRedirectTarget] = useState();
 
   if (redirectTarget) {
+    window.scrollTo(0, 0);
+
     return <Redirect push to={redirectTarget} />;
   }
 

--- a/src/components/Newsletter/Newsletter.style.js
+++ b/src/components/Newsletter/Newsletter.style.js
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 
 export const StyledNewsletter = styled.div`
   iframe {
-    min-height: 350px;
+    min-height: 400px;
 
     @media (min-width: 600px) {
       min-height: 270px;

--- a/src/screens/ModelPage/CallToAction/CallToAction.style.js
+++ b/src/screens/ModelPage/CallToAction/CallToAction.style.js
@@ -1,0 +1,100 @@
+import styled from 'styled-components';
+
+export const CallToActionBox = styled.div`
+  margin-top: 2rem;
+  margin-bottom: 2rem;
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  border-radius: 4px;
+  box-sizing: border-box;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+
+  color: rgba(0, 0, 0, 0.7);
+  font-size: 1rem;
+  line-height: 1.5rem;
+
+  @media (min-width: 900px) {
+    flex-direction: row;
+  }
+`;
+
+export const Section = styled.div`
+  border-bottom: 1px solid rgba(0, 0, 0, 0.12);
+
+  @media (min-width: 900px) {
+    width: 50%;
+    border-right: 1px solid rgba(0, 0, 0, 0.12);
+    border-bottom: none;
+  }
+
+  &:last-child {
+    border: none;
+  }
+`;
+
+export const Title = styled.div`
+  background: #f2f2f2;
+  padding: 16px;
+  /* font-weight: bold; */
+  text-align: left;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.12);
+  flex: 0 1;
+
+  font-size: 1.25re m;
+  line-height: 1.75rem;
+
+  @media (min-width: 600px) {
+    /* text-align: center; */
+  }
+`;
+
+export const Content = styled.div`
+  padding: 16px;
+  display: flex;
+  text-align: left;
+  align-items: flex-start;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.12);
+  margin: auto;
+
+  @media (min-width: 600px) {
+    /* flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    flex: 1 0; */
+  }
+
+  &:last-child {
+    border: none;
+  }
+`;
+
+export const Text = styled.div`
+  display: flex;
+  flex-direction: column;
+
+  @media (min-width: 600px) {
+    /* text-align: center; */
+  }
+`;
+
+export const Primary = styled.span`
+  font-size: 1rem;
+  line-height: 1.5rem;
+  font-weight: bold;
+`;
+
+export const Detail = styled.span`
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+`;
+
+export const Icon = styled.div`
+  display: flex;
+  margin-right: 16px;
+
+  @media (min-width: 600px) {
+    /* margin-right: 0;
+    margin-bottom: 8px; */
+  }
+`;

--- a/src/screens/ModelPage/ModelPage.js
+++ b/src/screens/ModelPage/ModelPage.js
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { useParams } from 'react-router-dom';
 // import CountyMap from 'components/CountyMap/CountyMap';
 import Outcomes from './Outcomes/Outcomes';
+import CallToAction from './CallToAction/CallToAction';
 import ShareModelBlock from './ShareModelBlock/ShareModelBlock';
 import StateHeader from 'components/StateHeader/StateHeader';
 import ModelChart from 'components/Charts/ModelChart';
@@ -86,7 +87,10 @@ function ModelPage() {
           />
 
           <Content>
-            <ShareModelBlock location={location} />
+            <CallToAction
+              interventions={interventions}
+              currentIntervention={intervention}
+            />
 
             <Outcomes
               title="Predicted Outcomes after 3 Months"
@@ -134,6 +138,8 @@ function ModelPage() {
                 </a>
               </li>
             </ul>
+
+            <ShareModelBlock location={location} />
           </Content>
         </Panel>
       )}

--- a/src/screens/ModelPage/ModelPage.style.js
+++ b/src/screens/ModelPage/ModelPage.style.js
@@ -5,9 +5,9 @@ export const Wrapper = styled.div``;
 export const Content = styled.div`
   text-align: center;
   max-width: 900px;
-  padding: 32px;
+  padding: 2rem;
   margin: auto;
-  @media (min-width: 600px) {
+  @media (min-width: 900px) {
     padding: 0;
   }
 `;


### PR DESCRIPTION
### Disclaimer
It may seem like this change makes important information _less_ prominent, but coupled with the [new state headers](https://github.com/covid-projections/covid-projections/pull/243), this will be an elegant and appropriate visual for conveying key information.

### Before
![Screen Shot 2020-03-28 at 12 12 32 AM](https://user-images.githubusercontent.com/921228/77817540-d5059f00-7088-11ea-883a-060f63fecb78.png)

### After
![Screen Shot 2020-03-28 at 12 11 48 AM](https://user-images.githubusercontent.com/921228/77817529-ba332a80-7088-11ea-8501-02d824b60e8b.png)
