### PR TITLE
Allow 1-day-interval datasets.

### DIFF
--- a/src/components/Charts/ModelChart.js
+++ b/src/components/Charts/ModelChart.js
@@ -48,22 +48,13 @@ const ModelChart = ({
 }) => {
   // We use the inferred projection if supported, otherwise the worst case for the currently active intervention
   let projection = projections.primary;
-  const scenarioComparisonOverTime = duration => [
-    projections.baseline.getDataset('hospitalizations', duration),
-    projections.distancingPoorEnforcement.now.getDataset(
-      'hospitalizations',
-      duration,
-    ),
-    projections.primary.getDataset('hospitalizations', duration),
-    projections.distancing.now.getDataset('hospitalizations', duration),
-    projections.baseline.getDataset(
-      'beds',
-      duration,
-      'Available hospital beds',
-    ),
+  const data = [
+    projections.baseline.getDataset('hospitalizations'),
+    projections.distancingPoorEnforcement.now.getDataset('hospitalizations'),
+    projections.primary.getDataset('hospitalizations'),
+    projections.distancing.now.getDataset('hospitalizations'),
+    projections.baseline.getDataset('beds', 'Available hospital beds'),
   ];
-
-  const data = scenarioComparisonOverTime(200);
 
   // We'll use this to determine whether to right-align
   // or left-align our plot line labels


### PR DESCRIPTION
I have a [dummy draft PR](https://github.com/covid-projections/covid-projections/pull/596) that can be used to see what this actually looks like pointed at a 1-day-interval snapshot: https://covid-projecti-git-mikelehen-allow-1-day-intervals-use-1-a5a45e.covidactnow.now.sh/us/sd/county/meade_county (note the hospital overload lines up as expected now).

* We had logic to extract a 200-day duration by dividing it by 4 (to compensate for 4-day-interval), but in practice the API gives us way less than 200 days of data (it's ~4mo == 120 days), so I just removed the duration logic for now.
* Actually testing with a snapshot with 1-day-interval (e.g. snapshot 146) exposed a bug (https://github.com/covid-projections/covid-data-model/issues/315) which I have temporarily worked around (see fixZeros() function) so that it's not blocking.

Note: We may want to reintroduce some sort of duration logic, but I think for phase 3 we're mostly going to be looking at _historical_ durations instead of future-facing, so it would likely need to be reworked anyway.