### PR TITLE
Try to fix CI error (Error: ENOSPC: System limit for number of file watchers reached).

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "serve": "react-scripts build && serve -s build",
     "eject": "react-scripts eject",
     "test": "start-server-and-test start http://localhost:3000 cy.open",
-    "test.ci": "cross-env BROWSER=none start-server-and-test start http://localhost:3000 cy.run",
+    "test.ci": "CHOKIDAR_USEPOLLING=1 cross-env BROWSER=none start-server-and-test start http://localhost:3000 cy.run",
     "cy.open": "cypress open",
     "cy.run": "cypress run",
     "lint": "eslint src",


### PR DESCRIPTION
Set CHOKIDAR_USEPOLLING=1 env var per https://github.com/gatsbyjs/gatsby/issues/11406#issuecomment-565748588 to avoid "System limit for number of file watchers reached" error that's been occurring in CI (e.g. see failure in https://github.com/covid-projections/covid-projections/pull/427/checks?check_run_id=563255441).  Seems to have worked.

This problem should go away soon once we move data files out of the covid-projections repo.