### PR TITLE
Fix 'Last Updated' date on Safari and give us an extra day of breathing room.

### DIFF
--- a/src/components/Charts/ModelChart.js
+++ b/src/components/Charts/ModelChart.js
@@ -359,7 +359,10 @@ const ModelChart = ({
                 title="Currently we aggregate data over 4 day intervals to smooth out inconsistencies in the source data. We’re working on improving this now."
                 placement="bottom"
               >
-                <span>Last updated {lastUpdatedDate.toLocaleDateString()}</span>
+                <span>
+                  Last updated{' '}
+                  {lastUpdatedDate && lastUpdatedDate.toLocaleDateString()}
+                </span>
               </LightTooltip>
             </DisclaimerHeader>
             <DisclaimerBody>

--- a/src/utils/model.js
+++ b/src/utils/model.js
@@ -1,4 +1,5 @@
 import Promise from 'bluebird';
+import * as moment from 'moment';
 import { useState, useEffect } from 'react';
 import { Projections } from './../models';
 import { STATES } from 'enums';
@@ -200,7 +201,12 @@ export function useModelLastUpdatedDate() {
   useEffect(() => {
     fetch(versionUrl)
       .then(data => data.json())
-      .then(version => setLastUpdated(new Date(version.timestamp)));
+      .then(version => {
+        // We add 1 day since models are generally published the day after
+        // they're generated (due to QA process).
+        const date = moment(version.timestamp).add(1, 'day');
+        setLastUpdated(date.toDate());
+      });
   }, [versionUrl]);
 
   return lastUpdated;


### PR DESCRIPTION
`new Date()` on safari doesn't like the timezone offset as `+0000` so just use moment for parsing.