### PR TITLE
Add city match indicator. Closes #481

### DIFF
--- a/src/components/MapSelectors/MapSelectors.style.js
+++ b/src/components/MapSelectors/MapSelectors.style.js
@@ -41,6 +41,12 @@ export const StyledResultsMenuSubText = styled.div`
   color: rgba(0, 0, 0, 0.7);
 `;
 
+export const StyledCityInCounty = styled.span`
+  color: rgba(0, 0, 0, 0.7);
+  font-style: italic;
+  padding-left: 0.3em;
+`;
+
 export const StyledState = styled.div`
   position: relative;
   top: 3px;


### PR DESCRIPTION
~~(edit: done, thanks) Aside: Can somebody give me sufficient permission in the repo so that I can assign issues to myself while I'm working on them, so I don't worry that someone else is duplicating the work?~~

## What it looks like
![image](https://user-images.githubusercontent.com/3341011/79093309-b948fc80-7d08-11ea-9aab-78e039317d96.png)

![image](https://user-images.githubusercontent.com/3341011/79093316-bf3edd80-7d08-11ea-88f3-76e0eb3c4fad.png)


## Some manual test cases

type these in to the search bar
"seat" for Seattle and SeaTac, WA
"Snohomish" which is a city inside of a county of the same name (does not show city indicator)
"cit" to match all kinds of places and see the "X and others" behavior.