### PR TITLE
Initial take on renaming to Stay at Home, per JKT's copy change.

### DIFF
--- a/src/components/Charts/ModelChart.js
+++ b/src/components/Charts/ModelChart.js
@@ -41,7 +41,7 @@ const ModelChart = ({
     let plotLineText;
     switch (currentIntervention) {
       case INTERVENTIONS.SHELTER_IN_PLACE:
-        plotLineText = '<span>Shelter in place<br />(poor compliance)</span>';
+        plotLineText = '<span>Stay at Home<br/>(poor compliance)</span>';
         break;
       case INTERVENTIONS.LIMITED_ACTION:
         plotLineText = 'Assuming limited action';

--- a/src/components/Charts/ModelChart.style.js
+++ b/src/components/Charts/ModelChart.style.js
@@ -125,7 +125,7 @@ export const Wrapper = styled.div`
         : socialDistancingColor};
     fill-opacity: 0.8;
   }
-  /* Shelter in place */
+  /* Stay at home */
   .highcharts-series-2 {
     fill: ${shelterInPlaceColor};
     stroke: ${shelterInPlaceColor};

--- a/src/components/StateHeader/StateHeader.js
+++ b/src/components/StateHeader/StateHeader.js
@@ -43,7 +43,7 @@ const Stateheader = ({
       case INTERVENTIONS.SHELTER_IN_PLACE:
         return (
           <span>
-            Maintain shelter in place in <strong>{locationName}.</strong>
+            Keep staying at home in <strong>{locationName}.</strong>
           </span>
         );
       default:

--- a/src/enums/interventions.js
+++ b/src/enums/interventions.js
@@ -2,9 +2,9 @@ import InterventionJSON from '../assets/data/interventions.json';
 
 const LIMITED_ACTION = 'Limited Action';
 const SOCIAL_DISTANCING = 'Social Distancing';
-const SHELTER_IN_PLACE = 'Shelter in Place';
+const SHELTER_IN_PLACE = 'Stay at Home';
 const LOCKDOWN = 'Lockdown';
-const SHELTER_IN_PLACE_WORST_CASE = 'Shelter in Place Worst Case';
+const SHELTER_IN_PLACE_WORST_CASE = 'Stay at Home Worst Case';
 
 export const INTERVENTIONS = {
   LIMITED_ACTION,

--- a/src/screens/ModelPage/Outcomes/Outcomes.js
+++ b/src/screens/ModelPage/Outcomes/Outcomes.js
@@ -35,9 +35,9 @@ const Outcomes = ({
             let rowLabel = model.label;
             if (currentIntervention === INTERVENTIONS.SHELTER_IN_PLACE) {
               if (rowLabel === '3 Months of Social Distancing') {
-                rowLabel = '3 Months of Shelter in Place (worst case)';
-              } else if (rowLabel === '3 Months of Shelter in Place') {
-                rowLabel = '3 Months of Shelter in Place (best case)';
+                rowLabel = '3 Months of Stay at Home (worst case)';
+              } else if (rowLabel === '3 Months of Stay at Home') {
+                rowLabel = '3 Months of Stay at Home (best case)';
               }
             }
 


### PR DESCRIPTION
TL;DR: it's more friendly, Shelter in Place is more of a disaster response term.

I left "Shelter in Place" in `interventions-data.js`, since it seems to be used in CSVs. Unsure if this data makes it to the front end and therefore needs to change, or if we can leave it around.

As a side note, I left all the variable names in place, I just changed the string values.