### PR TITLE
UX fast-follows from V2

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -79,7 +79,7 @@ tr {
 
 .Map path:hover {
   opacity: 0.5;
-  fill: rgba(0,0,0,0.25);
+  fill: rgba(0, 0, 0, 0.25);
   cursor: pointer;
 }
 

--- a/src/components/Charts/ModelChart.style.js
+++ b/src/components/Charts/ModelChart.style.js
@@ -90,8 +90,12 @@ export const Wrapper = styled.div`
     font-size: 13px;
     color: rgba(0, 0, 0, 0.7);
   }
+  .highcharts-legend-item {
+    cursor: pointer;
+    user-select: none;
+  }
   .highcharts-area {
-    fill-opacity: 1;
+    fill-opacity: 0.8;
   }
   /* these are styled according to the
      order passed into the series array */
@@ -100,7 +104,7 @@ export const Wrapper = styled.div`
     fill: ${props =>
       props.interventions.getChartSeriesColorMap().limitedActionSeries};
     stroke: white;
-    fill-opacity: ;
+    fill-opacity: 1;
   }
   /* Social distancing */
   .highcharts-series-1 {

--- a/src/components/Map/Legend.js
+++ b/src/components/Map/Legend.js
@@ -97,7 +97,7 @@ export function MiniLegendItem(props) {
 
   return (
     <Grid item xs={12} md={4}>
-      <LegendItemHeader>
+      <LegendItemHeader mini>
         <ColorBox color={color} />
         {description}
       </LegendItemHeader>

--- a/src/components/Map/Legend.style.js
+++ b/src/components/Map/Legend.style.js
@@ -24,6 +24,7 @@ export const LegendItemHeader = styled(Box)`
   flex-direction: row;
   align-items: center;
   justify-content: flex-start;
+  font-weight: ${props => (props.mini ? 'normal' : 'bold')};
   font-size: 13px;
 `;
 


### PR DESCRIPTION
Executes several UX improvements from Josh Ziman:

- On homepage’s legend, consider changing titles to `font-weight: bold` in order to increase visibility
- On chart page’s legend and on hover state for each legend item, consider changing to `cursor: pointer` to better indicate interactivity/toggle affordance
- On charts, consider changing curves to `fill-opacity: .8` to reveal the trajectory of curves in the background