### PR TITLE
redo share styling

### DIFF
--- a/src/components/ClaimStateBlock/ClaimStateBlock.style.js
+++ b/src/components/ClaimStateBlock/ClaimStateBlock.style.js
@@ -8,6 +8,10 @@ export const ClaimStateWrapper = styled.div`
   background-color: #fbfbfb;
   padding: 3.5rem 1rem;
   margin-top: 3rem;
+
+  @media (min-width: 600px) {
+    padding: 3.5rem 0;
+  }
 `;
 
 export const ClaimStateContainer = styled.div`
@@ -16,8 +20,14 @@ export const ClaimStateContainer = styled.div`
   display: flex;
   flex-direction: column;
 
-  @media (min-width: 600px) {
-    flex-direction: row;
+  @media (min-width: 1350px) {
+    max-width: 900px;
+    margin: 0 445px 0 auto;
+    position: relative;
+  }
+
+  @media (min-width: 1750px) {
+    margin: 0 auto;
   }
 `;
 
@@ -31,7 +41,7 @@ export const ClaimStateText = styled.div`
 
 export const ClaimStateHeader = styled(Typography)`
   margin-top: 0;
-  margin-bottom: 1rem;
+  margin-bottom: 0;
   font-size: 1rem;
   font-weight: 700;
   line-height: 1.6rem;

--- a/src/components/LocationPage/ChartsHolder.tsx
+++ b/src/components/LocationPage/ChartsHolder.tsx
@@ -147,12 +147,12 @@ const ChartsHolder = (props: {
               condensed={false}
               forCompareModels={false}
             />
+            <ShareModelBlock
+              condensed={false}
+              stateId={props.stateId}
+              county={props.countyId}
+            />
           </MainContentInner>
-          <ShareModelBlock
-            condensed={false}
-            stateId={props.stateId}
-            county={props.countyId}
-          />
           <ClaimStateBlock
             stateId={props.stateId}
             countyName={props.countyId}

--- a/src/components/Newsletter/Newsletter.style.tsx
+++ b/src/components/Newsletter/Newsletter.style.tsx
@@ -12,7 +12,7 @@ export const StyledNewsletter = styled.div`
       line-height: 2rem;
       height: 2.5rem;
       outline: 0;
-      border: 1px solid rgba(0, 0, 0, 0.12);;
+      border: 1px solid rgba(0, 0, 0, 0.12);
       border-right-width: 0;
       border-top-left-radius: 4px;
       border-bottom-left-radius: 4px;

--- a/src/components/Newsletter/Newsletter.style.tsx
+++ b/src/components/Newsletter/Newsletter.style.tsx
@@ -12,7 +12,7 @@ export const StyledNewsletter = styled.div`
       line-height: 2rem;
       height: 2.5rem;
       outline: 0;
-      border: 1px solid ${palette.divider};
+      border: 1px solid rgba(0, 0, 0, 0.12);;
       border-right-width: 0;
       border-top-left-radius: 4px;
       border-bottom-left-radius: 4px;

--- a/src/components/ShareBlock/ShareBlock.style.tsx
+++ b/src/components/ShareBlock/ShareBlock.style.tsx
@@ -12,17 +12,16 @@ export const ShareSpacer = styled.div`
 
 export const ShareContainer = styled.div<{
   condensed?: boolean;
-  centered?: boolean;
+  forceVertical?: boolean;
 }>`
   background: ${palette.white};
   max-width: 900px;
-  margin: ${props =>
-    props.condensed ? 0 : props.centered ? '3rem auto' : '3rem 0'};
+  margin: ${props => (props.condensed ? 0 : '3rem 0')};
   border: 1px solid rgba(0, 0, 0, 0.12);
   border-radius: 4px;
 
   @media screen and (min-width: 900px) {
-    display: flex;
+    display: ${props => (props.forceVertical ? 'block' : 'flex')};
   }
 `;
 
@@ -57,7 +56,7 @@ export const ShareButtonContainer = styled.div<{ reflow: boolean }>`
   }
 `;
 
-export const ShareType = styled.div`
+export const ShareType = styled.div<{ forceVertical?: Boolean }>`
   border-bottom: 1px solid rgba(0, 0, 0, 0.12);
   padding: 1.5rem;
   flex: 1;
@@ -67,8 +66,10 @@ export const ShareType = styled.div`
 
 
   @media (min-width: 900px) {
-    border-right: 1px solid rgba(0, 0, 0, 0.12);
-    border-bottom: 0;
+    border-right: ${props =>
+      props.forceVertical ? '0' : '1px solid rgba(0, 0, 0, 0.12);'}
+    border-bottom: ${props =>
+      props.forceVertical ? '1px solid rgba(0, 0, 0, 0.12);' : '0'};
 
     &:last-child {
       border-right: 0;

--- a/src/components/ShareBlock/ShareBlock.style.tsx
+++ b/src/components/ShareBlock/ShareBlock.style.tsx
@@ -15,12 +15,15 @@ export const ShareContainer = styled.div<{
   centered?: boolean;
 }>`
   background: ${palette.white};
-  max-width: 640px;
+  max-width: 900px;
   margin: ${props =>
     props.condensed ? 0 : props.centered ? '3rem auto' : '3rem 0'};
   border: 1px solid rgba(0, 0, 0, 0.12);
-  padding: 1.5rem;
   border-radius: 4px;
+
+  @media screen and (min-width: 900px) {
+    display: flex;
+  }
 `;
 
 export const ShareInstruction = styled(Typography)<{ component?: string }>`
@@ -30,7 +33,7 @@ export const ShareInstruction = styled(Typography)<{ component?: string }>`
   font-weight: 700;
   line-height: 1.6rem;
   color: ${palette.black};
-  text-align: center;
+  text-align: left;
 `;
 
 export const ShareButtonContainer = styled.div<{ reflow: boolean }>`
@@ -54,9 +57,23 @@ export const ShareButtonContainer = styled.div<{ reflow: boolean }>`
   }
 `;
 
-export const ShareTypeDivider = styled.div`
-  border-top: 1px solid rgba(0, 0, 0, 0.12);
-  margin: 1.5rem -1.5rem;
+export const ShareType = styled.div`
+  border-bottom: 1px solid rgba(0, 0, 0, 0.12);
+  padding: 1.5rem;
+  flex: 1;
+  &:last-child {
+    border-bottom: 0;
+  }
+
+
+  @media (min-width: 900px) {
+    border-right: 1px solid rgba(0, 0, 0, 0.12);
+    border-bottom: 0;
+
+    &:last-child {
+      border-right: 0;
+    }
+  }
 `;
 
 export const StyledShareButton = styled.div<{

--- a/src/components/ShareBlock/ShareBlock.style.tsx
+++ b/src/components/ShareBlock/ShareBlock.style.tsx
@@ -10,15 +10,17 @@ export const ShareSpacer = styled.div`
   }
 `;
 
-export const ShareContainer = styled.div<{ condensed?: boolean }>`
+export const ShareContainer = styled.div<{
+  condensed?: boolean;
+  centered?: boolean;
+}>`
   background: ${palette.white};
   max-width: 640px;
-  margin: ${props => (props.condensed ? 0 : '3rem auto')};
-  border: 1px solid ${palette.divider};
+  margin: ${props =>
+    props.condensed ? 0 : props.centered ? '3rem auto' : '3rem 0'};
+  border: 1px solid rgba(0, 0, 0, 0.12);
   padding: 1.5rem;
   border-radius: 4px;
-  box-shadow: 0 0 0 1px rgba(63, 63, 68, 0.05),
-    0 1px 3px 0 rgba(63, 63, 68, 0.15);
 `;
 
 export const ShareInstruction = styled(Typography)<{ component?: string }>`
@@ -53,7 +55,7 @@ export const ShareButtonContainer = styled.div<{ reflow: boolean }>`
 `;
 
 export const ShareTypeDivider = styled.div`
-  border-top: 1px solid ${palette.divider};
+  border-top: 1px solid rgba(0, 0, 0, 0.12);
   margin: 1.5rem -1.5rem;
 `;
 

--- a/src/components/ShareBlock/ShareBlock.tsx
+++ b/src/components/ShareBlock/ShareBlock.tsx
@@ -14,7 +14,7 @@ import {
   ShareContainer,
   ShareInstruction,
   StyledShareButton,
-  ShareTypeDivider,
+  ShareType,
 } from './ShareBlock.style';
 import { STATES } from 'enums';
 
@@ -69,68 +69,69 @@ const ShareBlock = ({
 
   return (
     <ShareContainer condensed={condensed} centered={centered}>
-      <ShareInstruction>
-        {shareInstruction || 'Share the Covid Act Now map'}
-      </ShareInstruction>
-      <ShareButtonContainer reflow>
-        <StyledShareButton disableElevation variant="contained" color="#3b5998">
-          <FacebookShareButton
-            url={url}
-            quote={quote}
-            beforeOnClick={() => {
-              trackShare('facebook');
-              return Promise.resolve();
-            }}
-          >
-            <FacebookIcon size={40} round={false} bgStyle={{ fill: 'auto' }} />
-          </FacebookShareButton>
-        </StyledShareButton>
-        <StyledShareButton disableElevation variant="contained" color="#00acee">
-          <TwitterShareButton
-            url={url}
-            title={quote}
-            hashtags={[hashtag]}
-            beforeOnClick={() => {
-              trackShare('twitter');
-              return Promise.resolve();
-            }}
-          >
-            <TwitterIcon size={40} round={false} bgStyle={{ fill: 'auto' }} />
-          </TwitterShareButton>
-        </StyledShareButton>
-        <StyledShareButton disableElevation variant="contained" color="#007fb1">
-          <LinkedinShareButton
-            url={url}
-            title={quote}
-            // @ts-ignore: seems to not be available for linkedin?
-            hashtags={[hashtag]}
-            beforeOnClick={() => {
-              trackShare('linkedin');
-              return Promise.resolve();
-            }}
-          >
-            <LinkedinIcon size={40} round={false} bgStyle={{ fill: 'auto' }} />
-          </LinkedinShareButton>
-        </StyledShareButton>
-        {isMatchingProjectionsRoute && (
-          <StyledShareButton
-            disableElevation
-            variant="contained"
-            color="#616161"
-            onClick={onClickEmbed}
-          >
-            Embed
+      <ShareType>
+        <ShareInstruction>
+          {shareInstruction || 'Share the Covid Act Now map'}
+        </ShareInstruction>
+        <ShareButtonContainer reflow>
+          <StyledShareButton disableElevation variant="contained" color="#3b5998">
+            <FacebookShareButton
+              url={url}
+              quote={quote}
+              beforeOnClick={() => {
+                trackShare('facebook');
+                return Promise.resolve();
+              }}
+            >
+              <FacebookIcon size={40} round={false} bgStyle={{ fill: 'auto' }} />
+            </FacebookShareButton>
           </StyledShareButton>
-        )}
-      </ShareButtonContainer>
-
-      <ShareTypeDivider />
-
-      <ShareInstruction color="inherit" component="p" variant="subtitle2">
-        {newsletterInstruction ||
-          'Get the latest updates from the Covid Act Now team'}
-      </ShareInstruction>
-      <Newsletter county={countyName} stateId={stateId} />
+          <StyledShareButton disableElevation variant="contained" color="#00acee">
+            <TwitterShareButton
+              url={url}
+              title={quote}
+              hashtags={[hashtag]}
+              beforeOnClick={() => {
+                trackShare('twitter');
+                return Promise.resolve();
+              }}
+            >
+              <TwitterIcon size={40} round={false} bgStyle={{ fill: 'auto' }} />
+            </TwitterShareButton>
+          </StyledShareButton>
+          <StyledShareButton disableElevation variant="contained" color="#007fb1">
+            <LinkedinShareButton
+              url={url}
+              title={quote}
+              // @ts-ignore: seems to not be available for linkedin?
+              hashtags={[hashtag]}
+              beforeOnClick={() => {
+                trackShare('linkedin');
+                return Promise.resolve();
+              }}
+            >
+              <LinkedinIcon size={40} round={false} bgStyle={{ fill: 'auto' }} />
+            </LinkedinShareButton>
+          </StyledShareButton>
+          {isMatchingProjectionsRoute && (
+            <StyledShareButton
+              disableElevation
+              variant="contained"
+              color="#616161"
+              onClick={onClickEmbed}
+            >
+              Embed
+            </StyledShareButton>
+          )}
+        </ShareButtonContainer>
+      </ShareType>
+      <ShareType>
+        <ShareInstruction color="inherit" component="p" variant="subtitle2">
+          {newsletterInstruction ||
+            'Get the latest updates from the Covid Act Now team'}
+        </ShareInstruction>
+        <Newsletter county={countyName} stateId={stateId} />
+      </ShareType>
     </ShareContainer>
   );
 };

--- a/src/components/ShareBlock/ShareBlock.tsx
+++ b/src/components/ShareBlock/ShareBlock.tsx
@@ -20,6 +20,7 @@ import { STATES } from 'enums';
 
 const ShareBlock = ({
   condensed,
+  centered,
   stateId,
   countyName,
   shareQuote,
@@ -29,6 +30,7 @@ const ShareBlock = ({
   onClickEmbed,
 }: {
   condensed?: boolean;
+  centered?: boolean;
   stateId?: string;
   countyName?: String;
   shareQuote?: string;
@@ -66,7 +68,7 @@ const ShareBlock = ({
   });
 
   return (
-    <ShareContainer condensed={condensed}>
+    <ShareContainer condensed={condensed} centered={centered}>
       <ShareInstruction>
         {shareInstruction || 'Share the Covid Act Now map'}
       </ShareInstruction>

--- a/src/components/ShareBlock/ShareBlock.tsx
+++ b/src/components/ShareBlock/ShareBlock.tsx
@@ -20,7 +20,7 @@ import { STATES } from 'enums';
 
 const ShareBlock = ({
   condensed,
-  centered,
+  forceVertical,
   stateId,
   countyName,
   shareQuote,
@@ -30,7 +30,7 @@ const ShareBlock = ({
   onClickEmbed,
 }: {
   condensed?: boolean;
-  centered?: boolean;
+  forceVertical?: boolean;
   stateId?: string;
   countyName?: String;
   shareQuote?: string;
@@ -68,13 +68,17 @@ const ShareBlock = ({
   });
 
   return (
-    <ShareContainer condensed={condensed} centered={centered}>
-      <ShareType>
+    <ShareContainer condensed={condensed} forceVertical={forceVertical}>
+      <ShareType forceVertical={forceVertical}>
         <ShareInstruction>
           {shareInstruction || 'Share the Covid Act Now map'}
         </ShareInstruction>
         <ShareButtonContainer reflow>
-          <StyledShareButton disableElevation variant="contained" color="#3b5998">
+          <StyledShareButton
+            disableElevation
+            variant="contained"
+            color="#3b5998"
+          >
             <FacebookShareButton
               url={url}
               quote={quote}
@@ -83,10 +87,18 @@ const ShareBlock = ({
                 return Promise.resolve();
               }}
             >
-              <FacebookIcon size={40} round={false} bgStyle={{ fill: 'auto' }} />
+              <FacebookIcon
+                size={40}
+                round={false}
+                bgStyle={{ fill: 'auto' }}
+              />
             </FacebookShareButton>
           </StyledShareButton>
-          <StyledShareButton disableElevation variant="contained" color="#00acee">
+          <StyledShareButton
+            disableElevation
+            variant="contained"
+            color="#00acee"
+          >
             <TwitterShareButton
               url={url}
               title={quote}
@@ -99,7 +111,11 @@ const ShareBlock = ({
               <TwitterIcon size={40} round={false} bgStyle={{ fill: 'auto' }} />
             </TwitterShareButton>
           </StyledShareButton>
-          <StyledShareButton disableElevation variant="contained" color="#007fb1">
+          <StyledShareButton
+            disableElevation
+            variant="contained"
+            color="#007fb1"
+          >
             <LinkedinShareButton
               url={url}
               title={quote}
@@ -110,7 +126,11 @@ const ShareBlock = ({
                 return Promise.resolve();
               }}
             >
-              <LinkedinIcon size={40} round={false} bgStyle={{ fill: 'auto' }} />
+              <LinkedinIcon
+                size={40}
+                round={false}
+                bgStyle={{ fill: 'auto' }}
+              />
             </LinkedinShareButton>
           </StyledShareButton>
           {isMatchingProjectionsRoute && (
@@ -125,7 +145,7 @@ const ShareBlock = ({
           )}
         </ShareButtonContainer>
       </ShareType>
-      <ShareType>
+      <ShareType forceVertical={forceVertical}>
         <ShareInstruction color="inherit" component="p" variant="subtitle2">
           {newsletterInstruction ||
             'Get the latest updates from the Covid Act Now team'}

--- a/src/screens/About/About.tsx
+++ b/src/screens/About/About.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import AppMetaTags from 'components/AppMetaTags/AppMetaTags';
+import ShareBlock from 'components/ShareBlock/ShareBlock';
 import Typography from '@material-ui/core/Typography';
 import { TEAM } from './../../enums';
 import StapledSidebar, {
@@ -359,6 +360,7 @@ const About = ({ children }: { children: React.ReactNode }) => {
             </a>
             .
           </Typography>
+          <ShareBlock forceVertical={true} />
         </StapledSidebar>
       </Content>
     </Wrapper>

--- a/src/screens/Contact/Contact.tsx
+++ b/src/screens/Contact/Contact.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import AppMetaTags from 'components/AppMetaTags/AppMetaTags';
+import ShareBlock from 'components/ShareBlock/ShareBlock';
 import Typography from '@material-ui/core/Typography';
 import StapledSidebar, {
   SidebarLink,
@@ -145,6 +146,7 @@ const Contact = ({ children }: { children: React.ReactNode }) => {
             </a>{' '}
             if you’re interested in making a grant.
           </Typography>
+          <ShareBlock forceVertical={true} />
         </StapledSidebar>
       </Content>
     </Wrapper>

--- a/src/screens/HomePage/CriteriaExplanation/CriteriaExplanation.style.tsx
+++ b/src/screens/HomePage/CriteriaExplanation/CriteriaExplanation.style.tsx
@@ -21,7 +21,7 @@ export const Wrapper = styled.div`
     padding-top: 3rem;
   }
 
-  @media (min-width: 900px) {
+  @media (min-width: 932px) {
     margin: 4.5rem auto 0;
   }
 `;

--- a/src/screens/HomePage/HomePage.js
+++ b/src/screens/HomePage/HomePage.js
@@ -26,7 +26,7 @@ export default function HomePage() {
                 padding: '0 1rem',
               }}
             >
-              <ShareBlock />
+              <ShareBlock centered={true} />
             </div>
           </Content>
         </div>

--- a/src/screens/HomePage/HomePage.js
+++ b/src/screens/HomePage/HomePage.js
@@ -26,7 +26,7 @@ export default function HomePage() {
                 padding: '0 1rem',
               }}
             >
-              <ShareBlock centered={true} />
+              <ShareBlock />
             </div>
           </Content>
         </div>

--- a/src/screens/Resources/Resources.tsx
+++ b/src/screens/Resources/Resources.tsx
@@ -179,7 +179,7 @@ const Resources = ({ children }: { children: React.ReactNode }) => {
             frameBorder="0"
             scrolling="no"
           />
-          <ShareBlock />
+          <ShareBlock forceVertical={true} />
         </StapledSidebar>
       </Content>
     </Wrapper>


### PR DESCRIPTION
Our sharing and "claim state" modules were weirdly aligned on some large screen sizes. Fixed that and removed box shadow to align with our styling approach.