### PR TITLE
changes the font of the axis to match other text

### DIFF
--- a/src/components/Charts/ModelChart.style.js
+++ b/src/components/Charts/ModelChart.style.js
@@ -70,6 +70,12 @@ export const Wrapper = styled.div`
     display: none;
   }
 
+  .highcharts-axis-labels.highcharts-xaxis-labels {
+    span {
+      font-family: ${chartFontFamily} !important;
+    }
+  }
+
   .highcharts-grid-line {
     display: none;
   }
@@ -97,10 +103,7 @@ export const Wrapper = styled.div`
     box-shadow: 0px 1px 2px rgba(0, 0, 0, 0.2);
     padding: 16px;
   }
-  /* .highcharts-tooltip text {
-    fill: white;
-    text-shadow: 0 0 3px black;
-  } */
+
   .highcharts-legend {
     font-family: 'Roboto', sans-serif;
     font-style: normal;

--- a/src/components/Charts/ModelChart.style.js
+++ b/src/components/Charts/ModelChart.style.js
@@ -71,6 +71,9 @@ export const Wrapper = styled.div`
   }
 
   .highcharts-axis-labels.highcharts-xaxis-labels {
+    text {
+      font-family: ${chartFontFamily} !important;
+    }
     span {
       font-family: ${chartFontFamily} !important;
     }

--- a/src/components/Charts/ZoneChart.style.js
+++ b/src/components/Charts/ZoneChart.style.js
@@ -9,6 +9,18 @@ export const ZoneChartWrapper = styled.div`
     margin-left: -3rem;
   }
 
+  .highcharts-axis-labels.highcharts-yaxis-labels {
+    span {
+      font-family: ${chartFontFamily} !important;
+    }
+  }
+
+  .highcharts-axis-labels.highcharts-xaxis-labels {
+    span {
+      font-family: ${chartFontFamily} !important;
+    }
+  }
+
   .highcharts-yaxis-grid .highcharts-grid-line {
     stroke: ${palette.black};
     stroke-opacity: 0.6;
@@ -37,7 +49,8 @@ export const ZoneChartWrapper = styled.div`
       fill: ${palette.primary.contrastText};
     }
     &.ZoneAnnotation rect {
-      fill-opacity: 0;
+      fill-opacity: 1;
+      fill: ${palette.white};
       stroke: none;
     }
   }

--- a/src/components/Charts/ZoneChart.style.js
+++ b/src/components/Charts/ZoneChart.style.js
@@ -10,12 +10,18 @@ export const ZoneChartWrapper = styled.div`
   }
 
   .highcharts-axis-labels.highcharts-yaxis-labels {
+    text {
+      font-family: ${chartFontFamily} !important;
+    }
     span {
       font-family: ${chartFontFamily} !important;
     }
   }
 
   .highcharts-axis-labels.highcharts-xaxis-labels {
+    text {
+      font-family: ${chartFontFamily} !important;
+    }
     span {
       font-family: ${chartFontFamily} !important;
     }


### PR DESCRIPTION
## Changes
- makes the font-family of the axes consistent with the rest of the text on the charts
- Adds a background for the current value annotation, so if it overlaps with the grid lines it doesn't look as bad

## Notes
- Highcharts renders axes as `<span>` (HTML) or `<text>` (SVG) elements, so I had to style both. It appears that chooses which one randomly 🤷‍♂️ 