### PR TITLE
Moved CTA to the top of the page, added nudge to states w/o strict intervention

### DIFF
--- a/src/screens/ModelPage/CallToAction/CallToAction.js
+++ b/src/screens/ModelPage/CallToAction/CallToAction.js
@@ -40,7 +40,13 @@ const CallToAction = ({ interventions, currentIntervention }) => {
       </div>
     );
     nudgeText = (
-      <div style={{ fontWeight: 'normal', marginTop: '1.2rem' }}><b>Act now</b>: <a href="https://docs.google.com/document/d/1ETeXAfYOvArfLvlxExE0_xrO5M4ITC0_Am38CRusCko/preview#heading=h.vyhw42b7pgoj">stricter intervention</a> could mean hospitals are never overloaded</div>
+      <div style={{ fontWeight: 'normal', marginTop: '1.2rem' }}>
+        <b>Act now</b>:{' '}
+        <a href="https://docs.google.com/document/d/1ETeXAfYOvArfLvlxExE0_xrO5M4ITC0_Am38CRusCko/preview#heading=h.vyhw42b7pgoj">
+          stricter intervention
+        </a>{' '}
+        could mean hospitals are never overloaded
+      </div>
     );
   }
 

--- a/src/screens/ModelPage/CallToAction/CallToAction.js
+++ b/src/screens/ModelPage/CallToAction/CallToAction.js
@@ -22,7 +22,7 @@ const CallToAction = ({ interventions, currentIntervention }) => {
 
   const model = interventionToModel[currentIntervention];
 
-  let actionText, actionDateRange;
+  let actionText, actionDateRange, nudgeText;
   if (currentIntervention === INTERVENTIONS.SHELTER_IN_PLACE) {
     actionText = `${currentIntervention} is projected to reduce hospital overload over the next 3 months`;
   } else if (
@@ -39,6 +39,9 @@ const CallToAction = ({ interventions, currentIntervention }) => {
         {formatDate(earlyDate)} to {formatDate(lateDate)}
       </div>
     );
+    nudgeText = (
+      <div style={{ fontWeight: 'normal', marginTop: '1.2rem' }}><b>Act now</b>: <a href="https://docs.google.com/document/d/1ETeXAfYOvArfLvlxExE0_xrO5M4ITC0_Am38CRusCko/preview#heading=h.vyhw42b7pgoj">stricter intervention</a> could mean hospitals are never overloaded</div>
+    );
   }
 
   const [calloutFillColor, calloutStrokeColor] = LAST_DATES_CALLOUT_COLORS[
@@ -52,6 +55,7 @@ const CallToAction = ({ interventions, currentIntervention }) => {
     >
       <div style={{ fontWeight: 'normal' }}>{actionText}</div>
       {actionDateRange}
+      {nudgeText}
     </Callout>
   );
 };

--- a/src/screens/ModelPage/ModelPage.js
+++ b/src/screens/ModelPage/ModelPage.js
@@ -71,6 +71,13 @@ function ModelPage() {
       )}
       {showModel && interventions && (
         <Panel>
+          <Content>
+          <CallToAction
+              currentIntervention={intervention}
+              interventions={interventions}
+            />
+          </Content>
+          
           <ModelChart
             state={locationName}
             county={county}
@@ -80,11 +87,6 @@ function ModelPage() {
           />
 
           <Content>
-            <CallToAction
-              currentIntervention={intervention}
-              interventions={interventions}
-            />
-
             <ShareModelBlock location={location} />
 
             <Outcomes

--- a/src/screens/ModelPage/ModelPage.js
+++ b/src/screens/ModelPage/ModelPage.js
@@ -94,8 +94,6 @@ function ModelPage() {
           />
 
           <Content>
-            <ShareModelBlock location={location} />
-
             <Outcomes
               title="Predicted Outcomes after 3 Months"
               models={[

--- a/src/screens/ModelPage/ModelPage.js
+++ b/src/screens/ModelPage/ModelPage.js
@@ -72,12 +72,12 @@ function ModelPage() {
       {showModel && interventions && (
         <Panel>
           <Content>
-          <CallToAction
+            <CallToAction
               currentIntervention={intervention}
               interventions={interventions}
             />
           </Content>
-          
+
           <ModelChart
             state={locationName}
             county={county}


### PR DESCRIPTION
Per conversation with James/Max/JKT on making the page less confusing:

> A reporter from has Arizona raised a concern about the model that I think you should be aware and perhaps act on it.

> On the website, currently for Arizona to prevent hospital overload, stricter intervention must be implemented by:Apr 21 to Apr 26. The reporter was concerned that this adds a sense of “nothing needs to be done now, as there’s no urgency”.

> I understand how the model works, but would be great to have a “canned response”. 

![image](https://user-images.githubusercontent.com/2575327/77870522-dd7fe600-71fe-11ea-853e-2b8476dc190a.png)
