### PR TITLE
Use API v1 to load state / county timeseries projections.

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -28,31 +28,31 @@ const ApiInterventions: { [intervention: string]: string } = {
 type InterventionKey = keyof typeof INTERVENTIONS;
 
 /** Represents summary+timeseries for any kind of region. */
-export type RegionSummaryTimeseries =
+export type RegionSummaryWithTimeseries =
   | CovidActNowCountyTimeseries
   | CovidActNowStateTimeseries;
 
 /** A mapping of interventions to the corresponding region summary+timeseries data. */
-export type RegionSummaryTimeseriesMap = {
+export type RegionSummaryWithTimeseriesMap = {
   /**
    * We use null to represent data we tried to fetch from the API but which was
    * missing (e.g. the region doesn't exist or doesn't have data for a
    * particular intervention. E.g. not all counties have inference data.)
    */
-  [intervention: string]: RegionSummaryTimeseries | null;
+  [intervention: string]: RegionSummaryWithTimeseries | null;
 };
 
 /**
  * Fetches the summary+timeseries for a region for each available intervention
  * and returns them as a map.
  */
-export async function fetchSummaryTimeseriesMap(
+export async function fetchSummaryWithTimeseriesMap(
   region: RegionDescriptor,
-): Promise<RegionSummaryTimeseriesMap> {
-  const result = {} as RegionSummaryTimeseriesMap;
+): Promise<RegionSummaryWithTimeseriesMap> {
+  const result = {} as RegionSummaryWithTimeseriesMap;
   await Promise.all(
     Object.keys(ApiInterventions).map(async intervention => {
-      result[intervention] = await fetchSummaryTimeseries(
+      result[intervention] = await fetchSummaryWithTimeseries(
         region,
         intervention as InterventionKey,
       );
@@ -62,10 +62,10 @@ export async function fetchSummaryTimeseriesMap(
 }
 
 /** Fetches the summary+timeseries for a region and a single intervention. */
-export async function fetchSummaryTimeseries(
+export async function fetchSummaryWithTimeseries(
   region: RegionDescriptor,
   intervention: InterventionKey,
-): Promise<RegionSummaryTimeseries | null> {
+): Promise<RegionSummaryWithTimeseries | null> {
   const apiIntervention = ApiInterventions[intervention];
   if (region.isState()) {
     return await fetchApiJson<CovidActNowStateTimeseries>(

--- a/src/models/Projection.ts
+++ b/src/models/Projection.ts
@@ -1,4 +1,4 @@
-import { RegionSummaryTimeseries } from 'api';
+import { RegionSummaryWithTimeseries } from 'api';
 
 const MS_PER_DAY = 1000 * 60 * 60 * 24;
 
@@ -22,7 +22,6 @@ export class Projection {
   durationDays: number | null;
   delayDays: number;
   rt: number | null;
-  rtStdev: number | undefined;
   dates: Date[];
   dayZero: Date;
   daysSinceDayZero: number;
@@ -35,18 +34,17 @@ export class Projection {
   dateOverwhelmed: Date | null;
 
   constructor(
-    summaryTimeseries: RegionSummaryTimeseries,
+    summaryWithTimeseries: RegionSummaryWithTimeseries,
     parameters: ProjectionParameters,
   ) {
-    const timeseries = summaryTimeseries.timeseries;
+    const timeseries = summaryWithTimeseries.timeseries;
     this.intervention = parameters.intervention;
     this.isInferred = parameters.isInferred;
     this.durationDays = parameters.durationDays || null /* permanent */;
     this.delayDays = parameters.delayDays || 0;
     this.rt = null;
     if (this.isInferred) {
-      this.rt = summaryTimeseries.projections.Rt;
-      this.rtStdev = summaryTimeseries.projections.RtCI90;
+      this.rt = summaryWithTimeseries.projections.Rt;
     }
 
     this.dates = timeseries.map(row => new Date(row.date));
@@ -58,7 +56,7 @@ export class Projection {
     this.hospitalizations = timeseries.map(row => row.hospitalBedsRequired);
     this.beds = timeseries.map(row => row.hospitalBedCapacity);
     this.cumulativeDeaths = timeseries.map(row => row.cumulativeDeaths);
-    this.totalPopulation = summaryTimeseries.actuals.population;
+    this.totalPopulation = summaryWithTimeseries.actuals.population;
     this.cumulativeInfected = timeseries.map(row => row.cumulativeInfected);
 
     this.cumulativeDead = this.cumulativeDeaths[
@@ -66,7 +64,7 @@ export class Projection {
     ];
 
     const shortageStart =
-      summaryTimeseries.projections.totalHospitalBeds.shortageStartDate;
+      summaryWithTimeseries.projections.totalHospitalBeds.shortageStartDate;
     this.dateOverwhelmed =
       shortageStart === null ? null : new Date(shortageStart);
   }

--- a/src/models/Projections.ts
+++ b/src/models/Projections.ts
@@ -6,6 +6,7 @@ import {
   COLOR_MAP,
 } from '../enums/interventions';
 import { STATES } from '../enums';
+import { RegionSummaryTimeseriesMap } from 'api';
 
 /**
  * The model for the complete set of projections and related information
@@ -27,7 +28,11 @@ export class Projections {
   interventionModelMap: any;
   worstCaseInterventionModel: any;
 
-  constructor(projectionInfos: any, stateCode: string, county: any) {
+  constructor(
+    summaryTimeseriesMap: RegionSummaryTimeseriesMap,
+    stateCode: string,
+    county: any,
+  ) {
     this.stateCode = stateCode.toUpperCase();
     this.stateName = (STATES as any)[this.stateCode];
     this.county = null;
@@ -40,7 +45,7 @@ export class Projections {
     this.supportsInferred = false;
     this.isCounty = county != null;
 
-    this.populateInterventions(projectionInfos);
+    this.populateInterventions(summaryTimeseriesMap);
     this.populateCurrentIntervention();
     this.populateCounty(county);
   }
@@ -191,7 +196,7 @@ export class Projections {
     return moment(model.dateOverwhelmed).isSameOrAfter(futureDate);
   }
 
-  populateInterventions(projectionInfos: any) {
+  populateInterventions(summaryTimeseriesMap: RegionSummaryTimeseriesMap) {
     const fipsBlacklist = [
       '13275',
       '18019',
@@ -208,19 +213,20 @@ export class Projections {
       '47065',
       '50007',
     ];
-    projectionInfos.forEach((pi: any) => {
+    for (const intervention in summaryTimeseriesMap) {
+      const summaryTimeseries = summaryTimeseriesMap[intervention];
       let projection = null;
-      if (pi.data) {
-        projection = new Projection(pi.data, {
-          intervention: pi.intervention,
-          isInferred: pi.intervention === INTERVENTIONS.PROJECTED,
+      if (summaryTimeseries !== null) {
+        projection = new Projection(summaryTimeseries, {
+          intervention: intervention,
+          isInferred: intervention === INTERVENTIONS.PROJECTED,
         });
       }
-      if (pi.intervention === INTERVENTIONS.LIMITED_ACTION) {
+      if (intervention === INTERVENTIONS.LIMITED_ACTION) {
         this.baseline = projection;
-      } else if (pi.intervention === INTERVENTIONS.SHELTER_IN_PLACE) {
+      } else if (intervention === INTERVENTIONS.SHELTER_IN_PLACE) {
         this.distancing = { now: projection };
-      } else if (pi.intervention === INTERVENTIONS.PROJECTED) {
+      } else if (intervention === INTERVENTIONS.PROJECTED) {
         if (
           !this.county ||
           fipsBlacklist.indexOf(this.county.full_fips_code) === -1
@@ -230,10 +236,10 @@ export class Projections {
         } else {
           console.log('Blacklisted inference projection');
         }
-      } else if (pi.intervention === INTERVENTIONS.SOCIAL_DISTANCING) {
+      } else if (intervention === INTERVENTIONS.SOCIAL_DISTANCING) {
         this.distancingPoorEnforcement = { now: projection };
       }
-    });
+    }
     this.interventionModelMap = {
       [INTERVENTIONS.LIMITED_ACTION]: this.baseline,
       [INTERVENTIONS.SOCIAL_DISTANCING]: this.distancingPoorEnforcement.now,

--- a/src/models/Projections.ts
+++ b/src/models/Projections.ts
@@ -6,7 +6,7 @@ import {
   COLOR_MAP,
 } from '../enums/interventions';
 import { STATES } from '../enums';
-import { RegionSummaryTimeseriesMap } from 'api';
+import { RegionSummaryWithTimeseriesMap } from 'api';
 
 /**
  * The model for the complete set of projections and related information
@@ -29,7 +29,7 @@ export class Projections {
   worstCaseInterventionModel: any;
 
   constructor(
-    summaryTimeseriesMap: RegionSummaryTimeseriesMap,
+    summaryWithTimeseriesMap: RegionSummaryWithTimeseriesMap,
     stateCode: string,
     county: any,
   ) {
@@ -45,7 +45,7 @@ export class Projections {
     this.supportsInferred = false;
     this.isCounty = county != null;
 
-    this.populateInterventions(summaryTimeseriesMap);
+    this.populateInterventions(summaryWithTimeseriesMap);
     this.populateCurrentIntervention();
     this.populateCounty(county);
   }
@@ -196,7 +196,9 @@ export class Projections {
     return moment(model.dateOverwhelmed).isSameOrAfter(futureDate);
   }
 
-  populateInterventions(summaryTimeseriesMap: RegionSummaryTimeseriesMap) {
+  populateInterventions(
+    summaryWithTimeseriesMap: RegionSummaryWithTimeseriesMap,
+  ) {
     const fipsBlacklist = [
       '13275',
       '18019',
@@ -213,11 +215,11 @@ export class Projections {
       '47065',
       '50007',
     ];
-    for (const intervention in summaryTimeseriesMap) {
-      const summaryTimeseries = summaryTimeseriesMap[intervention];
+    for (const intervention in summaryWithTimeseriesMap) {
+      const summaryWithTimeseries = summaryWithTimeseriesMap[intervention];
       let projection = null;
-      if (summaryTimeseries !== null) {
-        projection = new Projection(summaryTimeseries, {
+      if (summaryWithTimeseries !== null) {
+        projection = new Projection(summaryWithTimeseries, {
           intervention: intervention,
           isInferred: intervention === INTERVENTIONS.PROJECTED,
         });

--- a/src/utils/model.js
+++ b/src/utils/model.js
@@ -5,7 +5,7 @@ import { STATES } from '../enums';
 import DataUrlJson from '../assets/data/data_url';
 import fetch from 'node-fetch';
 import { RegionDescriptor } from './RegionDescriptor';
-import { fetchSummaryTimeseriesMap } from 'api';
+import { fetchSummaryWithTimeseriesMap } from 'api';
 
 const DATA_URL = DataUrlJson.data_url.replace(/\/$/, '');
 
@@ -22,8 +22,8 @@ export async function fetchProjections(
   } else {
     region = RegionDescriptor.forState(stateId);
   }
-  const summaryTimeseriesMap = await fetchSummaryTimeseriesMap(region);
-  return new Projections(summaryTimeseriesMap, stateId, countyInfo);
+  const summaryWithTimeseriesMap = await fetchSummaryWithTimeseriesMap(region);
+  return new Projections(summaryWithTimeseriesMap, stateId, countyInfo);
 }
 
 export function useProjections(location, county = null) {


### PR DESCRIPTION
Column numbers are gone and accessing properties from the API schema is all type-checked. 😁 I _think_ everything is working other than county inference.