### PR TITLE
add traditional GA property to gtag

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -46,6 +46,7 @@
       gtag('js', new Date());
 
       gtag('config', 'G-HFCDC7K5G1');
+      gtag('config', 'UA-160622988-1');
     </script>
 
   </head>


### PR DESCRIPTION
duplicating the tracking to legacy GA property since the Firebase / App+Web reports have some limitations.