### PR TITLE
Update the Future Projections Chart

### DIFF
--- a/src/components/Charts/ModelChart.style.js
+++ b/src/components/Charts/ModelChart.style.js
@@ -1,5 +1,4 @@
 import styled from 'styled-components';
-
 import { COLORS } from 'enums';
 import { INTERVENTIONS } from 'enums/interventions';
 import palette from 'assets/theme/palette';
@@ -64,16 +63,14 @@ export const Wrapper = styled.div`
     }
   }
 
-  /* Don't show a label for 0
-     because it overlaps with the x-axis */
-  .highcharts-yaxis-labels span:first-child {
+  /* Hide the ticks and grid lines for the y-axis*/
+  .highcharts-yaxis-labels {
     display: none;
   }
 
-  /* .highcharts-tooltip-box {
-    fill: black;
-    fill-opacity: 0.6;
-  } */
+  .highcharts-grid-line {
+    display: none;
+  }
   g.highcharts-tooltip {
     display: none;
   }
@@ -84,6 +81,7 @@ export const Wrapper = styled.div`
   }
   .highcharts-markers {
     stroke: white !important;
+    stroke-dasharray: none !important; /* I'm really, really sorry */
   }
   .highcharts-halo {
     fill: white !important;
@@ -92,7 +90,7 @@ export const Wrapper = styled.div`
   }
   .highcharts-tooltip > span {
     background: rgba(0, 0, 0, 0.7);
-    color: #ffffff;
+    color: ${palette.white};
     border-radius: 4px;
     box-shadow: 0px 1px 2px rgba(0, 0, 0, 0.2);
     padding: 16px;
@@ -120,14 +118,81 @@ export const Wrapper = styled.div`
 
   /* No action */
   .limited-action {
-    fill: ${props =>
-      props.projections.getChartSeriesColorMap().limitedActionSeries};
-    stroke: ${props =>
-      props.isInferred
-        ? props.projections.getChartSeriesColorMap().limitedActionSeries
-        : 'white'};
-    fill-opacity: 1;
+    .highcharts-graph {
+      stroke: ${COLORS.LIMITED_ACTION};
+      stroke-dasharray: 1, 6;
+      stroke-width: 4px;
+      fill-opacity: 1;
+      stroke-linecap: square;
+    }
+
+    &.highcharts-markers {
+      path {
+        fill: ${COLORS.LIMITED_ACTION};
+      }
+    }
   }
+  /* Projected */
+  .projected {
+    .highcharts-graph {
+      stroke: ${COLORS.PROJECTED};
+      stroke-dasharray: 1, 6;
+      stroke-width: 4px;
+      stroke-linecap: square;
+    }
+
+    &.highcharts-markers {
+      path {
+        fill: ${COLORS.PROJECTED};
+      }
+    }
+  }
+  /* Hospitalizations */
+  .hospitalizations {
+    .highcharts-graph {
+      stroke: ${COLORS.HOSPITALIZATIONS};
+      stroke-width: 4px;
+      stroke-linecap: round;
+    }
+
+    &.highcharts-markers {
+      path {
+        fill: ${COLORS.HOSPITALIZATIONS};
+      }
+    }
+  }
+
+  /* Stay at home */
+  .stay-at-home {
+    .highcharts-graph {
+      stroke: ${props =>
+        props.projections.getChartSeriesColorMap().shelterInPlaceSeries};
+      stroke-dasharray: 1, 6;
+      stroke-width: 4px;
+      stroke-linecap: square;
+    }
+
+    &.highcharts-markers {
+      path {
+        fill: ${props =>
+          props.projections.getChartSeriesColorMap().shelterInPlaceSeries};
+      }
+    }
+  }
+
+  .Annotation {
+    &.Annotation--BedsAvailable {
+      text {
+        fill: ${palette.primary.contrastText};
+        font-size: 18px;
+      }
+      rect {
+        fill-opacity: 0;
+        stroke: none;
+      }
+    }
+  }
+
   /* Social distancing */
   .social-distancing {
     fill: ${props =>
@@ -138,16 +203,7 @@ export const Wrapper = styled.div`
         : 'white'};
     fill-opacity: 1;
   }
-  /* Stay at home */
-  .stay-at-home {
-    fill: ${props =>
-      props.projections.getChartSeriesColorMap().shelterInPlaceSeries};
-    stroke: ${props =>
-      props.isInferred
-        ? props.projections.getChartSeriesColorMap().shelterInPlaceSeries
-        : 'white'};
-    fill-opacity: 1;
-  }
+
   /* Available beds */
   .beds {
     stroke: white;
@@ -158,15 +214,7 @@ export const Wrapper = styled.div`
     fill: rgba(0, 0, 0, 0.7);
     stroke: rgba(0, 0, 0, 0.7);
   }
-  .highcharts-plot-line {
-    stroke: #ff3348;
-    stroke-width: 3px;
-  }
-  /* Projected */
-  .projected {
-    stroke: ${props =>
-      props.projections.getChartSeriesColorMap().projectedSeries};
-  }
+
   .${snakeCase(INTERVENTIONS.LIMITED_ACTION)} {
     stroke: ${props => props.projections.getAlarmLevelColor()};
   }

--- a/src/enums/colors.js
+++ b/src/enums/colors.js
@@ -1,3 +1,7 @@
 export default {
   LIGHTGRAY: '#f2f2f2',
+  // Future projections
+  HOSPITALIZATIONS: 'black',
+  PROJECTED: '#3bbce6',
+  LIMITED_ACTION: '#fc374d',
 };

--- a/src/enums/team.js
+++ b/src/enums/team.js
@@ -200,6 +200,11 @@ export default {
       link: 'https://www.linkedin.com/in/mishachellam/',
     },
     {
+      name: 'Pablo Navarro Castillo',
+      title: 'Software Engineer at Alloy.ai',
+      link: 'https://www.linkedin.com/in/pnavarrc/',
+    },
+    {
       name: 'Rachel RoseFigura',
       title: 'Software Engineer at Uber',
       link: 'https://www.linkedin.com/in/rachelrosefigura/',


### PR DESCRIPTION
Update the Future Projections Chart

Designs in [Figma](https://www.figma.com/file/UUCr3ZpwaPV4o1KuGdSCNl/Covid?node-id=2719%3A4830)

Screenshot: with and without inferred data
![image](https://user-images.githubusercontent.com/114084/80564874-e69dd780-89a3-11ea-88b4-216bf429ff64.png)

### Notes

I'm still trying to have this annotation outside the chart, but maybe we should have a plan B for it (Josh?)

![image](https://user-images.githubusercontent.com/114084/80558351-f0691000-898e-11ea-962b-cc3d8ff5a359.png)

I'm using the `projected` series to show the "previous estimate" section, let me know if we need to update it.

### TODO
- [x] Get colors from enums/variables
- [x] Fix the color of available beds and the available beds annotation
- [ ] ~~Add back the y-axis, adding only a tick for the available number of beds (with the correct label)~~ that would take too long, we are adding the label on top of the available beds line
- [x] Arrange the legends
- [x] Remove available beds from the legends
- [x] Adjust colors to match the mocks
- [x] Add a marker at the end of the "previous estimates" line
- [x] Fix the color of the markers so they match the series