### PR TITLE
hide instructions in minimap

### DIFF
--- a/src/components/Map/Map.js
+++ b/src/components/Map/Map.js
@@ -37,10 +37,12 @@ function Map({ hideLegend = false, setMobileMenuOpen, setMapOption }) {
 
   return (
     <div className="Map">
-      <MapInstructions>
-        <strong>Click on a state</strong> to view reopening risk details and
-        county projections.
-      </MapInstructions>
+      {!hideLegend && (
+        <MapInstructions>
+          <strong>Click on a state</strong> to view reopening risk details and
+          county projections.
+        </MapInstructions>
+      )}
       <div className="us-state-map">
         <USACountyMap
           setTooltipContent={setContent}


### PR DESCRIPTION
Fixed a bug where we were showing the "click a state" instructions in the minimap 