### PR TITLE
Update bug template to use Markdown titles

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-template.md
+++ b/.github/ISSUE_TEMPLATE/bug-template.md
@@ -7,14 +7,20 @@ assignees: ''
 
 ---
 
-*summary:*
+## summary
 
-*expected result:*
 
-*actual result:*
+## expected result
 
-*environment (device, browser, mobile / web):*
 
-*link:*
+## actual result
 
-*screenshot (you can copy/paste images directly in):*
+
+## environment
+*(device, browser, mobile / web)*
+
+## link
+
+
+## screenshot
+*(you can copy/paste images directly in)*


### PR DESCRIPTION
Since mostly blocks of text are expected, it makes more sense to use titles and sections than italicized prompts.

I left the endorsement template because that's different - we'd only expect a short response for each item.