### PR TITLE
Fix the y-axis limit for zone charts

### DIFF
--- a/src/components/Charts/utils.ts
+++ b/src/components/Charts/utils.ts
@@ -70,8 +70,15 @@ export const getTickPositions = (
 
 export const getYAxisLimits = (minY: number, maxY: number, zones: Zone[]) => {
   const tickPositions = getTickPositions(minY, maxY, zones);
-  return [_.min(tickPositions), _.max(tickPositions)];
+  const minTickPosition = _.min(tickPositions) || minY;
+  const maxTickPosition = _.max(tickPositions) || maxY;
+  return roundAxisLimits(minTickPosition, maxTickPosition);
 };
+
+export const roundAxisLimits = (axisMin: number, axisMax: number) => [
+  axisMin,
+  _.ceil(1.2 * axisMax, 1),
+];
 
 export const getMaxY = (data: Highcharts.Point[]) => _.max(data.map(d => d.y));
 

--- a/src/components/Charts/utils.ts
+++ b/src/components/Charts/utils.ts
@@ -59,19 +59,21 @@ export const getTickPositions = (
   minY: number,
   maxY: number,
   zones: Zone[],
-): (number | undefined)[] =>
-  zones
+): (number | undefined)[] => {
+  const zoneTicks = zones
     .map(zone => zone.value)
-    .filter(val => !_.isUndefined(val))
-    .concat([minY, maxY])
-    .sort();
+    .filter(val => !_.isUndefined(val));
+  const maxZone = _.max(zoneTicks) || maxY;
+  const maxYAxis = maxY < maxZone ? 1.5 * maxZone : maxY;
+  return [minY, maxYAxis, ...zoneTicks].sort();
+};
+
+export const getYAxisLimits = (minY: number, maxY: number, zones: Zone[]) => {
+  const tickPositions = getTickPositions(minY, maxY, zones);
+  return [_.min(tickPositions), _.max(tickPositions)];
+};
 
 export const getMaxY = (data: Highcharts.Point[]) => _.max(data.map(d => d.y));
-
-export const roundAxisLimits = (axisMin: number, axisMax: number) => [
-  axisMin,
-  _.ceil(1.2 * axisMax, 1),
-];
 
 export const baseOptions: Highcharts.Options = {
   title: {

--- a/src/components/Charts/zoneUtils.js
+++ b/src/components/Charts/zoneUtils.js
@@ -5,9 +5,9 @@ import {
   formatPercent,
   getMaxY,
   getTickPositions,
+  getYAxisLimits,
   lastValidPoint,
   parseDate,
-  roundAxisLimits,
   titleCase,
   zoneAnnotations,
 } from './utils';
@@ -38,16 +38,9 @@ const ZONES_HOSPITAL_USAGE = getHighchartZones(HOSPITAL_USAGE);
 
 export const optionsRt = (data, endDate) => {
   const { x, y } = lastValidPoint(data);
-  // Ensure high-region is at least as large as medium region.
-  const mediumRegionHeight =
-    CASE_GROWTH_RATE.MEDIUM.upperLimit - CASE_GROWTH_RATE.LOW.upperLimit;
-  const minHighRegionLimit =
-    CASE_GROWTH_RATE.MEDIUM.upperLimit + mediumRegionHeight;
-  const [minYAxis, maxYAxis] = roundAxisLimits(
-    0,
-    Math.max(getMaxY(data), minHighRegionLimit),
-  );
-
+  const zones = ZONES_RT;
+  const [minY, maxY] = [0, getMaxY(data)];
+  const [minYAxis, maxYAxis] = getYAxisLimits(minY, maxY, zones);
   return {
     ...baseOptions,
     xAxis: {
@@ -87,19 +80,21 @@ export const optionsRt = (data, endDate) => {
 };
 
 export const optionsPositiveTests = (data, endDate) => {
+  const zones = ZONES_POSITIVE_RATE;
   const { x, y } = lastValidPoint(data);
-  const [minYAxis, maxYAxis] = roundAxisLimits(0, getMaxY(data));
+  const [minY, maxY] = [0, getMaxY(data)];
+  const [minYAxis, maxYAxis] = getYAxisLimits(minY, maxY, zones);
   return {
     ...baseOptions,
     annotations: [
       currentValueAnnotation(x, y, y && formatPercent(y)),
-      ...zoneAnnotations(endDate, minYAxis, maxYAxis, y, ZONES_POSITIVE_RATE),
+      ...zoneAnnotations(endDate, minYAxis, maxYAxis, y, zones),
     ],
     series: [
       {
         name: 'Positive Tests',
         data,
-        zones: ZONES_POSITIVE_RATE,
+        zones,
       },
     ],
     tooltip: {
@@ -118,19 +113,21 @@ export const optionsPositiveTests = (data, endDate) => {
           return formatPercent(this.value);
         },
       },
-      tickPositions: getTickPositions(minYAxis, maxYAxis, ZONES_POSITIVE_RATE),
+      tickPositions: getTickPositions(minYAxis, maxYAxis, zones),
     },
   };
 };
 
 export const optionsHospitalUsage = (data, endDate) => {
   const { x, y } = lastValidPoint(data);
-  const [minYAxis, maxYAxis] = roundAxisLimits(0, getMaxY(data));
+  const zones = ZONES_HOSPITAL_USAGE;
+  const [minY, maxY] = [0, getMaxY(data)];
+  const [minYAxis, maxYAxis] = getYAxisLimits(minY, maxY, zones);
   return {
     ...baseOptions,
     annotations: [
       currentValueAnnotation(x, y, y && formatPercent(y)),
-      ...zoneAnnotations(endDate, minYAxis, maxYAxis, y, ZONES_HOSPITAL_USAGE),
+      ...zoneAnnotations(endDate, minYAxis, maxYAxis, y, zones),
     ],
     tooltip: {
       pointFormatter: function () {
@@ -148,13 +145,13 @@ export const optionsHospitalUsage = (data, endDate) => {
           return formatPercent(this.value);
         },
       },
-      tickPositions: getTickPositions(minYAxis, maxYAxis, ZONES_HOSPITAL_USAGE),
+      tickPositions: getTickPositions(minYAxis, maxYAxis, zones),
     },
     series: [
       {
         name: 'Hospital Usage',
         data,
-        zones: ZONES_HOSPITAL_USAGE,
+        zones,
       },
     ],
   };


### PR DESCRIPTION
Fixes the upper limit for zone charts

The upper limit for the y-axis was taken only from the data. When the max y value was below the upper limit of the medium region, the mid point between the max y value and the upper limit of the medium region, making it show below the upper limit of the medium region:

**Example: Before the change**
```
maxY = 0.4
mediumUpperLimit = 0.8
yHighLabel = (maxY + mediumUpperLimit) / 2 = 0.6
```

This changes the logic to take either the max of the data, or `1.5 * mediumUpperLimit`, to ensure that the high region is visible, also aligning the high region label

```
maxY = 0.4
maxYAxis = max(maxY, 1.5 * mediumUpperLimit) = 1.6
mediumUpperLimit = 0.8
yHighLabel = (maxYAxis + mediumUpperLimit) / 2 = 1.2
``` 

**Examples**
![image](https://user-images.githubusercontent.com/114084/80642883-0d97f000-8a1c-11ea-9bcf-1d24a0138b92.png)
