### PR TITLE
Initial commit of the privacy policy, including links from the ToU

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -9,6 +9,7 @@ import HomePage from 'screens/HomePage/HomePage';
 import FAQ from 'screens/FAQ/FAQ';
 import Contact from 'screens/Contact/Contact';
 import Terms from 'screens/Terms/Terms';
+import Privacy from 'screens/Terms/Privacy';
 import Endorsements from 'screens/Endorsements/Endorsements';
 import About from 'screens/About/About';
 import AppBar from 'components/AppBar/AppBar';
@@ -30,6 +31,7 @@ export default function App() {
             <Route path="/about" component={About} />
             <Route path="/contact" component={Contact} />
             <Route path="/terms" component={Terms} />
+            <Route path="/privacy" component={Privacy} />
             {/* <Route path="/donate" component={ComingSoon} /> */}
             <Route path="/*">
               <Redirect to="/" />

--- a/src/screens/Terms/Privacy.js
+++ b/src/screens/Terms/Privacy.js
@@ -1,0 +1,528 @@
+import React from 'react';
+import Typography from '@material-ui/core/Typography';
+
+import { Wrapper, Content } from './Terms.style';
+
+const Privacy = ({ children }) => {
+  return (
+    <Wrapper>
+      <Content>
+        <Typography variant="h3" component="h1" align="center">
+          Website Privacy Policy
+        </Typography>
+        <Typography variant="h6" component="h1" align="center">
+          Last updated: March 28, 2020
+        </Typography>
+        <Typography variant="h5" component="h1">
+          Introduction
+        </Typography>
+        <Typography variant="body1" component="p">
+          CoVidActNow.org ("<b>Company</b>" or "<b>We</b>") respect your privacy
+          and are committed to protecting it through our compliance with this
+          policy.
+        </Typography>
+        <Typography variant="body1" component="p">
+          This policy describes the types of information we may collect from you
+          or that you may provide when you visit the website CoVidActNow.org
+          (our "<b>Website</b>") and our practices for collecting, using,
+          maintaining, protecting, and disclosing that information.
+        </Typography>
+        <Typography variant="body1" component="p">
+          This policy applies to information we collect:
+        </Typography>
+        <Typography>
+          <ul>
+            <li>On this Website.</li>
+            <li>
+              In email, text, and other electronic messages between you and this
+              Website.
+            </li>
+            <li>
+              Through mobile and desktop applications you download from this
+              Website, which provide dedicated non-browser-based interaction
+              between you and this Website.
+            </li>
+            <li>
+              When you interact with our advertising and applications on
+              third-party websites and services, if those applications or
+              advertising include links to this policy.
+            </li>
+          </ul>
+        </Typography>
+        <Typography variant="body1" component="p">
+          It does not apply to information collected by:
+        </Typography>
+        <Typography>
+          <ul>
+            <li>
+              Us offline or through any other means, including on any other
+              website operated by Company or any third party; or
+            </li>
+            <li>
+              Any third party, including through any application or content
+              (including advertising) that may link to or be accessible from or
+              on the Website.
+            </li>
+          </ul>
+        </Typography>
+        <Typography variant="body1" component="p">
+          Please read this policy carefully to understand our policies and
+          practices regarding your information and how we will treat it. If you
+          do not agree with our policies and practices, your choice is not to
+          use our Website. By accessing or using this Website, you agree to this
+          privacy policy. This policy may change from time to time (see Changes
+          to Our Privacy Policy). Your continued use of this Website after we
+          make changes is deemed to be acceptance of those changes, so please
+          check the policy periodically for updates.
+        </Typography>
+
+        <Typography variant="h5" component="h1">
+          Children Under the Age of 13
+        </Typography>
+
+        <Typography variant="body1" component="p">
+          Our Website is not intended for children under 13 years of age. No one
+          under age 13 may provide any information to or on the Website. We do
+          not knowingly collect personal information from children under 13. If
+          you are under 13, do not use or provide any information on this
+          Website or on or through any of its features. If we learn we have
+          collected or received personal information from a child under 13
+          without verification of parental consent, we will delete that
+          information. If you believe we might have any information from or
+          about a child under 13, please contact us at:{' '}
+          <a href="mailto:privacy@covidactnow.org">privacy@covidactnow.org</a>.
+        </Typography>
+
+        <Typography variant="h5" component="h1">
+          Information We Collect About You and How We Collect It
+        </Typography>
+        <Typography variant="body1" component="p">
+          We collect several types of information from and about users of our
+          Website, including information:
+        </Typography>
+        <Typography>
+          <ul>
+            <li>
+              By which you may be personally identified, such as name, postal
+              address, e-mail address, telephone number, or any other identifier
+              by which you may be contacted online or offline ("
+              <b>personal information</b>");
+            </li>
+            <li>
+              That is about you but individually does not identify you; and/or
+            </li>
+            <li>
+              About your internet connection, the equipment you use to access
+              our Website, and usage details.
+            </li>
+          </ul>
+        </Typography>
+        <Typography variant="body1" component="p">
+          We collect this information:
+        </Typography>
+        <Typography>
+          <ul>
+            <li>Directly from you when you provide it to us.</li>
+            <li>
+              Automatically as you navigate through the site. Information
+              collected automatically may include usage details, IP addresses,
+              and information collected through cookies, web beacons, and other
+              tracking technologies.
+            </li>
+            <li>From third parties, for example, our business partners.</li>
+          </ul>
+        </Typography>
+
+        <Typography variant="h5" component="h1">
+          Information You Provide to Us
+        </Typography>
+        <Typography variant="body1" component="p">
+          The information we collect on or through our Website may include:
+        </Typography>
+        <Typography>
+          <ul>
+            <li>
+              Information that you provide by filling in forms on our Website.
+              This includes information provided at the time of subscribing to
+              our service, posting material, or requesting further services. We
+              may also ask you for information when you report a problem with
+              our Website.
+            </li>
+            <li>
+              Records and copies of your correspondence (including email
+              addresses), if you contact us.
+            </li>
+            <li>
+              Your responses to surveys that we might ask you to complete for
+              research purposes.
+            </li>
+            <li>Your search queries on the Website.</li>
+          </ul>
+        </Typography>
+        <Typography variant="body1" component="p">
+          You also may provide information to be published or displayed
+          (hereinafter, "<b>posted</b>") on public areas of the Website, or
+          transmitted to other users of the Website or third parties
+          (collectively, "<b>User Contributions</b>"). Your User Contributions
+          are posted on and transmitted to others at your own risk. Although we
+          limit access to certain pages, please be aware that no security
+          measures are perfect or impenetrable. Additionally, we cannot control
+          the actions of other users of the Website with whom you may choose to
+          share your User Contributions. Therefore, we cannot and do not
+          guarantee that your User Contributions will not be viewed by
+          unauthorized persons.
+        </Typography>
+
+        <Typography variant="h5" component="h1">
+          Information We Collect Through Automatic Data Collection Technologies
+        </Typography>
+        <Typography variant="body1" component="p">
+          As you navigate through and interact with our Website, we may use
+          automatic data collection technologies to collect certain information
+          about your equipment, browsing actions, and patterns, including:
+        </Typography>
+        <Typography>
+          <ul>
+            <li>
+              Details of your visits to our Website, including traffic data,
+              location data, logs, and other communication data and the
+              resources that you access and use on the Website.
+            </li>
+            <li>
+              Information about your computer and internet connection, including
+              your IP address, operating system, and browser type.
+            </li>
+          </ul>
+        </Typography>
+        <Typography variant="body1" component="p">
+          We also may use these technologies to collect information about your
+          online activities over time and across third-party websites or other
+          online services (behavioral tracking). Click here for information on
+          how you can opt out of behavioral tracking on this website and how we
+          respond to web browser signals and other mechanisms that enable
+          consumers to exercise choice about behavioral tracking.
+        </Typography>
+        <Typography variant="body1" component="p">
+          The information we collect automatically may include personal
+          information, or we may maintain it or associate it with personal
+          information we collect in other ways or receive from third parties. It
+          helps us to improve our Website and to deliver a better and more
+          personalized service, including by enabling us to:
+        </Typography>
+        <Typography>
+          <ul>
+            <li>Estimate our audience size and usage patterns.</li>
+            <li>
+              Store information about your preferences, allowing us to customize
+              our Website according to your individual interests.
+            </li>
+            <li>Speed up your searches.</li>
+            <li>Recognize you when you return to our Website.</li>
+          </ul>
+        </Typography>
+        <Typography variant="body1" component="p">
+          The technologies we use for this automatic data collection may
+          include:
+        </Typography>
+        <Typography>
+          <ul>
+            <li>
+              <b>Cookies (or browser cookies)</b>. A cookie is a small file
+              placed on the hard drive of your computer. You may refuse to
+              accept browser cookies by activating the appropriate setting on
+              your browser. However, if you select this setting you may be
+              unable to access certain parts of our Website. Unless you have
+              adjusted your browser setting so that it will refuse cookies, our
+              system will issue cookies when you direct your browser to our
+              Website.{' '}
+            </li>
+            <li>
+              <b>Flash Cookies</b>. Certain features of our Website may use
+              local stored objects (or Flash cookies) to collect and store
+              information about your preferences and navigation to, from, and on
+              our Website. Flash cookies are not managed by the same browser
+              settings as are used for browser cookies. For information about
+              managing your privacy and security settings for Flash cookies, see
+              Choices About How We Use and Disclose Your Information.
+            </li>
+            <li>
+              <b>Web Beacons</b>. Pages of our Website and our emails may
+              contain small electronic files known as web beacons (also referred
+              to as clear gifs, pixel tags, and single-pixel gifs) that permit
+              the Company, for example, to count users who have visited those
+              pages or opened an email and for other related website statistics
+              (for example, recording the popularity of certain website content
+              and verifying system and server integrity).
+            </li>
+          </ul>
+        </Typography>
+        <Typography variant="h5" component="h1">
+          Third-Party Use of Cookies and Other Tracking Technologies
+        </Typography>
+        <Typography variant="body1" component="p">
+          Some content or applications, including advertisements, on the Website
+          are served by third-parties, including advertisers, ad networks and
+          servers, content providers, and application providers. These third
+          parties may use cookies alone or in conjunction with web beacons or
+          other tracking technologies to collect information about you when you
+          use our website. The information they collect may be associated with
+          your personal information or they may collect information, including
+          personal information, about your online activities over time and
+          across different websites and other online services. They may use this
+          information to provide you with interest-based (behavioral)
+          advertising or other targeted content.
+        </Typography>
+        <Typography variant="body1" component="p">
+          We do not control these third parties' tracking technologies or how
+          they may be used. If you have any questions about an advertisement or
+          other targeted content, you should contact the responsible provider
+          directly. For information about how you can opt out of receiving
+          targeted advertising from many providers, see Choices About How We Use
+          and Disclose Your Information.
+        </Typography>
+
+        <Typography variant="h5" component="h1">
+          How We Use Your Information
+        </Typography>
+        <Typography variant="body1" component="p">
+          We use information that we collect about you or that you provide to
+          us, including any personal information:
+        </Typography>
+        <Typography>
+          <ul>
+            <li>To present our Website and its contents to you.</li>
+            <li>
+              To provide you with information, products, or services that you
+              request from us.
+            </li>
+            <li>To fulfill any other purpose for which you provide it.</li>
+            <li>
+              To provide you with notices about your account, including
+              expiration and renewal notices.
+            </li>
+            <li>
+              To carry out our obligations and enforce our rights arising from
+              any contracts entered into between you and us, including for
+              billing and collection.
+            </li>
+            <li>
+              To notify you about changes to our Website or any products or
+              services we offer or provide though it.
+            </li>
+            <li>
+              To allow you to participate in interactive features on our
+              Website.
+            </li>
+            <li>
+              In any other way we may describe when you provide the information.
+            </li>
+            <li>For any other purpose with your consent.</li>
+          </ul>
+        </Typography>
+        <Typography variant="body1" component="p">
+          We may also use your information to contact you about our own and
+          third-parties' goods and services that may be of interest to you. If
+          you do not want us to use your information in this way, please check
+          the relevant box located on the form on which we collect your data
+          (the registration form). For more information, see Choices About How
+          We Use and Disclose Your Information.
+        </Typography>
+        <Typography variant="body1" component="p">
+          We may use the information we have collected from you to enable us to
+          display advertisements to our advertisers' target audiences. Even
+          though we do not disclose your personal information for these purposes
+          without your consent, if you click on or otherwise interact with an
+          advertisement, the advertiser may assume that you meet its target
+          criteria.
+        </Typography>
+
+        <Typography variant="h5" component="h1">
+          Disclosure of Your Information
+        </Typography>
+        <Typography variant="body1" component="p">
+          We may disclose aggregated information about our users, and
+          information that does not identify any individual, without
+          restriction.
+        </Typography>
+        <Typography variant="body1" component="p">
+          We may disclose personal information that we collect or you provide as
+          described in this privacy policy:
+        </Typography>
+        <Typography>
+          <ul>
+            <li>To our subsidiaries and affiliates.</li>
+            <li>
+              To contractors, service providers, and other third parties we use
+              to support our business.
+            </li>
+            <li>
+              To a buyer or other successor in the event of a merger,
+              divestiture, restructuring, reorganization, dissolution, or other
+              sale or transfer of some or all of CoVidActNow.org's assets,
+              whether as a going concern or as part of bankruptcy, liquidation,
+              or similar proceeding, in which personal information held by
+              CoVidActNow.org about our Website users is among the assets
+              transferred.
+            </li>
+            <li>
+              To third parties to market their products or services to you if
+              you have not opted out of these disclosures. For more information,
+              see Choices About How We Use and Disclose Your Information.
+            </li>
+            <li>
+              To fulfill the purpose for which you provide it. For example, if
+              you give us an email address to use the "email a friend" feature
+              of our Website, we will transmit the contents of that email and
+              your email address to the recipients.
+            </li>
+            <li>
+              For any other purpose disclosed by us when you provide the
+              information.
+            </li>
+            <li>With your consent.</li>
+            <li>We may also disclose your personal information:</li>
+            <li>
+              To comply with any court order, law, or legal process, including
+              to respond to any government or regulatory request.
+            </li>
+            <li>
+              To enforce or apply our <a href="/terms">Terms of Use</a> and
+              other agreements, including for billing and collection purposes.
+            </li>
+            <li>
+              If we believe disclosure is necessary or appropriate to protect
+              the rights, property, or safety of CoVidActNow.org, our customers,
+              or others. This includes exchanging information with other
+              companies and organizations for the purposes of fraud protection
+              and credit risk reduction.
+            </li>
+          </ul>
+        </Typography>
+
+        <Typography variant="h5" component="h1">
+          Choices About How We Use and Disclose Your Information
+        </Typography>
+        <Typography variant="body1" component="p">
+          We strive to provide you with choices regarding the personal
+          information you provide to us. We have created mechanisms to provide
+          you with the following control over your information:
+        </Typography>
+        <Typography>
+          <ul>
+            <li>
+              <b>Tracking Technologies and Advertising</b>. You can set your
+              browser to refuse all or some browser cookies, or to alert you
+              when cookies are being sent. To learn how you can manage your
+              Flash cookie settings, visit the Flash player settings page on
+              Adobe's website. If you disable or refuse cookies, please note
+              that some parts of this site may then be inaccessible or not
+              function properly.
+            </li>
+            <li>
+              <b>Disclosure of Your Information for Third-Party Advertising</b>.
+              If you do not want us to share your personal information with
+              unaffiliated or non-agent third parties for promotional purposes,
+              you can opt out by checking the relevant box located on the form
+              on which we collect your data (the registration form). You can
+              also always opt out by checking or unchecking the relevant boxes
+              or by sending us an email stating your request to
+              privacy@covidactnow.org.
+            </li>
+            <li>
+              <b>Promotional Offers from the Company</b>. If you do not wish to
+              have your contact information used by the Company to promote our
+              own or third parties' products or services, you can opt out by
+              checking the relevant box located on the form on which we collect
+              your data (the registration form) or at any other time by sending
+              us an email stating your request to privacy@covidactnow.org. If we
+              have sent you a promotional email, you may send us a return email
+              asking to be omitted from future email distributions.
+            </li>
+            <li>
+              <b>Targeted Advertising</b>. If you do not want us to use
+              information that we collect or that you provide to us to deliver
+              advertisements according to our advertisers' target-audience
+              preferences, you can opt out by checking the relevant box located
+              on the form on which we collect your data (the registration form)
+              or at any other time by sending us an email stating your request
+              to{' '}
+              <a href="mailto:privacy@covidactnow.org">
+                privacy@covidactnow.org
+              </a>
+              .
+            </li>
+          </ul>
+        </Typography>
+        <Typography variant="body1" component="p">
+          We do not control third parties' collection or use of your information
+          to serve interest-based advertising. However these third parties may
+          provide you with ways to choose not to have your information collected
+          or used in this way. You can opt out of receiving targeted ads from
+          members of the Network Advertising Initiative ("<b>NAI</b>") on the
+          NAI's{' '}
+          <a href="http://www.networkadvertising.org/managing/opt_out.asp">
+            website
+          </a>
+          .
+        </Typography>
+
+        <Typography variant="h5" component="h1">
+          Data Security
+        </Typography>
+        <Typography variant="body1" component="p">
+          We have implemented measures designed to secure your personal
+          information from accidental loss and from unauthorized access, use,
+          alteration, and disclosure.
+        </Typography>
+        <Typography variant="body1" component="p">
+          The safety and security of your information also depends on you. Where
+          we have given you (or where you have chosen) a password for access to
+          certain parts of our Website, you are responsible for keeping this
+          password confidential. We ask you not to share your password with
+          anyone. We urge you to be careful about giving out information in
+          public areas of the Website like message boards. The information you
+          share in public areas may be viewed by any user of the Website.
+        </Typography>
+        <Typography variant="body1" component="p">
+          Unfortunately, the transmission of information via the internet is not
+          completely secure. Although we do our best to protect your personal
+          information, we cannot guarantee the security of your personal
+          information transmitted to our Website. Any transmission of personal
+          information is at your own risk. We are not responsible for
+          circumvention of any privacy settings or security measures contained
+          on the Website.
+        </Typography>
+
+        <Typography variant="h5" component="h1">
+          Changes to Our Privacy Policy
+        </Typography>
+        <Typography variant="body1" component="p">
+          It is our policy to post any changes we make to our privacy policy on
+          this page with a notice that the privacy policy has been updated on
+          the Website home page. If we make material changes to how we treat our
+          users' personal information, we will notify you through a notice on
+          the Website home page. The date the privacy policy was last revised is
+          identified at the top of the page. You are responsible for ensuring we
+          have an up-to-date active and deliverable email address for you, and
+          for periodically visiting our Website and this privacy policy to check
+          for any changes.
+        </Typography>
+
+        <Typography variant="h5" component="h1">
+          Contact Information
+        </Typography>
+        <Typography variant="body1" component="p">
+          To ask questions or comment about this privacy policy and our privacy
+          practices, contact us at:{' '}
+          <a href="mailto:privacy@covidactnow.org">privacy@covidactnow.org</a>.
+        </Typography>
+        <Typography variant="body1" component="p">
+          To register a complaint or concern, please contact us as the email
+          address provided above.
+        </Typography>
+      </Content>
+    </Wrapper>
+  );
+};
+
+export default Privacy;

--- a/src/screens/Terms/Privacy.js
+++ b/src/screens/Terms/Privacy.js
@@ -39,8 +39,8 @@ const Privacy = ({ children }) => {
             </li>
             <li>
               Through mobile and desktop applications you download from this
-              Website, which provide dedicated non-browser-based interaction
-              between you and this Website.
+              Website or an app store, which provide dedicated non-browser-based
+              interaction between you and this Website.
             </li>
             <li>
               When you interact with our advertising and applications on

--- a/src/screens/Terms/Privacy.js
+++ b/src/screens/Terms/Privacy.js
@@ -517,7 +517,7 @@ const Privacy = ({ children }) => {
           <a href="mailto:privacy@covidactnow.org">privacy@covidactnow.org</a>.
         </Typography>
         <Typography variant="body1" component="p">
-          To register a complaint or concern, please contact us as the email
+          To register a complaint or concern, please contact us at the email
           address provided above.
         </Typography>
       </Content>

--- a/src/screens/Terms/Terms.js
+++ b/src/screens/Terms/Terms.js
@@ -75,8 +75,8 @@ const Terms = ({ children }) => {
           Website.{' '}
           <b>
             By using the Website, you accept and agree to be bound and abide by
-            these Terms of Use and our Privacy Policy, incorporated herein by
-            reference.
+            these Terms of Use and our <a href="/privacy">Privacy Policy</a>,
+            incorporated herein by reference.
           </b>{' '}
           If you do not want to agree to these Terms of Use or the Privacy
           Policy, you must not access or use the Website.
@@ -134,7 +134,7 @@ const Terms = ({ children }) => {
           otherwise, including, but not limited to, through the use of any
           interactive features on the Website, is governed by our Privacy
           Policy, and you consent to all actions we take with respect to your
-          information consistent with our Privacy Policy.
+          information consistent with our <a href="/privacy">Privacy Policy</a>.
         </Typography>
         <Typography variant="body1" component="p">
           If you choose, or are provided with, a user name, password or any
@@ -435,7 +435,7 @@ const Terms = ({ children }) => {
               privacy) of others or contain any material that could give rise to
               any civil or criminal liability under applicable laws or
               regulations or that otherwise may be in conflict with these Terms
-              of Use and our Privacy Policy.
+              of Use and our <a href="/privacy">Privacy Policy</a>.
             </li>
             <li>Be likely to deceive any person.</li>
             <li>
@@ -787,11 +787,11 @@ const Terms = ({ children }) => {
           Entire Agreement
         </Typography>
         <Typography variant="body1" component="p">
-          The Terms of Use and our Privacy Policy constitute the sole and entire
-          agreement between you and CoVidActNow.org with respect to the Website
-          and supersede all prior and contemporaneous understandings,
-          agreements, representations and warranties, both written and oral,
-          with respect to the Website.
+          The Terms of Use and our <a href="/privacy">Privacy Policy</a>{' '}
+          constitute the sole and entire agreement between you and
+          CoVidActNow.org with respect to the Website and supersede all prior
+          and contemporaneous understandings, agreements, representations and
+          warranties, both written and oral, with respect to the Website.
         </Typography>
 
         <Typography variant="h5" component="h1">


### PR DESCRIPTION
Not ready to be merged until we have final approval (edit: we have it now), but I anticipate it will look almost identical to this. Note that this is not intended to get a nav link, but only be reachable directly at the URL (`/privacy`) or via the Terms of Use.