### PR TITLE
set the y-axis limit for positive test rate to 50%

### DIFF
--- a/src/components/Charts/utils.ts
+++ b/src/components/Charts/utils.ts
@@ -53,6 +53,7 @@ export const currentValueAnnotation = (
       className: 'ZoneAnnotation ZoneAnnotation--CurrentValue',
     },
   ],
+  zIndex: -1,
 });
 
 export const getTickPositions = (
@@ -77,7 +78,7 @@ export const getYAxisLimits = (minY: number, maxY: number, zones: Zone[]) => {
 
 export const roundAxisLimits = (axisMin: number, axisMax: number) => [
   axisMin,
-  _.ceil(1.2 * axisMax, 1),
+  _.ceil(axisMax, 2),
 ];
 
 export const getMaxY = (data: Highcharts.Point[]) => _.max(data.map(d => d.y));
@@ -173,6 +174,7 @@ const getZoneLabels = (
       },
       text: zone.name,
       className: `${zone.labelClassName} ${activeClassName}`,
+      allowOverlap: false,
     };
   });
 

--- a/src/components/Charts/zoneUtils.js
+++ b/src/components/Charts/zoneUtils.js
@@ -83,8 +83,12 @@ export const optionsPositiveTests = (data, endDate) => {
   const { x, y } = lastValidPoint(data);
   const [minY, maxY] = [0, getMaxY(data)];
   const [minYAxis, maxYAxis] = getYAxisLimits(minY, maxY, zones);
-  // sets the limit on the y-axis to be no more than 50%
-  const adjustedMaxYAxis = Math.min(maxYAxis, 0.5);
+
+  // sets the limit on the y-axis to be no more than 40%
+  const CAP = 0.4;
+  const adjustedMaxYAxis = Math.min(maxYAxis, CAP);
+  data = data.map(({ x, y }) => ({ x, y: y && Math.min(y, CAP) }));
+
   return {
     ...baseOptions,
     annotations: [
@@ -100,7 +104,9 @@ export const optionsPositiveTests = (data, endDate) => {
     ],
     tooltip: {
       pointFormatter: function () {
-        return `Positive Tests ${formatPercent(this.y)}`;
+        return `Positive Tests ${
+          this.y === CAP ? `> ${formatPercent(CAP)}` : formatPercent(this.y)
+        }`;
       },
     },
     xAxis: {

--- a/src/components/Charts/zoneUtils.js
+++ b/src/components/Charts/zoneUtils.js
@@ -83,11 +83,13 @@ export const optionsPositiveTests = (data, endDate) => {
   const { x, y } = lastValidPoint(data);
   const [minY, maxY] = [0, getMaxY(data)];
   const [minYAxis, maxYAxis] = getYAxisLimits(minY, maxY, zones);
+  // sets the limit on the y-axis to be no more than 50%
+  const adjustedMaxYAxis = Math.min(maxYAxis, 0.5);
   return {
     ...baseOptions,
     annotations: [
       currentValueAnnotation(x, y, y && formatPercent(y)),
-      ...zoneAnnotations(endDate, minYAxis, maxYAxis, y, zones),
+      ...zoneAnnotations(endDate, minYAxis, adjustedMaxYAxis, y, zones),
     ],
     series: [
       {
@@ -112,7 +114,7 @@ export const optionsPositiveTests = (data, endDate) => {
           return formatPercent(this.value);
         },
       },
-      tickPositions: getTickPositions(minYAxis, maxYAxis, zones),
+      tickPositions: getTickPositions(minYAxis, adjustedMaxYAxis, zones),
     },
   };
 };


### PR DESCRIPTION
# Changes
- Set a maximum value for positive testing (see thread on [Slack](https://covidactnow.slack.com/archives/C0110QQAPJA/p1588215240213300) to 50%.
- It also rounds up the maxYAxis value to the closest 1% instead of rounding up to the closest 10%, this gives extra space to the data, it looks nicer in my opinion
- It increases the z-index of the last point annotation, to ensure that it always shows up, even if it overlaps with other annotations (this can be seen in the `/all` page)