### PR TITLE
Add "See county data" text

### DIFF
--- a/src/components/Header/SearchHeader.js
+++ b/src/components/Header/SearchHeader.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import useMediaQuery from '@material-ui/core/useMediaQuery';
 import { GlobalSelector } from 'components/MapSelectors/MapSelectors';
@@ -25,6 +25,7 @@ const SearchHeader = ({
 }) => {
   const history = useHistory();
   const isMobile = useMediaQuery('(max-width:1350px)');
+  const [isGlobalSelectorFocused, setIsGlobalSelectorFocused] = useState(false);
 
   const handleSelectChange = option => {
     let route = `/state/${option.state_code}`;
@@ -52,6 +53,7 @@ const SearchHeader = ({
             <GlobalSelector
               extendRight={true}
               handleChange={handleSelectChange}
+              onIsFocusedChanged={setIsGlobalSelectorFocused}
             />
           </SelectorWrapper>
           {isMobile && (
@@ -59,6 +61,7 @@ const SearchHeader = ({
               onClick={() => toggleMobileMenu()}
               isActive={mobileMenuOpen}
             >
+              {!isGlobalSelectorFocused && <>See county data&nbsp;&nbsp;</>}
               <MapIcon />
             </MapToggle>
           )}

--- a/src/components/Header/SearchHeader.js
+++ b/src/components/Header/SearchHeader.js
@@ -26,7 +26,7 @@ const SearchHeader = ({
   const history = useHistory();
   const isMobile = useMediaQuery('(max-width:1350px)');
   const isNarrowMobile = useMediaQuery('(max-width:500px)');
-  const [isGlobalSelectorFocused, setIsGlobalSelectorFocused] = useState(false);
+  const [isGlobalSelectorOpen, setIsGlobalSelectorOpen] = useState(false);
 
   const handleSelectChange = option => {
     let route = `/state/${option.state_code}`;
@@ -54,7 +54,7 @@ const SearchHeader = ({
             <GlobalSelector
               extendRight={true}
               handleChange={handleSelectChange}
-              onIsFocusedChanged={setIsGlobalSelectorFocused}
+              handleIsOpen={setIsGlobalSelectorOpen}
             />
           </SelectorWrapper>
           {isMobile && (
@@ -62,8 +62,8 @@ const SearchHeader = ({
               onClick={() => toggleMobileMenu()}
               isActive={mobileMenuOpen}
             >
-              {!isGlobalSelectorFocused && !isNarrowMobile && (
-                <>See county data&nbsp;&nbsp;</>
+              {!isGlobalSelectorOpen && !isNarrowMobile && (
+                <>Find on map&nbsp;&nbsp;</>
               )}
               <MapIcon />
             </MapToggle>

--- a/src/components/Header/SearchHeader.js
+++ b/src/components/Header/SearchHeader.js
@@ -25,6 +25,7 @@ const SearchHeader = ({
 }) => {
   const history = useHistory();
   const isMobile = useMediaQuery('(max-width:1350px)');
+  const isNarrowMobile = useMediaQuery('(max-width:500px)');
   const [isGlobalSelectorFocused, setIsGlobalSelectorFocused] = useState(false);
 
   const handleSelectChange = option => {
@@ -61,7 +62,9 @@ const SearchHeader = ({
               onClick={() => toggleMobileMenu()}
               isActive={mobileMenuOpen}
             >
-              {!isGlobalSelectorFocused && <>See county data&nbsp;&nbsp;</>}
+              {!isGlobalSelectorFocused && !isNarrowMobile && (
+                <>See county data&nbsp;&nbsp;</>
+              )}
               <MapIcon />
             </MapToggle>
           )}

--- a/src/components/Header/SearchHeader.style.js
+++ b/src/components/Header/SearchHeader.style.js
@@ -36,13 +36,14 @@ export const SelectorWrapper = styled.div`
 export const MapToggle = styled.div`
   cursor: pointer;
   box-shadow: 0px 2px 2px rgba(0, 0, 0, 0.2);
-  width: 54px;
+  padding: 0 15px;
   border: 1px solid ${BORDER_COLOR};
   display: flex;
   justify-content: center;
   align-items: center;
   border-radius: 4px;
   margin-left: 1rem;
+  color: ${props => (props.isActive ? 'white' : 'red')};
   background: ${props => (props.isActive ? 'red' : 'transparent')};
 
   svg path {

--- a/src/components/MapSelectors/GlobalSelector.js
+++ b/src/components/MapSelectors/GlobalSelector.js
@@ -69,7 +69,7 @@ const CountyItem = ({ dataset }) => {
   );
 };
 
-const GlobalSelector = ({ handleChange, extendRight, onIsFocusedChanged }) => {
+const GlobalSelector = ({ handleChange, extendRight, handleIsOpen }) => {
   const { id: location } = useParams();
 
   const stateDataset = US_STATE_DATASET.state_dataset;
@@ -214,7 +214,7 @@ const GlobalSelector = ({ handleChange, extendRight, onIsFocusedChanged }) => {
         getRootProps,
         openMenu,
       }) => {
-        if (onIsFocusedChanged) onIsFocusedChanged(isOpen);
+        if (handleIsOpen) handleIsOpen(isOpen);
         return (
           <StyledDropDownWrapper>
             <StyledInputWrapper

--- a/src/components/MapSelectors/GlobalSelector.js
+++ b/src/components/MapSelectors/GlobalSelector.js
@@ -69,7 +69,7 @@ const CountyItem = ({ dataset }) => {
   );
 };
 
-const GlobalSelector = ({ handleChange, extendRight }) => {
+const GlobalSelector = ({ handleChange, extendRight, onIsFocusedChanged }) => {
   const { id: location } = useParams();
 
   const stateDataset = US_STATE_DATASET.state_dataset;
@@ -213,46 +213,49 @@ const GlobalSelector = ({ handleChange, extendRight }) => {
         selectedItem,
         getRootProps,
         openMenu,
-      }) => (
-        <StyledDropDownWrapper>
-          <StyledInputWrapper
-            {...getRootProps(
-              {
-                isOpen,
-              },
-              { suppressRefError: true },
-            )}
-          >
-            <StyledInputIcon>
-              <SearchIcon />
-            </StyledInputIcon>
-            <StyledInput
-              {...getInputProps({
-                isOpen,
-                onFocus: () => {
-                  openMenu();
+      }) => {
+        onIsFocusedChanged(isOpen);
+        return (
+          <StyledDropDownWrapper>
+            <StyledInputWrapper
+              {...getRootProps(
+                {
+                  isOpen,
                 },
-                placeholder: 'Find your county or state',
+                { suppressRefError: true },
+              )}
+            >
+              <StyledInputIcon>
+                <SearchIcon />
+              </StyledInputIcon>
+              <StyledInput
+                {...getInputProps({
+                  isOpen,
+                  onFocus: () => {
+                    openMenu();
+                  },
+                  placeholder: 'Find your county or state',
+                })}
+              />
+            </StyledInputWrapper>
+            <StyledMenu
+              {...getMenuProps({
+                isOpen,
+                extendRight,
               })}
-            />
-          </StyledInputWrapper>
-          <StyledMenu
-            {...getMenuProps({
-              isOpen,
-              extendRight,
-            })}
-          >
-            {isOpen
-              ? getMatchedItems(
-                  getItemProps,
-                  inputValue,
-                  highlightedIndex,
-                  selectedItem,
-                )
-              : null}
-          </StyledMenu>
-        </StyledDropDownWrapper>
-      )}
+            >
+              {isOpen
+                ? getMatchedItems(
+                    getItemProps,
+                    inputValue,
+                    highlightedIndex,
+                    selectedItem,
+                  )
+                : null}
+            </StyledMenu>
+          </StyledDropDownWrapper>
+        );
+      }}
     </Downshift>
   );
 };

--- a/src/components/MapSelectors/GlobalSelector.js
+++ b/src/components/MapSelectors/GlobalSelector.js
@@ -214,7 +214,7 @@ const GlobalSelector = ({ handleChange, extendRight, onIsFocusedChanged }) => {
         getRootProps,
         openMenu,
       }) => {
-        onIsFocusedChanged(isOpen);
+        if (onIsFocusedChanged) onIsFocusedChanged(isOpen);
         return (
           <StyledDropDownWrapper>
             <StyledInputWrapper


### PR DESCRIPTION
Note: Easier to review if you disable whitespace diffs:
https://github.com/covid-projections/covid-projections/pull/396/files?diff=split&w=1

Shows "See county data" text next to the map toggle, unless the search is focused or unless the screen is really narrow.

Normally:

> ![image](https://user-images.githubusercontent.com/1570168/78307573-11a71f80-74fb-11ea-9eca-03527db9e760.png)

When search is focused:

> ![image](https://user-images.githubusercontent.com/1570168/78307585-179d0080-74fb-11ea-9c15-6b5a2004d279.png)

When screen is narrow:

> ![image](https://user-images.githubusercontent.com/1570168/78307675-50d57080-74fb-11ea-9009-289052190fd1.png)

