### PR TITLE
Don't show time window for Hospital Overload if it's in the past

### DIFF
--- a/src/components/Charts/ModelChart.js
+++ b/src/components/Charts/ModelChart.js
@@ -86,7 +86,6 @@ const ModelChart = ({
       currentIntervention === INTERVENTIONS.SHELTER_IN_PLACE
         ? formatIntervention(INTERVENTIONS.SHELTER_IN_PLACE, ' (lax)')
         : formatIntervention(INTERVENTIONS.SOCIAL_DISTANCING),
-
     type: 'areaspline',
     data: data[2].data,
     marker: {
@@ -110,7 +109,6 @@ const ModelChart = ({
       currentIntervention === INTERVENTIONS.SHELTER_IN_PLACE
         ? formatIntervention(INTERVENTIONS.SHELTER_IN_PLACE, ' (strict)')
         : formatIntervention(INTERVENTIONS.SHELTER_IN_PLACE),
-
     type: 'areaspline',
     data: data[1].data,
     marker: {

--- a/src/models/Projections.js
+++ b/src/models/Projections.js
@@ -206,6 +206,15 @@ export class Projections {
 
   getChartHospitalsOverloadedText() {
     let text = '';
+    const isDateOverWhelmedBeforeToday =
+      this.worstCaseInterventionModel.dateOverwhelmed &&
+      moment(this.worstCaseInterventionModel.dateOverwhelmed).isBefore(
+        moment().startOf('day'),
+      );
+
+    if (isDateOverWhelmedBeforeToday) {
+      return text;
+    }
 
     switch (this.getInterventionColor()) {
       case COLOR_MAP.RED.BASE:


### PR DESCRIPTION
[See for yourself
](https://covid-projections-git-ap-fix-past-hospital-overload.covidactnow.now.sh/us/co/county/gunnison_county)

Resolves #470 
![Screen Shot 2020-04-08 at 5 31 11 AM](https://user-images.githubusercontent.com/1658177/78784589-737fe300-795a-11ea-9847-9e49aa418c34.png)
