### PR TITLE
Improve positive rate smoothing (do rolling average on deltas, before dividing to get the positive rate percent).

### DIFF
--- a/src/models/Projection.ts
+++ b/src/models/Projection.ts
@@ -198,14 +198,14 @@ export class Projection {
   }
 
   private calcTestPositiveRate(): Array<number | null> {
-    const dailyPositives = this.deltasFromCumulatives(
-      this.cumulativePositiveTests,
+    const dailyPositives = this.smoothWithRollingAverage(
+      this.deltasFromCumulatives(this.cumulativePositiveTests),
     );
-    const dailyNegatives = this.deltasFromCumulatives(
-      this.cumulativeNegativeTests,
+    const dailyNegatives = this.smoothWithRollingAverage(
+      this.deltasFromCumulatives(this.cumulativeNegativeTests),
     );
 
-    const testPositiveRate = dailyPositives.map((dailyPositive, idx) => {
+    return dailyPositives.map((dailyPositive, idx) => {
       const positive = dailyPositive || 0;
       const negative = dailyNegatives[idx] || 0;
       const total = positive + negative;
@@ -214,8 +214,6 @@ export class Projection {
       // it's probably a reporting lag issue. So just return null.
       return negative > 0 ? positive / total : null;
     });
-
-    return this.smoothWithRollingAverage(testPositiveRate);
   }
 
   /**


### PR DESCRIPTION
WA had some weird reporting where they reported 37 negatives, but 0 positives.  The result after interpolating, calculating deltas, dividing, and smoothing was:

![image](https://user-images.githubusercontent.com/206364/80562964-4beeca00-899e-11ea-9f64-40736b16edd8.png)

😬 
(basically interpolation generated a large number of positives for that day, which were huge compared to the low number of negatives)

But if we instead interpolate, smooth, calculate deltas, and then divide, then it's much better:

![image](https://user-images.githubusercontent.com/206364/80563021-76d91e00-899e-11ea-87cd-19e5e82c511e.png)

