### PR TITLE
Fix meta tags on all pages

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -9,7 +9,6 @@
     />
 
     <meta name="theme-color" content="#000000" />
-    <meta name="description" content="" data-react-helmet="true" />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <!--
       manifest.json provides metadata used when your web app is installed on a
@@ -25,18 +24,34 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <meta property="og:title" content="Understand when hospitals will likely become overloaded by COVID and what you can do to stop it" data-react-helmet="true">
-    <meta property="og:site_name" content="Covid Act Now">
-    <meta property="og:url" content="https://covidactnow.org">
-    <meta property="og:description" content="The only thing that matters is how quickly you act" data-react-helmet="true">
-    <meta property="og:type" content="website">
-    <meta property="og:image" content="/covidactnow1.png">
-    <meta property="og:image" content="/covidactnow2.png">
-    <meta name="twitter:title" content="Understand when hospitals will likely become overloaded by COVID and what you can do to stop it" data-react-helmet="true">
-    <meta name="twitter:description" content="The only thing that matters is how quickly you act" data-react-helmet="true">
-    <meta name="twitter:image" content="/covidactnow2.png">
-    <meta name="twitter:card" content="summary_large_image">
-    <title>Covid Act Now</title>
+
+    <!-- General meta tags (per-page) -->
+    <title data-react-helmet="true">Covid Act Now</title>
+    <link data-react-helmet="true" rel="canonical" href="http://scovidactnow.org/" />
+    <meta data-react-helmet="true" name="description" content="Urge your public officials to quickly take action against the COVID-19 pandemic. These charts predict the last day each state can act before the point of no return." />
+
+    <!-- Facebook Open Graph meta tags (site-wide) -->
+    <meta property="og:type" content="website" />
+    <meta property="og:image" content="https://covidactnow.org/covidactnow1.png" />
+    <meta property="og:image" content="https://covidactnow.org/covidactnow2.png" />
+    <meta property="og:site_name" content="Covid Act Now" />
+
+    <!-- Facebook Open Graph meta tags (per-page) -->
+    <!-- BUG: Note that these don't currently change per-page. -->
+    <!-- https://github.com/covid-projections/covid-projections/issues/450 -->
+    <meta data-react-helmet="true" property="og:url" content="https://covidactnow.org" />
+    <meta data-react-helmet="true" property="og:title" content="This model predicts the last day each state can act before the point of no return" />
+    <meta data-react-helmet="true" property="og:description" content="The only thing that matters right now is the speed of your response" />
+
+    <!-- Twitter meta tags (site-wide) -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:image" content="https://covidactnow.org/covidactnow2.png" />
+
+    <!-- Twitter meta tags (per-page) -->
+    <!-- BUG: Note that these don't currently change per-page. -->
+    <!-- https://github.com/covid-projections/covid-projections/issues/450 -->
+    <meta data-react-helmet="true" name="twitter:title" content="This model predicts the last day each state can act before the point of no return" />
+    <meta data-react-helmet="true" name="twitter:description" content="The only thing that matters right now is the speed of your response" />
 
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-HFCDC7K5G1"></script>

--- a/src/components/AppMetaTags/AppMetaTags.js
+++ b/src/components/AppMetaTags/AppMetaTags.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import { Helmet } from 'react-helmet';
+
+/**
+ * public/index.html contains meta tags for the home page. Every non-home page
+ * will contain react-helmet tags to override the meta tags for the home page.
+ * This component helps manage the per-page meta tags.
+ *
+ * TypeScript definition for props:
+ * @param {{canonicalUrl: string, pageTitle?: string, pageDescription: string, shareTitle?: string, shareDescription?: string}} props
+ */
+export default function AppMetaTags({
+  canonicalUrl,
+  pageTitle,
+  pageDescription,
+  // BUG: shareTitle and shareDescription don't work! See note below.
+  shareTitle,
+  shareDescription,
+}) {
+  let fullPageTitle = pageTitle
+    ? [pageTitle, 'Covid Act Now'].join(' - ')
+    : 'Covid Act Now';
+  let fullCanonicalUrl = new URL(canonicalUrl, 'http://covidactnow.org/').href;
+
+  shareTitle = shareTitle || fullPageTitle;
+  shareDescription = shareDescription || pageDescription;
+
+  return (
+    <Helmet>
+      {/* Keep these in sync with the meta tags marked data-react-helmet in public/index.html! */}
+      <title>{fullPageTitle}</title>
+      <link rel="canonical" href={fullCanonicalUrl} />
+      <meta name="description" content={pageDescription} />
+
+      {/* BUG: None of these share meta tags work! */}
+      {/* https://github.com/covid-projections/covid-projections/issues/450 */}
+      <meta property="og:url" content={fullCanonicalUrl} />
+      <meta property="og:title" content={shareTitle} />
+      <meta property="og:description" content={shareDescription} />
+      <meta name="twitter:title" content={shareTitle} />
+      <meta name="twitter:description" content={shareDescription} />
+    </Helmet>
+  );
+}

--- a/src/screens/Endorsements/EndorsementsPage.js
+++ b/src/screens/Endorsements/EndorsementsPage.js
@@ -1,8 +1,8 @@
 import React from 'react';
 
 import Endorsements from 'screens/Endorsements/Endorsements';
-import { Wrapper } from 'screens/Endorsements/EndorsementsPage.style.js';
-import AppMetaTags from '../../components/AppMetaTags/AppMetaTags';
+import { Wrapper } from 'screens/Endorsements/EndorsementsPage.style';
+import AppMetaTags from 'components/AppMetaTags/AppMetaTags';
 
 const EndorsementsPage = () => {
   return (

--- a/src/screens/Endorsements/EndorsementsPage.js
+++ b/src/screens/Endorsements/EndorsementsPage.js
@@ -2,10 +2,18 @@ import React from 'react';
 
 import Endorsements from 'screens/Endorsements/Endorsements';
 import { Wrapper } from 'screens/Endorsements/EndorsementsPage.style.js';
+import AppMetaTags from '../../components/AppMetaTags/AppMetaTags';
 
 const EndorsementsPage = () => {
   return (
     <Wrapper>
+      <AppMetaTags
+        canonicalUrl="/endorsements"
+        pageTitle="Endorsements"
+        pageDescription="While no projection is perfect, we endorse this tool and model as
+              a valid and important way to frame the decisions political leaders
+              must make now."
+      />
       <Endorsements />
     </Wrapper>
   );

--- a/src/screens/FAQ/FAQ.js
+++ b/src/screens/FAQ/FAQ.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import Typography from '@material-ui/core/Typography';
 import { TEAM } from './../../enums';
+import AppMetaTags from '../../components/AppMetaTags/AppMetaTags';
 import ShareBlock from 'components/ShareBlock/ShareBlock';
 
 import { Wrapper, Content } from './FAQ.style';
@@ -8,6 +9,13 @@ import { Wrapper, Content } from './FAQ.style';
 const FAQ = ({ children }) => {
   return (
     <Wrapper>
+      <AppMetaTags
+        canonicalUrl="/faq"
+        pageTitle="FAQ"
+        pageDescription="Covid Act Now was started by four volunteers who saw the explosive and
+          deadly growth of COVID infections around the world and felt they had
+          to do something."
+      />
       <Content>
         <Typography variant="h3" component="h1">
           About Covid Act Now

--- a/src/screens/FAQ/FAQ.js
+++ b/src/screens/FAQ/FAQ.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import Typography from '@material-ui/core/Typography';
 import { TEAM } from './../../enums';
-import AppMetaTags from '../../components/AppMetaTags/AppMetaTags';
+import AppMetaTags from 'components/AppMetaTags/AppMetaTags';
 import ShareBlock from 'components/ShareBlock/ShareBlock';
 
 import { Wrapper, Content } from './FAQ.style';

--- a/src/screens/HomePage/HomePage.js
+++ b/src/screens/HomePage/HomePage.js
@@ -4,7 +4,7 @@ import HomePageHeader from 'components/Header/HomePageHeader';
 import { COLORS } from 'enums';
 import Map from 'components/Map/Map';
 import Endorsements from 'screens/Endorsements/Endorsements';
-import AppMetaTags from '../../components/AppMetaTags/AppMetaTags';
+import AppMetaTags from 'components/AppMetaTags/AppMetaTags';
 import ShareBlock from 'components/ShareBlock/ShareBlock';
 
 import { Wrapper, Content, MapTitle, MapTitleDivider } from './HomePage.style';

--- a/src/screens/HomePage/HomePage.js
+++ b/src/screens/HomePage/HomePage.js
@@ -4,6 +4,7 @@ import HomePageHeader from 'components/Header/HomePageHeader';
 import { COLORS } from 'enums';
 import Map from 'components/Map/Map';
 import Endorsements from 'screens/Endorsements/Endorsements';
+import AppMetaTags from '../../components/AppMetaTags/AppMetaTags';
 import ShareBlock from 'components/ShareBlock/ShareBlock';
 
 import { Wrapper, Content, MapTitle, MapTitleDivider } from './HomePage.style';
@@ -11,6 +12,11 @@ import { Wrapper, Content, MapTitle, MapTitleDivider } from './HomePage.style';
 export default function HomePage() {
   return (
     <>
+      <AppMetaTags
+        canonicalUrl="/"
+        pageTitle={undefined}
+        pageDescription="Urge your public officials to quickly take action against the COVID-19 pandemic. These charts predict the last day each state can act before the point of no return."
+      />
       <HomePageHeader />
       <main>
         <div className="App">

--- a/src/screens/ModelPage/ModelPage.js
+++ b/src/screens/ModelPage/ModelPage.js
@@ -1,6 +1,5 @@
 import React, { useState, useMemo } from 'react';
 import _ from 'lodash';
-import { Helmet } from 'react-helmet';
 import { useParams, useHistory } from 'react-router-dom';
 import US_STATE_DATASET from 'components/MapSelectors/datasets/us_states_dataset_01_02_2020';
 import CountyMap from 'components/CountyMap/CountyMap';
@@ -17,6 +16,7 @@ import {
   MapMenuItem,
 } from 'components/Header/SearchHeader.style';
 
+import AppMetaTags from '../../components/AppMetaTags/AppMetaTags';
 import {
   Wrapper,
   ContentWrapper,
@@ -87,16 +87,24 @@ function ModelPage() {
     return <LoadingScreen></LoadingScreen>;
   }
 
-  let title;
-  let description;
-  const canonical = `/us/${_location.toLowerCase()}`;
+  let actionTitle;
+  let actionDescription;
   if (intervention === INTERVENTIONS.SHELTER_IN_PLACE) {
-    title = `Keep staying at home in ${locationName}.`;
-    description = `Avoiding hospital overload depends heavily on your cooperation.`;
+    actionTitle = `${locationName}: Keep staying at home to protect against the COVID-19 outbreak.`;
+    actionDescription = `Avoiding hospital overload depends heavily on your cooperation.`;
   } else {
-    title = `You must act now in ${locationName}!`;
-    description = `To prevent hospital overload, our projections indicate a Stay at home order must be implemented soon.`;
+    actionTitle = `${locationName}: Urge your public officials to act now against the COVID-19 outbreak!`;
+    actionDescription = `To prevent hospital overload, our projections indicate a Stay at home order must be implemented soon.`;
   }
+  let metaTags = (
+    <AppMetaTags
+      canonicalUrl={`/us/${_location.toLowerCase()}`}
+      pageTitle={`${locationName} Forecast`}
+      pageDescription={actionTitle}
+      shareTitle={actionTitle}
+      shareDescription={actionDescription}
+    />
+  );
 
   const renderHeader = () => {
     return (
@@ -262,16 +270,7 @@ function ModelPage() {
 
   return (
     <Wrapper>
-      <Helmet>
-        <title>{title}</title>
-        <meta name="title" content={title} />
-        <meta name="twitter:title" content={title} />
-        <meta property="og:title" content={title} />
-        <meta name="description" content={description} />
-        <meta name="twitter:description" content={description} />
-        <meta property="og:description" content={description} />
-        <link rel="canonical" href={canonical} />
-      </Helmet>
+      {metaTags}
       <ContentWrapper>
         {renderHeader()}
         {modelDatas && modelDatas.error ? (

--- a/src/screens/ModelPage/ModelPage.js
+++ b/src/screens/ModelPage/ModelPage.js
@@ -16,7 +16,7 @@ import {
   MapMenuItem,
 } from 'components/Header/SearchHeader.style';
 
-import AppMetaTags from '../../components/AppMetaTags/AppMetaTags';
+import AppMetaTags from 'components/AppMetaTags/AppMetaTags';
 import {
   Wrapper,
   ContentWrapper,


### PR DESCRIPTION
Fixes #411

This is the effect I hope this PR will have:

| Before    | After    |
| ----------| -------- |
| ![before] | ![after] |

[before]: https://user-images.githubusercontent.com/206364/78419072-b3f7fd80-75f6-11ea-8fe2-600244f3f751.png
[after]: https://user-images.githubusercontent.com/1570168/78424902-7c547a00-7625-11ea-9f15-4ca634e764d7.png

What's not fixed:

As noted extensively in comments, the FB/Twitter share buttons aren't picking up the meta tags that we're injecting using react-helmet. I don't think they've ever worked, and I don't think any frontend change can fix this. I opened #450 for this and added links to it where the code is currently broken.
