### PR TITLE
Limit concurrency of calculated-interventions script to prevent file descriptor issues.

### DIFF
--- a/scripts/calculated_interventions.js
+++ b/scripts/calculated_interventions.js
@@ -1,17 +1,23 @@
 #!/usr/bin/env node -r esm
+import Promise from 'bluebird';
 import _ from 'lodash';
 import fs from 'fs-extra';
 import path from 'path';
 import US_STATES from './../src/enums/us_states';
 import { fetchStateSummary, fetchProjections } from '../src/utils/model';
 
+// Limit concurrency (to ~200) to avoid file descriptor limits.
+const CONCURRENT_STATES = 4;
+const CONCURRENT_COUNTIES = 50;
+
 async function getStateAndCountyDataFiles(stateAbbr) {
   const stateSummaryData = await fetchStateSummary(stateAbbr);
   const stateProjections = await fetchProjections(stateAbbr);
   let inferenceCounties = 0;
   let countyFipsData = {};
-  await Promise.all(
-    stateSummaryData.counties_with_data.map(async fipsCode => {
+  await Promise.map(
+    stateSummaryData.counties_with_data,
+    async fipsCode => {
       try {
         const countyProjections = await fetchProjections(stateAbbr, {
           full_fips_code: fipsCode,
@@ -21,7 +27,8 @@ async function getStateAndCountyDataFiles(stateAbbr) {
       } catch (ex) {
         console.log(`No color found for: ${stateAbbr} / ${fipsCode}`);
       }
-    }),
+    },
+    { concurrency: CONCURRENT_COUNTIES },
   );
 
   return {
@@ -37,16 +44,20 @@ async function getStateAndCountyDataFiles(stateAbbr) {
   const countyInventionMap = {};
 
   const stateCodes = _.keys(US_STATES);
-  await Promise.all(
-    stateCodes.map(async stateCode => {
+  let totalInferenceCounties = 0;
+  await Promise.map(
+    stateCodes,
+    async stateCode => {
       console.log(`Starting ${stateCode}`);
       const data = await getStateAndCountyDataFiles(stateCode);
       stateInterventionMap[stateCode] = data.stateInterventionColor;
       Object.assign(countyInventionMap, data.countyFipsData);
+      totalInferenceCounties += data.inferenceCounties;
       console.log(
         `Finishing ${stateCode}, ${data.inferenceCounties} counties had inference data`,
       );
-    }),
+    },
+    { concurrency: CONCURRENT_STATES },
   );
 
   const outputFolder = path.join(__dirname, '..', 'src', 'assets', 'data');
@@ -59,6 +70,6 @@ async function getStateAndCountyDataFiles(stateAbbr) {
     `${outputFolder}/calculated_county_interventions.json`,
     countyInventionMap,
   );
-  console.log('done');
+  console.log(`done. ${totalInferenceCounties} counties had inference data`);
   process.exit(0);
 })();


### PR DESCRIPTION
Forgot to send this out earlier.

I don't love using bluebird, but it's easy.