### PR TITLE
Deploy: Add 1 decimal point to positive rate in header too

### DIFF
--- a/src/components/SummaryStats/SummaryStats.tsx
+++ b/src/components/SummaryStats/SummaryStats.tsx
@@ -39,7 +39,7 @@ const SummaryStat = (props: {
     } else if (chartType === ChartType.HOSPITAL_USAGE) {
       return formatPercent(value);
     } else if (chartType === ChartType.POSITIVE_TESTS) {
-      return formatPercent(value);
+      return formatPercent(value, 1);
     }
     fail('Invalid Chart Type');
   };


### PR DESCRIPTION
Helps avoid confusion when the rounded value lands on a zone threshold.