### PR TITLE
backfill from interventions update

### DIFF
--- a/src/assets/data/interventions.json
+++ b/src/assets/data/interventions.json
@@ -1,5 +1,5 @@
 {
-  "AK": "social_distancing",
+  "AK": "shelter_in_place",
   "AL": "social_distancing",
   "AZ": "social_distancing",
   "AR": "social_distancing",


### PR DESCRIPTION
Alaska announces shelter in place

https://www.alaskapublic.org/2020/03/27/we-crossed-a-line-today-dunleavy-further-limits-travel-and-movement-as-coronavirus-cases-increase/