### PR TITLE
Add 7-day trailing average text to disclaimer under positive rate chart.

### DIFF
--- a/src/components/LocationPage/ChartsHolder.tsx
+++ b/src/components/LocationPage/ChartsHolder.tsx
@@ -109,6 +109,7 @@ const ChartsHolder = (props: {
                   The World Health Organization recommends a positive test rate
                   of less than 10% before reopening. The countries most
                   successful in containing COVID have rates of 3% or less.
+                  We calculate the rate as a 7-day trailing average.
                 </Disclaimer>
               </>
             )}

--- a/src/components/LocationPage/ChartsHolder.tsx
+++ b/src/components/LocationPage/ChartsHolder.tsx
@@ -108,8 +108,8 @@ const ChartsHolder = (props: {
                 <Disclaimer metricName="positive test rate">
                   The World Health Organization recommends a positive test rate
                   of less than 10% before reopening. The countries most
-                  successful in containing COVID have rates of 3% or less.
-                  We calculate the rate as a 7-day trailing average.
+                  successful in containing COVID have rates of 3% or less. We
+                  calculate the rate as a 7-day trailing average.
                 </Disclaimer>
               </>
             )}


### PR DESCRIPTION
Good enough? (else let me know what you want)

![image](https://user-images.githubusercontent.com/206364/80825275-e3b60900-8b94-11ea-826d-c80a89ca81dc.png)

NOTE: We end up saying "we calculate ... rate" twice in a row, but the second one is harder to change.

Alternative:
* We calculate the rate as a 7-day trailing average to smooth out daily reporting inconsistencies.

