### PR TITLE
Phase 3 Charts: Ensure high region is at least as large as the medium region.

### DIFF
--- a/src/components/Charts/zoneUtils.js
+++ b/src/components/Charts/zoneUtils.js
@@ -38,7 +38,16 @@ const ZONES_HOSPITAL_USAGE = getHighchartZones(HOSPITAL_USAGE);
 
 export const optionsRt = (data, endDate) => {
   const { x, y } = last(data);
-  const [minYAxis, maxYAxis] = roundAxisLimits(0, getMaxY(data));
+  // Ensure high-region is at least as large as medium region.
+  const mediumRegionHeight =
+    CASE_GROWTH_RATE.MEDIUM.upperLimit - CASE_GROWTH_RATE.LOW.upperLimit;
+  const minHighRegionLimit =
+    CASE_GROWTH_RATE.MEDIUM.upperLimit + mediumRegionHeight;
+  const [minYAxis, maxYAxis] = roundAxisLimits(
+    0,
+    Math.max(getMaxY(data), minHighRegionLimit),
+  );
+
   return {
     ...baseOptions,
     xAxis: {


### PR DESCRIPTION
Fixes part 1 (Charts don't always have all 3 sections) of https://github.com/covid-projections/covid-projections/issues/609.

If you'd rather not merge this since you'll probably be mucking with this code later today, that's 100% fine. But it seems to work, so sending it your way for consideration.