### PR TITLE
/compare: Disable "Restrictions Lifted" graph by default.

### DIFF
--- a/src/components/Charts/ModelChart.js
+++ b/src/components/Charts/ModelChart.js
@@ -39,6 +39,7 @@ const ModelChart = ({
   interventions,
   currentIntervention,
   showDisclaimer,
+  forCompareModels, // true when used by CompareModels.js component.
 }) => {
   const interventionToModel = {
     [INTERVENTIONS.LIMITED_ACTION]: interventions.baseline,
@@ -93,6 +94,7 @@ const ModelChart = ({
     marker: {
       symbol: 'circle',
     },
+    visible: !forCompareModels,
     condensedLegend: {
       bgColor: interventions.getChartSeriesColorMap().limitedActionSeries,
     },

--- a/src/screens/CompareModels/CompareModels.js
+++ b/src/screens/CompareModels/CompareModels.js
@@ -334,6 +334,7 @@ function StateChart({ state, models }) {
         subtitle="Hospitalizations over time"
         interventions={models}
         currentIntervention={intervention}
+        forCompareModels={true}
       />
     </LazyLoad>
   );


### PR DESCRIPTION
It tends to dwarf the "current trend" graph, so disable it by default when comparing.