### PR TITLE
Fixes missing current values for zone charts

### DIFF
--- a/src/components/Charts/utils.ts
+++ b/src/components/Charts/utils.ts
@@ -2,7 +2,13 @@ import _ from 'lodash';
 import Highcharts, { dateFormat } from 'highcharts';
 import palette from '../../assets/theme/palette';
 
-export const last = (list: any[]) => list[list.length - 1];
+const isValidPoint = (d: Highcharts.Point): boolean =>
+  _.isFinite(d.x) && _.isFinite(d.y);
+
+const last = (list: any[]) => list[list.length - 1];
+
+export const lastValidPoint = (data: Highcharts.Point[]) =>
+  last(data.filter(isValidPoint));
 
 export const formatDecimal = (num: number, places = 2): string =>
   num.toFixed(places);

--- a/src/components/Charts/zoneUtils.js
+++ b/src/components/Charts/zoneUtils.js
@@ -1,11 +1,11 @@
 import {
   baseOptions,
+  currentValueAnnotation,
   formatDecimal,
   formatPercent,
   getMaxY,
   getTickPositions,
-  last,
-  currentValueAnnotation,
+  lastValidPoint,
   parseDate,
   roundAxisLimits,
   titleCase,
@@ -37,7 +37,7 @@ const ZONES_POSITIVE_RATE = getHighchartZones(POSITIVE_TESTS);
 const ZONES_HOSPITAL_USAGE = getHighchartZones(HOSPITAL_USAGE);
 
 export const optionsRt = (data, endDate) => {
-  const { x, y } = last(data);
+  const { x, y } = lastValidPoint(data);
   // Ensure high-region is at least as large as medium region.
   const mediumRegionHeight =
     CASE_GROWTH_RATE.MEDIUM.upperLimit - CASE_GROWTH_RATE.LOW.upperLimit;
@@ -87,7 +87,7 @@ export const optionsRt = (data, endDate) => {
 };
 
 export const optionsPositiveTests = (data, endDate) => {
-  const { x, y } = last(data);
+  const { x, y } = lastValidPoint(data);
   const [minYAxis, maxYAxis] = roundAxisLimits(0, getMaxY(data));
   return {
     ...baseOptions,
@@ -124,7 +124,7 @@ export const optionsPositiveTests = (data, endDate) => {
 };
 
 export const optionsHospitalUsage = (data, endDate) => {
-  const { x, y } = last(data);
+  const { x, y } = lastValidPoint(data);
   const [minYAxis, maxYAxis] = roundAxisLimits(0, getMaxY(data));
   return {
     ...baseOptions,


### PR DESCRIPTION
Fixes an issue that was causing the current value for zone charts to be hidden.

The value for the current point annotation was taken as the last item of the passed `data` array. Since the future values have data, but it's undefined, the values for `x` and `y` were `undefined` too. This PR gets the last value such that both `x` and `y` are finite numbers.

Before
![image](https://user-images.githubusercontent.com/114084/80441362-ac5b0a00-88bf-11ea-90c6-7cace0f4bad7.png)

After
![image](https://user-images.githubusercontent.com/114084/80441145-250d9680-88bf-11ea-9500-981e90d8314a.png)
(I took a screenshot scaling down, it might look a bit funky, but the values are shown now).

