### PR TITLE
Fix county embeds (they were trying to show inference projections).

### DIFF
--- a/src/components/Charts/ModelChart.js
+++ b/src/components/Charts/ModelChart.js
@@ -6,6 +6,7 @@ import { INTERVENTIONS } from 'enums';
 import LightTooltip from 'components/LightTooltip/LightTooltip';
 import Chart from './Chart';
 import { Typography } from '@material-ui/core';
+import { useEmbed } from 'utils/hooks';
 
 import {
   ChartContainer,
@@ -45,7 +46,7 @@ const condensedFormatIntervention = (intervention, optCase) =>
 const ModelChart = ({
   height,
   condensed,
-  countyName,
+  isCounty,
   interventions,
   currentIntervention,
   showDisclaimer,
@@ -58,7 +59,8 @@ const ModelChart = ({
     [INTERVENTIONS.PROJECTED]: interventions.projected,
     [INTERVENTIONS.SHELTER_IN_PLACE]: interventions.distancing.now,
   };
-  const hasProjections = !countyName;
+  const hasProjections = !isCounty;
+  const { isEmbed } = useEmbed();
 
   let model = interventionToModel[currentIntervention];
   if (hasProjections) {
@@ -198,7 +200,6 @@ const ModelChart = ({
         spacing: [8, 0, condensed ? 12 : 32, 0],
       },
       title: {
-        // text: county ? `${county.county}, ${state}` : state,
         text: undefined,
       },
       subtitle: {
@@ -360,7 +361,7 @@ const ModelChart = ({
         }
       >
         <Chart options={options} />
-        {countyName ? (
+        {isCounty && !isEmbed ? (
           <Disclaimer
             style={{ border: '2px solid #00d07d', background: 'white' }}
           >

--- a/src/components/Charts/ModelChart.js
+++ b/src/components/Charts/ModelChart.js
@@ -46,7 +46,6 @@ const condensedFormatIntervention = (intervention, optCase) =>
 const ModelChart = ({
   height,
   condensed,
-  isCounty,
   interventions,
   currentIntervention,
   showDisclaimer,
@@ -59,7 +58,7 @@ const ModelChart = ({
     [INTERVENTIONS.PROJECTED]: interventions.projected,
     [INTERVENTIONS.SHELTER_IN_PLACE]: interventions.distancing.now,
   };
-  const hasProjections = !isCounty;
+  const hasProjections = interventions.hasProjections;
   const { isEmbed } = useEmbed();
 
   let model = interventionToModel[currentIntervention];
@@ -361,7 +360,7 @@ const ModelChart = ({
         }
       >
         <Chart options={options} />
-        {isCounty && !isEmbed ? (
+        {interventions.isCounty && !isEmbed ? (
           <Disclaimer
             style={{ border: '2px solid #00d07d', background: 'white' }}
           >

--- a/src/models/Projections.js
+++ b/src/models/Projections.js
@@ -22,7 +22,8 @@ export class Projections {
     this.distancing = null;
     this.distancingPoorEnforcement = null;
     this.currentInterventionModel = null;
-    this.hasProjections = county == null;
+    this.isCounty = county != null;
+    this.hasProjections = !this.isCounty;
 
     this.populateInterventions(props);
     this.populateCurrentIntervention();

--- a/src/screens/CompareModels/CompareModels.js
+++ b/src/screens/CompareModels/CompareModels.js
@@ -329,7 +329,6 @@ function StateChart({ state, models }) {
     // Chart height is 600px; we pre-load when a chart is within 1200px of view.
     <LazyLoad height={600} offset={1200}>
       <ModelChart
-        isCounty={false}
         subtitle="Hospitalizations over time"
         interventions={models}
         currentIntervention={intervention}

--- a/src/screens/CompareModels/CompareModels.js
+++ b/src/screens/CompareModels/CompareModels.js
@@ -329,8 +329,7 @@ function StateChart({ state, models }) {
     // Chart height is 600px; we pre-load when a chart is within 1200px of view.
     <LazyLoad height={600} offset={1200}>
       <ModelChart
-        state={locationName}
-        county={null}
+        isCounty={false}
         subtitle="Hospitalizations over time"
         interventions={models}
         currentIntervention={intervention}

--- a/src/screens/Embed/ChartsTab.js
+++ b/src/screens/Embed/ChartsTab.js
@@ -6,7 +6,7 @@ import { EmbedChartContainer } from './Embed.style';
 
 export default function ChartsTab({
   state,
-  county,
+  isCounty,
   interventions,
   currentIntervention,
 }) {
@@ -14,9 +14,8 @@ export default function ChartsTab({
     <EmbedChartContainer>
       <ModelChart
         condensed
-        state={state}
         height={290}
-        county={county}
+        isCounty={isCounty}
         subtitle="Hospitalizations over time"
         interventions={interventions}
         currentIntervention={currentIntervention}

--- a/src/screens/Embed/ChartsTab.js
+++ b/src/screens/Embed/ChartsTab.js
@@ -4,18 +4,12 @@ import ModelChart from 'components/Charts/ModelChart';
 
 import { EmbedChartContainer } from './Embed.style';
 
-export default function ChartsTab({
-  state,
-  isCounty,
-  interventions,
-  currentIntervention,
-}) {
+export default function ChartsTab({ interventions, currentIntervention }) {
   return (
     <EmbedChartContainer>
       <ModelChart
         condensed
         height={290}
-        isCounty={isCounty}
         subtitle="Hospitalizations over time"
         interventions={interventions}
         currentIntervention={currentIntervention}

--- a/src/screens/Embed/Embed.js
+++ b/src/screens/Embed/Embed.js
@@ -132,8 +132,7 @@ export default function Embed() {
           />
         ) : (
           <ChartsTab
-            state={STATES[location]}
-            county={null}
+            isCounty={selectedCounty != null}
             interventions={interventions}
             currentIntervention={intervention}
           />

--- a/src/screens/Embed/Embed.js
+++ b/src/screens/Embed/Embed.js
@@ -132,7 +132,6 @@ export default function Embed() {
           />
         ) : (
           <ChartsTab
-            isCounty={selectedCounty != null}
             interventions={interventions}
             currentIntervention={intervention}
           />

--- a/src/screens/ModelPage/ModelPage.js
+++ b/src/screens/ModelPage/ModelPage.js
@@ -135,7 +135,7 @@ function ModelPage() {
             {interventions && (
               <Panel>
                 <ModelChart
-                  countyName={countyName}
+                  isCounty={countyName != null}
                   interventions={interventions}
                   currentIntervention={intervention}
                   showDisclaimer={true}

--- a/src/screens/ModelPage/ModelPage.js
+++ b/src/screens/ModelPage/ModelPage.js
@@ -135,7 +135,6 @@ function ModelPage() {
             {interventions && (
               <Panel>
                 <ModelChart
-                  isCounty={countyName != null}
                   interventions={interventions}
                   currentIntervention={intervention}
                   showDisclaimer={true}


### PR DESCRIPTION
We were overloading the countyName property of ModelChart as a signal for two things:
1. Should we show the county disclaimer?
2. Should we try to show inference projections?

The embeds were not setting countyName because they didn't want a disclaimer. But this resulted in them hitting the inference projections codepath, which doesn't work for counties.

I fixed this by:
1. Removing `countyName` since it's not necessary (we can find out if it's a county from the projections).
2. Using `interventions.isCounty && !isEmbed` to decide whether to show the county disclaimer or not.