### PR TITLE
Run lint-staged on commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   },
   "lint-staged": {
     "src/**/*.{css,scss,js}": [
-      "eslint --fix src"
+      "eslint --cache --fix src"
     ]
   },
   "browserslist": {
@@ -81,9 +81,15 @@
     "eslint": "6.8.0",
     "eslint-config-prettier": "6.10.1",
     "eslint-plugin-prettier": "3.1.2",
+    "husky": ">=4",
     "istanbul-lib-coverage": "^3.0.0",
     "nyc": "^15.0.0",
     "prettier": "2.0.2",
     "start-server-and-test": "^1.10.11"
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "lint-staged"
+    }
   }
 }

--- a/src/components/AppBar/AppBar.js
+++ b/src/components/AppBar/AppBar.js
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
 import { useHistory, useLocation, matchPath } from 'react-router-dom';
-import { ArrowBack } from '@material-ui/icons';
 import Logo from 'assets/images/logo';
 import MobileMenu from './MobileMenu';
 import Burger from './Burger';

--- a/src/components/CountyMap/CountyMap.js
+++ b/src/components/CountyMap/CountyMap.js
@@ -32,6 +32,7 @@ const CountyMap = ({
     });
   }, []);
 
+  // eslint-disable-next-line no-unused-vars
   const colorScale = scaleQuantile()
     .domain(data.map(d => d.unemployment_rate))
     .range([
@@ -67,6 +68,7 @@ const CountyMap = ({
             <Geographies geography={counties}>
               {({ geographies }) =>
                 geographies.map(geo => {
+                  // eslint-disable-next-line no-unused-vars
                   const cur = data.find(s => s.id === geo.properties.GEOID);
                   return (
                     <Geography

--- a/src/components/Footer/Footer.js
+++ b/src/components/Footer/Footer.js
@@ -26,8 +26,7 @@ const Footer = ({ children }) => {
   const history = useHistory();
   const { pathname } = useLocation();
 
-  const isMapPage = pathname.startsWith('/us')
-      || pathname.startsWith('/state');
+  const isMapPage = pathname.startsWith('/us') || pathname.startsWith('/state');
 
   const goTo = route => {
     history.push(route);

--- a/src/components/Footer/Footer.style.js
+++ b/src/components/Footer/Footer.style.js
@@ -27,11 +27,11 @@ export const StyledFooterInner = styled.div`
     justify-content: space-between;
     align-items: flex-start;
   }
-  
+
   @media (min-width: 1350px) {
-    margin: ${props => props.isMapPage ? '0 445px 0 auto' : '0 auto'}; 
+    margin: ${props => (props.isMapPage ? '0 445px 0 auto' : '0 auto')};
   }
-  
+
   @media (min-width: 1750px) {
     margin: 0 auto;
   }

--- a/src/components/Header/SearchHeader.style.js
+++ b/src/components/Header/SearchHeader.style.js
@@ -45,8 +45,7 @@ export const MapToggle = styled.div`
   align-items: center;
   border-radius: 4px;
   margin-left: 1rem;
-  color: ${props =>
-    props.isActive ? 'white' : palette.secondary.main};
+  color: ${props => (props.isActive ? 'white' : palette.secondary.main)};
   background: ${props =>
     props.isActive ? palette.secondary.main : 'transparent'};
 

--- a/src/screens/ModelPage/ModelPage.js
+++ b/src/screens/ModelPage/ModelPage.js
@@ -232,8 +232,10 @@ function ModelPage() {
                       create surge capacity in hospitals and develop therapeutic
                       drugs that may have potential to lower hospitalization and
                       fatality rates from COVID.{' '}
-                      <a href="https://data.covidactnow.org/Covid_Act_Now_Model_References_and_Assumptions.pdf"
-                         rel="noreferrer noopener">
+                      <a
+                        href="https://data.covidactnow.org/Covid_Act_Now_Model_References_and_Assumptions.pdf"
+                        rel="noreferrer noopener"
+                      >
                         See full scenario definitions here.
                       </a>
                     </li>
@@ -242,8 +244,10 @@ function ModelPage() {
                       Wuhan-style Lockdown to achieve full containment. However,
                       it is unclear at this time how you could manage newly
                       introduced infections.{' '}
-                      <a href="https://data.covidactnow.org/Covid_Act_Now_Model_References_and_Assumptions.pdf"
-                         rel="noreferrer noopener">
+                      <a
+                        href="https://data.covidactnow.org/Covid_Act_Now_Model_References_and_Assumptions.pdf"
+                        rel="noreferrer noopener"
+                      >
                         See full scenario definitions here.
                       </a>
                     </li>
@@ -340,6 +344,7 @@ function ModelPage() {
                 </div>
                 <div style={{ marginTop: '1rem' }}>
                   View projections for{' '}
+                  {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
                   <a onClick={() => goTo('/state/' + location)}>
                     {locationName}
                   </a>

--- a/yarn.lock
+++ b/yarn.lock
@@ -4613,6 +4613,11 @@ commoner@^0.10.1:
     q "^1.1.2"
     recast "^0.11.17"
 
+compare-versions@^3.5.1:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/compare-versions/-/compare-versions-3.6.0.tgz#1a5689913685e5a87637b8d3ffca75514ec41d62"
+  integrity sha512-W6Af2Iw1z4CB7q4uU4hv646dW9GQuBM+YpC0UvUCWSD8w90SJjp+ujJuXaEMtAXBtSqGfMPuFOVn4/+FlaqfBA==
+
 component-emitter@^1.2.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"
@@ -7059,6 +7064,13 @@ find-up@^3.0.0:
   dependencies:
     locate-path "^3.0.0"
 
+find-versions@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/find-versions/-/find-versions-3.2.0.tgz#10297f98030a786829681690545ef659ed1d254e"
+  integrity sha512-P8WRou2S+oe222TOCHitLy8zj+SIsVJh52VP4lvXkaFVnOFFdoWv1H1Jjvel1aI6NCFOAaeAVm8qrI0odiLcww==
+  dependencies:
+    semver-regex "^2.0.0"
+
 find-yarn-workspace-root@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/find-yarn-workspace-root/-/find-yarn-workspace-root-1.2.1.tgz#40eb8e6e7c2502ddfaa2577c176f221422f860db"
@@ -7973,6 +7985,22 @@ humanize-url@^1.0.0:
   dependencies:
     normalize-url "^1.0.0"
     strip-url-auth "^1.0.0"
+
+husky@>=4:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-4.2.3.tgz#3b18d2ee5febe99e27f2983500202daffbc3151e"
+  integrity sha512-VxTsSTRwYveKXN4SaH1/FefRJYCtx+wx04sSVcOpD7N2zjoHxa+cEJ07Qg5NmV3HAK+IRKOyNVpi2YBIVccIfQ==
+  dependencies:
+    chalk "^3.0.0"
+    ci-info "^2.0.0"
+    compare-versions "^3.5.1"
+    cosmiconfig "^6.0.0"
+    find-versions "^3.2.0"
+    opencollective-postinstall "^2.0.2"
+    pkg-dir "^4.2.0"
+    please-upgrade-node "^3.2.0"
+    slash "^3.0.0"
+    which-pm-runs "^1.0.0"
 
 hyphenate-style-name@^1.0.3:
   version "1.0.3"
@@ -10877,6 +10905,11 @@ open@^7.0.2:
     is-docker "^2.0.0"
     is-wsl "^2.1.1"
 
+opencollective-postinstall@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/opencollective-postinstall/-/opencollective-postinstall-2.0.2.tgz#5657f1bede69b6e33a45939b061eb53d3c6c3a89"
+  integrity sha512-pVOEP16TrAO2/fjej1IdOyupJY8KDUM1CvsaScRbw6oddvpQoOfGk4ywha0HKKVAD6RkW4x6Q+tNBwhf3Bgpuw==
+
 opn@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/opn/-/opn-5.5.0.tgz#fc7164fab56d235904c51c3b27da6758ca3b9bfc"
@@ -11405,7 +11438,7 @@ pkg-dir@^3.0.0:
   dependencies:
     find-up "^3.0.0"
 
-pkg-dir@^4.1.0:
+pkg-dir@^4.1.0, pkg-dir@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-4.2.0.tgz#f099133df7ede422e81d1d8448270eeb3e4261f3"
   integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
@@ -13516,6 +13549,11 @@ semver-compare@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/semver-compare/-/semver-compare-1.0.0.tgz#0dee216a1c941ab37e9efb1788f6afc5ff5537fc"
   integrity sha1-De4hahyUGrN+nvsXiPavxf9VN/w=
+
+semver-regex@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/semver-regex/-/semver-regex-2.0.0.tgz#a93c2c5844539a770233379107b38c7b4ac9d338"
+  integrity sha512-mUdIBBvdn0PLOeP3TEkMH7HHeUP3GjsXCwKarjv/kGmUFOYg1VqEemKhoQpWMu6X2I8kHeuVdGibLGkVK+/5Qw==
 
 "semver@2 || 3 || 4 || 5", semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0:
   version "5.7.1"


### PR DESCRIPTION
#173 added lint-staged, but it wasn't run automatically yet. This PR adds the git pre-commit hook to automatically run lint-staged.

This was set up using the command [recommended on the lint-stage readme](https://github.com/okonet/lint-staged#installation-and-setup):

```
npx mrm lint-staged
```