### PR TITLE
Chart Updates - Style Fixes

### DIFF
--- a/src/components/Charts/ModelChart.js
+++ b/src/components/Charts/ModelChart.js
@@ -191,9 +191,7 @@ const ModelChart = ({
         },
       },
       yAxis: {
-        title: {
-          text: undefined,
-        },
+        visible: false,
       },
       tooltip: {
         formatter: function () {

--- a/src/components/Charts/ModelChart.js
+++ b/src/components/Charts/ModelChart.js
@@ -59,7 +59,7 @@ const ModelChart = ({
     condensedLegend: {
       bgColor: projections.getChartSeriesColorMap().limitedActionSeries,
     },
-    legendIndex: 1,
+    legendIndex: 2,
   };
 
   const socialDistancing = {
@@ -97,7 +97,7 @@ const ModelChart = ({
     condensedLegend: {
       bgColor: projections.getChartSeriesColorMap().projectedSeries,
     },
-    legendIndex: 2,
+    legendIndex: 3,
   };
 
   const previousEstimates = {
@@ -143,7 +143,7 @@ const ModelChart = ({
           : condensedFormatIntervention(INTERVENTIONS.SHELTER_IN_PLACE),
       bgColor: projections.getChartSeriesColorMap().shelterInPlaceSeries,
     },
-    legendIndex: 2,
+    legendIndex: 3,
   };
 
   const availableBeds = {

--- a/src/components/Charts/ModelChart.style.js
+++ b/src/components/Charts/ModelChart.style.js
@@ -7,6 +7,8 @@ import { colors } from '@material-ui/core';
 import Typography from '@material-ui/core/Typography';
 import { COLOR_MAP } from '../../enums/interventions';
 
+const chartFontFamily = "'Source Code Pro', 'Roboto', sans-serif";
+
 export const ChartContainer = styled.section`
   width: 100%;
 `;
@@ -181,6 +183,9 @@ export const Wrapper = styled.div`
   }
 
   .Annotation {
+    text {
+      font-family: ${chartFontFamily};
+    }
     &.Annotation--BedsAvailable {
       text {
         fill: ${palette.primary.contrastText};

--- a/src/components/Charts/ModelChart.style.js
+++ b/src/components/Charts/ModelChart.style.js
@@ -211,13 +211,12 @@ export const Wrapper = styled.div`
 
   /* Available beds */
   .beds {
-    stroke: white;
-    stroke-width: 1px;
-    stroke-dasharray: 8, 8;
-  }
-  .beds {
-    fill: rgba(0, 0, 0, 0.7);
-    stroke: rgba(0, 0, 0, 0.7);
+    .highcharts-graph {
+      stroke: ${palette.black};
+      stroke-opacity: 0.6;
+      stroke-width: 1px;
+      stroke-dasharray: 4, 3;
+    }
   }
 
   .${snakeCase(INTERVENTIONS.LIMITED_ACTION)} {

--- a/src/components/Charts/ZoneChart.style.js
+++ b/src/components/Charts/ZoneChart.style.js
@@ -11,9 +11,14 @@ export const ZoneChartWrapper = styled.div`
     stroke-width: 4px;
   }
 
-  .ZoneChart__AreaRange path {
-    stroke-width: 0;
-    stroke: none;
+  .ZoneChart__AreaRange {
+    .highcharts-area {
+      fill: ${palette.black};
+      fill-opacity: 0.07;
+    }
+    .highcharts-graph {
+      stroke: none;
+    }
   }
 
   .ZoneAnnotation--CurrentValue {

--- a/src/components/Charts/ZoneChart.style.js
+++ b/src/components/Charts/ZoneChart.style.js
@@ -21,6 +21,9 @@ export const ZoneChartWrapper = styled.div`
     .highcharts-graph {
       stroke: none;
     }
+    &.highcharts-series-inactive {
+      opacity: 1;
+    }
   }
 
   .ZoneAnnotation--CurrentValue {

--- a/src/components/Charts/ZoneChart.style.js
+++ b/src/components/Charts/ZoneChart.style.js
@@ -11,7 +11,7 @@ export const ZoneChartWrapper = styled.div`
 
   .highcharts-yaxis-grid .highcharts-grid-line {
     stroke: ${palette.black};
-    stroke-opacity: 0.7;
+    stroke-opacity: 0.6;
     stroke-width: 1px;
     stroke-dasharray: 4, 3;
   }

--- a/src/components/Charts/ZoneChart.style.js
+++ b/src/components/Charts/ZoneChart.style.js
@@ -2,6 +2,8 @@ import styled from 'styled-components';
 import palette from '../../assets/theme/palette';
 import { COLOR_ZONE } from '../../enums/zones';
 
+const chartFontFamily = "'Source Code Pro', 'Roboto', sans-serif";
+
 export const ZoneChartWrapper = styled.div`
   @media (min-width: 996px) {
     margin-left: -3rem;
@@ -31,10 +33,15 @@ export const ZoneChartWrapper = styled.div`
     }
   }
 
-  .ZoneAnnotation rect {
-    fill: ${palette.white};
-    stroke: ${palette.black};
-    stroke-opacity: 0.12;
+  .ZoneAnnotation {
+    rect {
+      fill: ${palette.white};
+      stroke: ${palette.black};
+      stroke-opacity: 0.12;
+    }
+    text {
+      font-family: ${chartFontFamily};
+    }
   }
 
   .ZoneAnnotation--isActive {

--- a/src/components/Charts/ZoneChart.style.js
+++ b/src/components/Charts/ZoneChart.style.js
@@ -9,6 +9,12 @@ export const ZoneChartWrapper = styled.div`
     margin-left: -3rem;
   }
 
+  .highcharts-yaxis-grid .highcharts-grid-line {
+    stroke: ${palette.black};
+    stroke-opacity: 0.7;
+    stroke-width: 1px;
+    stroke-dasharray: 4, 3;
+  }
   .ZoneChart__Line {
     stroke-width: 4px;
   }
@@ -41,6 +47,7 @@ export const ZoneChartWrapper = styled.div`
       fill: ${palette.white};
       stroke: ${palette.black};
       stroke-opacity: 0.12;
+      fill-opacity: 1;
     }
     text {
       font-family: ${chartFontFamily};

--- a/src/components/Charts/utils.ts
+++ b/src/components/Charts/utils.ts
@@ -13,8 +13,8 @@ export const lastValidPoint = (data: Highcharts.Point[]) =>
 export const formatDecimal = (num: number, places = 2): string =>
   num.toFixed(places);
 
-export const formatPercent = (num: number): string =>
-  `${formatDecimal(100 * num, 1)}%`;
+export const formatPercent = (num: number, places = 0): string =>
+  `${formatDecimal(100 * num, places)}%`;
 
 /** Adds comma's for thousands, millions, etc. */
 export const formatInteger = (num: number): string => num.toLocaleString();

--- a/src/components/Charts/utils.ts
+++ b/src/components/Charts/utils.ts
@@ -124,7 +124,6 @@ export const baseOptions: Highcharts.Options = {
           : this.axis.defaultLabelFormatter.call(this);
       },
     },
-    gridLineDashStyle: 'Dash',
   },
 };
 

--- a/src/components/Charts/zoneUtils.js
+++ b/src/components/Charts/zoneUtils.js
@@ -49,13 +49,12 @@ export const optionsRt = (data, endDate) => {
     },
     yAxis: {
       ...baseOptions.yAxis,
-      tickPositions: getTickPositions(minYAxis, maxYAxis, ZONES_RT),
+      tickPositions: getTickPositions(minYAxis, maxYAxis, zones),
     },
     series: [
       {
         className: 'ZoneChart__AreaRange',
         type: 'arearange',
-        fillColor: '#efefef',
         zIndex: 0,
         enableMouseTracking: false,
         data: data.map(d => [d.x, d.low, d.hi]),
@@ -63,7 +62,7 @@ export const optionsRt = (data, endDate) => {
       {
         name: 'Rt',
         type: 'spline',
-        zones: ZONES_RT,
+        zones,
         data,
       },
     ],


### PR DESCRIPTION
Updates the styles of some elements in the charts. Following the items from [UX Fit and Finish](https://www.dropbox.com/scl/fi/oih4o7ikqfhje2yw62yvn/UX-fit-and-finish.paper?dl=0&rlkey=f6d8ezrv210e92kgd0mc6hq9u)

- https://covid-projections-43g45t00c.now.sh/
- https://covid-projections-43g45t00c.now.sh/all

## Changes
- [x] Align the left edge of the SEIR chart to the left edge of the chart’s title, subtitle
- [x]  Set y-lines (bed capacity and all other thresholds) to border: `1px dashed rgba(0, 0, 0, 0.7);`
- [x] Set font type for chart text to “Source Code Pro” (preferred) or “Roboto” (backup)
- [x] Remove “.0” from y-axis labels 
- [x] Reorder legend items so that black line is first
- [x] [Zone Chart] Change the color of the confidence interval for Rt
- [x] [Zone Chart] Prevent the confidence interval from hiding when hovering the Rt line

## Note
- I'm working on a demo for a broken y-axis for when the values of the series make the LOW area to be too small (squeezing the LOW annotation). We don't know if that solution will work, so I'm doing that on a separate PR so we can discard it if it doesn't work.

cc @igorkofman @mikelehen 