### PR TITLE
Plumb Phase 3 data from API through getDataset().

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -4,8 +4,14 @@
  */
 
 import DataUrlJson from '../assets/data/data_url.json';
-import { CovidActNowStateTimeseries } from './schema/CovidActNowStatesTimeseries';
-import { CovidActNowCountyTimeseries } from './schema/CovidActNowCountiesTimeseries';
+import {
+  CovidActNowStateTimeseries,
+  Timeseries as CountyTimeseries,
+} from './schema/CovidActNowStatesTimeseries';
+import {
+  CovidActNowCountyTimeseries,
+  Timeseries as StateTimeseries,
+} from './schema/CovidActNowCountiesTimeseries';
 import { INTERVENTIONS } from 'enums';
 import { RegionDescriptor } from '../utils/RegionDescriptor';
 import { fail } from 'utils';
@@ -27,6 +33,9 @@ const ApiInterventions: { [intervention: string]: string } = {
 // INTERVENTIONS was a TypeScript enum or string union, and we should ideally
 // consolidate these different intervention types.
 type InterventionKey = keyof typeof INTERVENTIONS;
+
+/** Represents timeseries for any kind of region. */
+export type Timeseries = CountyTimeseries | StateTimeseries;
 
 /** Represents summary+timeseries for any kind of region. */
 export type RegionSummaryWithTimeseries =

--- a/src/components/LocationPage/ChartsHolder.tsx
+++ b/src/components/LocationPage/ChartsHolder.tsx
@@ -19,7 +19,7 @@ const ChartsHolder = (props: {
   const projection: Projection = props.projections.primary;
 
   if (projection && projection.isInferred) {
-    const rtData = projection.getDataset('rt');
+    const rtData = projection.getDataset('rtRange');
   }
 
   return (

--- a/src/models/Projection.ts
+++ b/src/models/Projection.ts
@@ -1,4 +1,4 @@
-import { RegionSummaryWithTimeseries } from 'api';
+import { RegionSummaryWithTimeseries, Timeseries } from 'api';
 
 /** Parameters that can be provided when constructing a Projection. */
 export interface ProjectionParameters {
@@ -14,6 +14,28 @@ export interface Column {
 export interface ProjectionDataset {
   label: string;
   data: Column[];
+}
+
+// TODO(michael): Rework the way we expose datasets (use an enum or separate
+// functions instead of magic strings).
+// These names must match exactly the field in `Projection` that stores the
+// data. See `getColumn()`.
+export type DatasetId =
+  | 'hospitalizations'
+  | 'beds'
+  | 'cumulativeDeaths'
+  | 'cumulativeInfected'
+  | 'rtRange'
+  | 'icuUsage'
+  | 'testPositiveRate';
+
+export interface RtRange {
+  /** The actual Rt value. */
+  rt: number;
+  /** The lower-bound of the confidence interval. */
+  low: number;
+  /** The upper-bound of the confidence interval. */
+  high: number;
 }
 
 /**
@@ -32,11 +54,16 @@ export class Projection {
   private readonly intervention: string;
   private readonly dates: Date[];
 
-  // NOTE: These can be used dynamically by getColumn()
+  // NOTE: These are used dynamically by getColumn()
   private readonly hospitalizations: number[];
   private readonly beds: number[];
   private readonly cumulativeDeaths: number[];
   private readonly cumulativeInfected: number[];
+  private readonly rtRange: Array<RtRange | null>;
+  // Hospital Usage series as values between 0-1 (or > 1 if over capacity).
+  private readonly icuUsage: number[];
+  // Test Positive series as values between 0-1.
+  private readonly testPositiveRate: Array<number | null>;
 
   constructor(
     summaryWithTimeseries: RegionSummaryWithTimeseries,
@@ -53,10 +80,14 @@ export class Projection {
 
     this.dates = timeseries.map(row => new Date(row.date));
 
+    // Set up our series data exposed via getDataset().
     this.hospitalizations = timeseries.map(row => row.hospitalBedsRequired);
     this.beds = timeseries.map(row => row.hospitalBedCapacity);
     this.cumulativeDeaths = timeseries.map(row => row.cumulativeDeaths);
     this.cumulativeInfected = timeseries.map(row => row.cumulativeInfected);
+    this.rtRange = this.calcRtRange(timeseries);
+    this.testPositiveRate = this.calcTestPositiveRate(timeseries);
+    this.icuUsage = this.calcIcuUsage(timeseries);
 
     this.fixZeros(this.hospitalizations);
     this.fixZeros(this.cumulativeDeaths);
@@ -92,22 +123,77 @@ export class Projection {
     }));
   }
 
-  getDataset(columnName: string, customLabel?: string): ProjectionDataset {
+  getDataset(dataset: DatasetId, customLabel?: string): ProjectionDataset {
     return {
       label: customLabel ? customLabel : this.label,
-      data: this.getColumn(columnName),
+      data: this.getColumn(dataset),
     };
+  }
+
+  private calcRtRange(timeseries: Timeseries): Array<RtRange | null> {
+    return timeseries.map(row => {
+      // TODO(michael): Why are the types wrong? I think
+      // json-schema-to-typescript may be broken. :-(
+      const rt = (row.Rt as any) as number;
+      const ci = (row.RtCI90 as any) as number;
+      if (rt) {
+        return {
+          rt: round(rt, 2),
+          low: round(rt - ci, 2),
+          high: round(rt + ci, 2),
+        };
+      } else {
+        return null;
+      }
+    });
+  }
+
+  private calcTestPositiveRate(timeseries: Timeseries): Array<number | null> {
+    const dailyPositives = this.deltasFromCumulatives(
+      timeseries.map(row => row.cumulativePositiveTests),
+    );
+    const dailyNegatives = this.deltasFromCumulatives(
+      timeseries.map(row => row.cumulativeNegativeTests),
+    );
+
+    return dailyPositives.map((positive, idx) => {
+      const negative = dailyNegatives[idx];
+      const total = positive + negative;
+      return total > 0 ? round(positive / total, 3) : null;
+    });
+  }
+
+  // Given a series of cumulative values, convert to a series of deltas.
+  // Treats null values as 0s.
+  private deltasFromCumulatives(cumulatives: Array<number | null>) {
+    let previous = 0;
+    return cumulatives.map(value => {
+      const delta = (value || 0) - previous;
+      previous = value || 0;
+      return delta;
+    });
+  }
+
+  private calcIcuUsage(timeseries: Timeseries): number[] {
+    return timeseries.map(row => {
+      return round(row.ICUBedsInUse / row.ICUBedCapacity, 3);
+    });
   }
 
   // TODO: Due to
   // https://github.com/covid-projections/covid-data-model/issues/315 there may
   // be an erroneous "zero" data point ~today. We detect these and just average
   // the adjacent numbers.
-  fixZeros(data: number[]) {
+  private fixZeros(data: number[]) {
     for (let i = 1; i < data.length - 1; i++) {
       if (data[i] === 0 && data[i - 1] !== 0 && data[i + 1] !== 0) {
         data[i] = (data[i - 1] + data[i + 1]) / 2;
       }
     }
   }
+}
+
+// Round a number to have only decimalDigits digits after the decimal.
+function round(x: number, decimalDigits: number): number {
+  return parseFloat(x.toFixed(decimalDigits));
 }


### PR DESCRIPTION
I've created PR #600 to demonstrate this in action by combining with @pnavarrc's chart work and doing a quick/dirty integration into the model page. Demo here: https://covid-projections-git-mikelehen-test-charts-and-api.covidactnow.now.sh/