### PR TITLE
Make sure we don't provide hospital overload predictions if we don't have inference data.

### DIFF
--- a/src/components/LocationPage/ChartsHolder.tsx
+++ b/src/components/LocationPage/ChartsHolder.tsx
@@ -169,8 +169,23 @@ function generateChartDescription(
   projection: Projection,
   noInterventionProjection: Projection,
 ) {
-  // TODO(sgoldblatt): figure out how to get people number data from projection
+  const noInterventionDate = noInterventionProjection.dateOverwhelmed;
+  const reopeningText = noInterventionDate
+    ? `happen in a slow and phased fashion. If all restrictions were completely lifted today, ` +
+      `hospitals are projected to become overloaded by ${formatDate(
+        noInterventionDate,
+      )}.`
+    : `happen in a slow and phased fashion.`;
+
+  if (!projection.isInferred) {
+    return (
+      `We don't have enough data to project whether hospitals are likely to become overloaded. ` +
+      `Reopening should always ${reopeningText}`
+    );
+  }
+
   if (projection.dateOverwhelmed) {
+    // TODO(sgoldblatt): figure out how to get people number data from projection
     if (projection.dateOverwhelmed < new Date()) {
       return `Our projections suggest hospitals in ${projection.locationName} are overloaded.`;
     }
@@ -180,16 +195,9 @@ function generateChartDescription(
       projection.dateOverwhelmed,
     )}. Exercise caution.`;
   } else {
-    const noInterventionDate = noInterventionProjection.dateOverwhelmed;
-    const restrictionsLiftedText = noInterventionDate
-      ? `However, any reopening should happen in a slow and phased fashion. If all restrictions were completely lifted today, hospitals would overload on ${formatDate(
-          noInterventionDate,
-        )}.`
-      : `However, any reopening should happen in a slow and phased fashion.`;
-
     return (
       `Assuming current trends and interventions continue, ${projection.locationName} hospitals are unlikely to become overloaded in the next 3 months. ` +
-      `${restrictionsLiftedText}`
+      `However, any reopening should ${reopeningText}`
     );
   }
 }


### PR DESCRIPTION
See https://covidactnow.org/us/ut/county/utah_county

Right now the chart and the text disagree since the text ends up using our "social distancing" static intervention to predict an overload date.

![image](https://user-images.githubusercontent.com/206364/80872769-f732a400-8c68-11ea-874e-c7d15d4c43b3.png)

With my change, the text should match the chart better.
![image](https://user-images.githubusercontent.com/206364/80872817-3d880300-8c69-11ea-8609-e89755745189.png)
