### PR TITLE
fix: interpolation of overwhelmed date

### DIFF
--- a/src/utils/model.js
+++ b/src/utils/model.js
@@ -88,7 +88,22 @@ const COLUMNS = {
   date: 0,
 };
 
-const DAYS = 1000 * 60 * 60 * 24;
+const MS_PER_DAY = 1000 * 60 * 60 * 24;
+
+//intersection between lines connect points [a, b] and [c, d]
+function intersection(a, b, c, d){
+  const det = (a.x - b.x)*(c.y - d.y) 
+          - (a.y - b.y)*(c.x - d.x),
+
+  l = a.x*b.y - a.y*b.x,
+  m = c.x*d.y - c.y*d.x,
+
+  ix = (l*(c.x - d.x) - m*(a.x - b.x))/det,
+  iy = (l*(c.y - d.y) - m*(a.y - b.y))/det,
+  i = { x: ix, y: iy };
+
+  return i;
+}
 
 export class Model {
   constructor(data, parameters) {
@@ -108,7 +123,7 @@ export class Model {
     this.dates = data.map(row => new Date(row[COLUMNS.date]));
     this.dayZero = this.dates[0];
     this.daysSinceDayZero = Math.floor(
-      (new Date().getTime() - this.dayZero.getTime()) / DAYS,
+      (new Date().getTime() - this.dayZero.getTime()) / MS_PER_DAY,
     );
 
     this.hospitalizations = data.map(row =>
@@ -137,14 +152,25 @@ export class Model {
     if (overwhelmedIdx === -1) {
       this.dateOverwhelmed = null;
     } else {
-      let overwhelmedBy =
-        this.hospitalizations[overwhelmedIdx] - this.beds[overwhelmedIdx];
-      let dayDelta = Math.floor(
-        overwhelmedBy / (0.25 * this.hospitalizations[overwhelmedIdx]),
-      );
-      this.dateOverwhelmed = new Date(
-        this.dates[overwhelmedIdx].getTime() - dayDelta * DAYS,
-      );
+      // since we only get reports every 4 daysfind x coordinate of the crossing point of
+      // hospitalizations and beds. 
+      const startIdx = overwhelmedIdx - 1;
+      const endIdx =  overwhelmedIdx;
+      // create coords normalized with an x range of 1
+      const bedsStart = { y: this.beds[startIdx], x: 0 }
+      const bedsEnd = { y: this.beds[endIdx], x: 1 }
+      const hospitalizationsStart = { y: this.hospitalizations[startIdx], x: 0 }
+      const hospitalizationsEnd = { y: this.hospitalizations[endIdx], x: 1}
+      // find the point at which they intersect. this method uses linear interpolation for
+      // simplicity so there may be some disconnect here.
+      const crossingPoint = intersection(bedsStart, bedsEnd, hospitalizationsStart, hospitalizationsEnd);
+      // scale the normalized range of 4 back up to the actual range of 4 days.
+      let dayDelta = Math.floor(4 * crossingPoint.x);
+      // create the new date by adding the delta to the day prior to overwhelming.
+      const startDate = this.dates[startIdx];
+      const deltaSecs = dayDelta * MS_PER_DAY;
+      const estimatedTimeStamp = startDate.getTime() + deltaSecs 
+      this.dateOverwhelmed = new Date(estimatedTimeStamp);
     }
 
     this.totalPopulation = _parseInt(data[0][COLUMNS.totalPopulation]);
@@ -188,7 +214,7 @@ export class Model {
   get interventionEnd() {
     return new Date(
       this.dayZero.getTime() +
-        (this.daysSinceDayZero + this.durationDays) * DAYS,
+        (this.daysSinceDayZero + this.durationDays) * MS_PER_DAY,
     );
   }
 

--- a/src/utils/model.js
+++ b/src/utils/model.js
@@ -91,16 +91,13 @@ const COLUMNS = {
 const MS_PER_DAY = 1000 * 60 * 60 * 24;
 
 //intersection between lines connect points [a, b] and [c, d]
-function intersection(a, b, c, d){
-  const det = (a.x - b.x)*(c.y - d.y) 
-          - (a.y - b.y)*(c.x - d.x),
-
-  l = a.x*b.y - a.y*b.x,
-  m = c.x*d.y - c.y*d.x,
-
-  ix = (l*(c.x - d.x) - m*(a.x - b.x))/det,
-  iy = (l*(c.y - d.y) - m*(a.y - b.y))/det,
-  i = { x: ix, y: iy };
+function intersection(a, b, c, d) {
+  const det = (a.x - b.x) * (c.y - d.y) - (a.y - b.y) * (c.x - d.x),
+    l = a.x * b.y - a.y * b.x,
+    m = c.x * d.y - c.y * d.x,
+    ix = (l * (c.x - d.x) - m * (a.x - b.x)) / det,
+    iy = (l * (c.y - d.y) - m * (a.y - b.y)) / det,
+    i = { x: ix, y: iy };
 
   return i;
 }
@@ -153,23 +150,31 @@ export class Model {
       this.dateOverwhelmed = null;
     } else {
       // since we only get reports every 4 daysfind x coordinate of the crossing point of
-      // hospitalizations and beds. 
+      // hospitalizations and beds.
       const startIdx = overwhelmedIdx - 1;
-      const endIdx =  overwhelmedIdx;
+      const endIdx = overwhelmedIdx;
       // create coords normalized with an x range of 1
-      const bedsStart = { y: this.beds[startIdx], x: 0 }
-      const bedsEnd = { y: this.beds[endIdx], x: 1 }
-      const hospitalizationsStart = { y: this.hospitalizations[startIdx], x: 0 }
-      const hospitalizationsEnd = { y: this.hospitalizations[endIdx], x: 1}
+      const bedsStart = { y: this.beds[startIdx], x: 0 };
+      const bedsEnd = { y: this.beds[endIdx], x: 1 };
+      const hospitalizationsStart = {
+        y: this.hospitalizations[startIdx],
+        x: 0,
+      };
+      const hospitalizationsEnd = { y: this.hospitalizations[endIdx], x: 1 };
       // find the point at which they intersect. this method uses linear interpolation for
       // simplicity so there may be some disconnect here.
-      const crossingPoint = intersection(bedsStart, bedsEnd, hospitalizationsStart, hospitalizationsEnd);
+      const crossingPoint = intersection(
+        bedsStart,
+        bedsEnd,
+        hospitalizationsStart,
+        hospitalizationsEnd,
+      );
       // scale the normalized range of 4 back up to the actual range of 4 days.
       let dayDelta = Math.floor(4 * crossingPoint.x);
       // create the new date by adding the delta to the day prior to overwhelming.
       const startDate = this.dates[startIdx];
       const deltaSecs = dayDelta * MS_PER_DAY;
-      const estimatedTimeStamp = startDate.getTime() + deltaSecs 
+      const estimatedTimeStamp = startDate.getTime() + deltaSecs;
       this.dateOverwhelmed = new Date(estimatedTimeStamp);
     }
 


### PR DESCRIPTION
#86 this doesn't apply to changing the flag based on the selected
series, but does fix the positioning of the flag.

the original interpolation wasn't placing the line close to the
intersection. It seems like it was using a portion of the bed shortfall
as a stand in for a duration, which doesn't make much sense to me.

the new appoaches finds the beginning and end of the window in
which the hospitalization and beds lines first intersect. finds the
intersection point, then uses that to interpolate the day range.