### PR TITLE
Swap 24hrs for 3 days and update hero

### DIFF
--- a/src/components/Charts/ModelChart.js
+++ b/src/components/Charts/ModelChart.js
@@ -382,7 +382,7 @@ const ModelChart = ({
                   .{' '}
                 </span>
               </LightTooltip>
-              This model updates every 24 hours and is intended to help make
+              This model updates every 3 days and is intended to help make
               fast decisions, not predict the future.{' '}
               <a
                 href="https://data.covidactnow.org/Covid_Act_Now_Model_References_and_Assumptions.pdf"

--- a/src/components/Charts/ModelChart.js
+++ b/src/components/Charts/ModelChart.js
@@ -32,8 +32,8 @@ function getDateUpdated() {
   const diff = now - start;
   const oneDay = 1000 * 60 * 60 * 24;
   const dayOfYear = Math.floor(diff / oneDay);
-  const daysSinceUpdate = dayOfYear % 3
-  return new Date(now - (oneDay * daysSinceUpdate)).toLocaleDateString();
+  const daysSinceUpdate = dayOfYear % 3;
+  return new Date(now - oneDay * daysSinceUpdate).toLocaleDateString();
 }
 
 const formatIntervention = (intervention, optCase) =>
@@ -386,14 +386,11 @@ const ModelChart = ({
                 placement="bottom"
               >
                 <span>
-                  <strong>
-                    Last updated {getDateUpdated()}
-                  </strong>
-                  .{' '}
+                  <strong>Last updated {getDateUpdated()}</strong>.{' '}
                 </span>
               </LightTooltip>
-              This model updates every 3 days and is intended to help make
-              fast decisions, not predict the future.{' '}
+              This model updates every 3 days and is intended to help make fast
+              decisions, not predict the future.{' '}
               <a
                 href="https://data.covidactnow.org/Covid_Act_Now_Model_References_and_Assumptions.pdf"
                 target="_blank"

--- a/src/components/Charts/ModelChart.js
+++ b/src/components/Charts/ModelChart.js
@@ -26,6 +26,16 @@ function dateIsPastHalfway(dateToCompare, dateArray, itemKey) {
   );
 }
 
+function getDateUpdated() {
+  const now = new Date();
+  const start = new Date(now.getFullYear(), 0, 0);
+  const diff = now - start;
+  const oneDay = 1000 * 60 * 60 * 24;
+  const dayOfYear = Math.floor(diff / oneDay);
+  const daysSinceUpdate = dayOfYear % 3
+  return new Date(now - (oneDay * daysSinceUpdate)).toLocaleDateString();
+}
+
 const formatIntervention = (intervention, optCase) =>
   `3 months of ${intervention.toLowerCase()}${optCase || ''}`;
 
@@ -377,7 +387,7 @@ const ModelChart = ({
               >
                 <span>
                   <strong>
-                    Last updated {new Date().toLocaleDateString()}
+                    Last updated {getDateUpdated()}
                   </strong>
                   .{' '}
                 </span>

--- a/src/components/Header/HomePageHeader.style.tsx
+++ b/src/components/Header/HomePageHeader.style.tsx
@@ -5,6 +5,7 @@ export const Wrapper = styled.div`
   margin: 0;
   padding: 3rem 2rem 2rem;
   background-color: #f2f2f2;
+  text-align: center;
 
   @media (min-width: 600px) {
     padding: 4rem 2rem 3rem;
@@ -17,8 +18,16 @@ export const Content = styled.div`
 `;
 
 export const HighlightColor = styled.span`
-  color: #00d07d;
-  font-weight: 600;
+  > a {
+    color: #00d07d;
+    font-weight: 600;
+    text-decoration: underline rgba(0, 0, 0, 0);
+    transition: 0.2s ease text-decoration-color;
+
+    &:hover {
+      text-decoration-color: #00d07d;
+    }
+  }
 `;
 
 export const HeaderTitle = styled(Typography)<{ component?: string }>`
@@ -26,12 +35,16 @@ export const HeaderTitle = styled(Typography)<{ component?: string }>`
   font-weight: 500;
   line-height: 2.3rem;
   margin-bottom: 0.5rem;
+
+  @media (max-width: 599px) {
+    font-size: 1.5em;
+  }
 `;
 
 export const HeaderSubCopy = styled(Typography)<{ component?: string }>`
   font-size: 1rem;
   line-height: 1.6rem;
-  margin-bottom: 2rem;
+  margin: 0 auto 2rem;
   max-width: 560px;
   color: rgba(0, 0, 0, 0.7);
 `;

--- a/src/components/Header/HomePageHeader.tsx
+++ b/src/components/Header/HomePageHeader.tsx
@@ -32,7 +32,12 @@ const HomePageHeader = () => {
     <Wrapper>
       <Content>
         <HeaderTitle>
-          43,000 American Lives Saved <HighlightColor><a href="https://blog.covidactnow.org/early-action-saves-43000-lives/">and Counting.</a></HighlightColor>
+          43,000 American Lives Saved{' '}
+          <HighlightColor>
+            <a href="https://blog.covidactnow.org/early-action-saves-43000-lives/">
+              and Counting.
+            </a>
+          </HighlightColor>
         </HeaderTitle>
         <div>
           <HeaderSubCopy color="inherit" component="p" variant="subtitle2">

--- a/src/components/Header/HomePageHeader.tsx
+++ b/src/components/Header/HomePageHeader.tsx
@@ -32,11 +32,12 @@ const HomePageHeader = () => {
     <Wrapper>
       <Content>
         <HeaderTitle>
-          Act now. <HighlightColor>Save lives.</HighlightColor>
+          43,000 American Lives Saved <HighlightColor><a href="https://blog.covidactnow.org/early-action-saves-43000-lives/">and Counting.</a></HighlightColor>
         </HeaderTitle>
         <div>
           <HeaderSubCopy color="inherit" component="p" variant="subtitle2">
-            Understand when hospitals will likely become overloaded by COVID and
+            Staying home saves lives. Our projections show how COVID is
+            spreading in your area, when hospitals may become overloaded, and
             what you can do to stop it.
           </HeaderSubCopy>
 

--- a/src/models/Projections.js
+++ b/src/models/Projections.js
@@ -166,16 +166,16 @@ export class Projections {
 
   getInterventionPredictionForShelterInPlace() {
     let predictionText =
-      'Things look good, keep it up! Assuming stay-at-home interventions remain in place, hospitals are not projected to become overloaded. Check back — projections update every 24 hours with the most recent data.';
+      'Things look good, keep it up! Assuming stay-at-home interventions remain in place, hospitals are not projected to become overloaded. Check back — projections update every 3 days with the most recent data.';
 
     if (this.getThresholdInterventionLevel() === COLOR_MAP.ORANGE.BASE) {
       predictionText =
-        'Things look okay. Assuming stay-at-home interventions remain in place, projections show low-to-moderate probability of hospital overload in the next two months. Check back — projections update every 24 hours with the most recent data.';
+        'Things look okay. Assuming stay-at-home interventions remain in place, projections show low-to-moderate probability of hospital overload in the next two months. Check back — projections update every 3 days with the most recent data.';
     }
 
     if (this.getThresholdInterventionLevel() === COLOR_MAP.RED.BASE) {
       predictionText =
-        'Be careful. Even with stay-at-home interventions in place, our projections show risk of hospital overload in your area. More action is needed to help flatten the curve. Check back — projections update every 24 hours with the most recent data.';
+        'Be careful. Even with stay-at-home interventions in place, our projections show risk of hospital overload in your area. More action is needed to help flatten the curve. Check back — projections update every 3 days with the most recent data.';
     }
 
     return <HeaderSubCopy>{predictionText}</HeaderSubCopy>;

--- a/src/screens/FAQ/FAQ.tsx
+++ b/src/screens/FAQ/FAQ.tsx
@@ -95,7 +95,7 @@ const FAQ = ({ children }: { children: React.ReactNode }) => {
           How often does the model update?
         </Typography>
         <Typography variant="body1" component="p">
-          The model updates every 24 hours, and the “last updated” date stamp on
+          The model updates every 3 days, and the “last updated” date stamp on
           the state page will tell you specifically.
         </Typography>
 


### PR DESCRIPTION
We're updating the model every 3 days now, not 24 hours, so I've updated that everywhere. In addition, this PR swaps the homepage hero and links to our 43k lives blog post.
<img width="1392" alt="Screen Shot 2020-04-16 at 7 08 21 PM" src="https://user-images.githubusercontent.com/2433509/79515103-bce4c800-8015-11ea-9c09-39ca715a4687.png">
<img width="303" alt="Screen Shot 2020-04-16 at 7 08 35 PM" src="https://user-images.githubusercontent.com/2433509/79515110-bfdfb880-8015-11ea-9743-ff60d5ee7866.png">

