### PR TITLE
Make AppBar state always reflect URL

### DIFF
--- a/src/components/AppBar/AppBar.js
+++ b/src/components/AppBar/AppBar.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useHistory, useLocation, matchPath } from 'react-router-dom';
 import Logo from 'assets/images/logo';
 import { useEmbed } from 'utils/hooks';
@@ -22,30 +22,29 @@ import {
 } from 'react-share';
 import { STATES } from 'enums';
 
+const Panels = ['/', '/faq', '/endorsements', '/contact', '/blog'];
+
+function getPanelIdxFromLocation(location) {
+  let idx = Panels.indexOf(location.pathname);
+  return idx === -1 ? false : idx;
+}
+
 const _AppBar = () => {
   const history = useHistory();
-  const { pathname } = useLocation();
-  const panels = ['/', '/faq', '/endorsements', '/contact', '/blog'];
+  const location = useLocation();
 
-  const getDefaultPanelId = () => {
-    const defaultPanelIndex = Number(panels.indexOf(pathname));
-
-    if (!defaultPanelIndex) {
-      return 0;
-    }
-
-    // We are on the state page, don't highlight a tab
-    if (defaultPanelIndex === -1) {
-      return false;
-    }
-
-    return defaultPanelIndex;
-  };
-
-  const [panelIdx, setPanelIdx] = useState(getDefaultPanelId());
+  const [panelIdx, setPanelIdx] = useState(getPanelIdxFromLocation(location));
   const [open, setOpen] = useState(false);
   const locationPath = useLocation();
   const { isEmbed } = useEmbed();
+
+  useEffect(() => {
+    function handleLocationChange(location) {
+      setPanelIdx(getPanelIdxFromLocation(location));
+    }
+    // https://github.com/ReactTraining/react-router/issues/3385#issuecomment-214758008
+    return history.listen(handleLocationChange);
+  }, [history]);
 
   // Don't show in iFrame
   if (isEmbed) return null;
@@ -70,7 +69,6 @@ const _AppBar = () => {
   const goTo = route => e => {
     e.preventDefault();
     setOpen(false);
-    setPanelIdx(panels.indexOf(route));
 
     history.push(route);
 


### PR DESCRIPTION
Previously, clicking the nav links in the footer did not change which link was highlighted in the AppBar (top bar). See this example -- we are on `/faq` but the AppBar still has **Map** highlighted.

![image](https://user-images.githubusercontent.com/1570168/78660106-5f1be780-7881-11ea-9fcc-568ac2929182.png)

The issue was by the fact that only the AppBar's own links told AppBar to update state. This PR changes AppBar to update state based on the current URL, so it's always up to date no matter how the page was navigated to.