### PR TITLE
Bring back the back arrow on state pages. Refs #398

### DIFF
--- a/src/components/AppBar/AppBar.js
+++ b/src/components/AppBar/AppBar.js
@@ -20,6 +20,7 @@ import {
   TwitterShareButton,
   TwitterIcon,
 } from 'react-share';
+import ArrowBack from '@material-ui/icons/ArrowBack';
 import { STATES } from 'enums';
 
 const Panels = ['/', '/faq', '/endorsements', '/contact', '/blog'];
@@ -110,6 +111,7 @@ const _AppBar = () => {
     <StyledAppBar position="sticky">
       <Wrapper>
         <Left onClick={goTo('/')}>
+          {match ? <ArrowBack /> : ''}
           <Logo />
         </Left>
         <StyledDesktopMenu value={false}>


### PR DESCRIPTION
This doesn't fix county pages currently because `match` isn't set for county pages, but that's because of #487 which I will deal with separately.