### PR TITLE
Fix Kings County (NY vs CA) search results.

### DIFF
--- a/src/components/MapSelectors/datasets/us_states_dataset_01_02_2020.json
+++ b/src/components/MapSelectors/datasets/us_states_dataset_01_02_2020.json
@@ -6601,7 +6601,7 @@
           "county_fips_code": "031",
           "state_fips_code": "06",
           "state_code": "CA",
-          "full_fips_code": "36061",
+          "full_fips_code": "06031",
           "cities": [
             "Armona",
             "Avenal",
@@ -60961,7 +60961,7 @@
           "county_fips_code": "047",
           "state_fips_code": "36",
           "state_code": "NY",
-          "full_fips_code": "36047",
+          "full_fips_code": "36061",
           "cities": [
             "Brooklyn"
           ],


### PR DESCRIPTION
24d628048e0c58d0d27a15612d3fc1dacb079d58 accidentally updated Kings County, CA to point at NYC instead of updating Kings County, NY.