### PR TITLE
Add push state to GA tracking

### DIFF
--- a/src/components/AppBar/AppBar.js
+++ b/src/components/AppBar/AppBar.js
@@ -93,6 +93,16 @@ const _AppBar = () => {
     });
   };
 
+  // Track GA pageview whenever a route is pushed.
+  history.listen(location => {
+    window.gtag('config', 'G-HFCDC7K5G1', {
+      page_path: location.pathname,
+    });
+    window.gtag('config', 'UA-160622988-1', {
+      page_path: location.pathname,
+    });
+  });
+
   return (
     <StyledAppBar position="sticky">
       <Wrapper>


### PR DESCRIPTION
1. Our push routes weren't being tracked as events in GA, so we can't actually see how people navigate on the site.  https://developers.google.com/analytics/devguides/collection/gtagjs/pages
2. My eye's twitching from the hardcoding of the config id, but I didn't want to add in react-ga module and risk breaking more things. Open to suggestions here.