### PR TITLE
Use an alias when importing the 'match' type from react-router to avo…

### DIFF
--- a/scripts/calculated_interventions/index.js
+++ b/scripts/calculated_interventions/index.js
@@ -44,7 +44,9 @@ async function getStateAndCountyDataFiles(stateCode) {
           );
           const countyProjections = new Projections(countyData, stateCode);
 
-          countyFipsData[fipsCode] = countyProjections.getThresholdInterventionLevel();
+          countyFipsData[
+            fipsCode
+          ] = countyProjections.getThresholdInterventionLevel();
         } catch (err) {
           console.error(`Failed to get data for ${stateCode}.${fipsCode}`, err);
         }

--- a/src/components/AppBar/AppBar.tsx
+++ b/src/components/AppBar/AppBar.tsx
@@ -1,6 +1,11 @@
 import React, { useEffect, useState } from 'react';
 import _ from 'lodash';
-import { useHistory, useLocation, matchPath } from 'react-router-dom';
+import {
+  useHistory,
+  useLocation,
+  match as MatchType,
+  matchPath,
+} from 'react-router-dom';
 import Logo from 'assets/images/logo';
 import { useEmbed } from 'utils/hooks';
 import MobileMenu from './MobileMenu';
@@ -33,7 +38,9 @@ function getPanelIdxFromLocation(location: Location<any>) {
   return idx === -1 ? false : idx;
 }
 
-function locationNameFromMatch(match: any | null) {
+function locationNameFromMatch(
+  match: MatchType<{ id: keyof typeof STATES; county?: string }> | null,
+) {
   if (!match || !match.params) {
     return '';
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1872,13 +1872,6 @@
   resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.2.tgz#690a1475b84f2a884fd07cd797c00f5f31356ea8"
   integrity sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw==
 
-"@types/react-copy-to-clipboard@^4.3.0":
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/@types/react-copy-to-clipboard/-/react-copy-to-clipboard-4.3.0.tgz#8e07becb4f11cfced4bd36038cb5bdf5c2658be5"
-  integrity sha512-iideNPRyroENqsOFh1i2Dv3zkviYS9r/9qD9Uh3Z9NNoAAqqa2x53i7iGndGNnJFIo20wIu7Hgh77tx1io8bgw==
-  dependencies:
-    "@types/react" "*"
-
 "@types/react-dom@*":
   version "16.9.5"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.9.5.tgz#5de610b04a35d07ffd8f44edad93a71032d9aaa7"


### PR DESCRIPTION
```
$ yarn lint && yarn prettier && yarn tsc
yarn run v1.19.1
$ eslint --ext .js,.ts,tsx src
✨  Done in 5.01s.
yarn run v1.19.1
$ prettier --check '**/*.{css,scss,js,tsx}'
Checking formatting...
All matched files use Prettier code style!
✨  Done in 2.23s.
yarn run v1.19.1
$ tsc
✨  Done in 6.57s.
```