### PR TITLE
remove contain now model loading

### DIFF
--- a/scripts/models/projections.js
+++ b/scripts/models/projections.js
@@ -18,7 +18,6 @@ class Projections {
     this.baseline = null;
     this.distancing = null;
     this.distancingPoorEnforcement = null;
-    this.contain = null;
     this.currentInterventionModel = null;
 
     this.populateInterventions(props);
@@ -146,14 +145,6 @@ class Projections {
         intervention: INTERVENTIONS.SOCIAL_DISTANCING,
         durationDays: 90,
         r0: 1.7,
-      }),
-    };
-
-    this.contain = {
-      now: new Model(props[3], {
-        intervention: INTERVENTIONS.LOCKDOWN,
-        durationDays: 90,
-        r0: 0.3,
       }),
     };
   }

--- a/src/models/Projections.js
+++ b/src/models/Projections.js
@@ -364,13 +364,5 @@ export class Projections {
         r0: 1.7,
       }),
     };
-
-    this.contain = {
-      now: new Model(props[3], {
-        intervention: INTERVENTIONS.LOCKDOWN,
-        durationDays: 90,
-        r0: 0.3,
-      }),
-    };
   }
 }

--- a/src/utils/model.js
+++ b/src/utils/model.js
@@ -34,7 +34,6 @@ async function fetchAll(urls) {
 export const ModelIds = {
   baseline: 0,
   strictDistancingNow: 1,
-  containNow: 2,
   weakDistancingNow: 3,
 };
 
@@ -70,7 +69,6 @@ async function fetchData(location, county = null, dataUrl = null) {
     ModelIds.baseline,
     ModelIds.strictDistancingNow,
     ModelIds.weakDistancingNow,
-    ModelIds.containNow,
   ].map(i => {
     let fipsCode =
       county && county.full_fips_code ? county.full_fips_code : null;


### PR DESCRIPTION
This removes the data fetching for the wuhan intervention file, it is currently file 2, if the BE updates reindexes 2 to become the social distancing model ModelIds->weakDistancingNow needs to be updated