### PR TITLE
Fix props on components with inline SVG

### DIFF
--- a/src/assets/images/checkIcon.tsx
+++ b/src/assets/images/checkIcon.tsx
@@ -13,9 +13,9 @@ const CheckIcon = (props: { textColor: string }) => {
       <path
         d="M13.1666 1.16666L5.83325 8.5L3.83325 6.5"
         stroke="white"
-        stroke-width="2"
-        stroke-linecap="round"
-        stroke-linejoin="round"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
       />
     </svg>
   );

--- a/src/assets/images/exclamationIcon.tsx
+++ b/src/assets/images/exclamationIcon.tsx
@@ -17,9 +17,9 @@ const ExclamationIcon = (props: { textColor: string }) => {
       <path
         d="M6.5 4.96153V7.42307"
         stroke="white"
-        stroke-width="2"
-        stroke-linecap="round"
-        stroke-linejoin="round"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
       />
       <ellipse
         cx="6.42308"

--- a/src/assets/images/questionIcon.tsx
+++ b/src/assets/images/questionIcon.tsx
@@ -10,17 +10,17 @@ const QuestionIcon = (props: { textColor: string }) => {
       xmlns="http://www.w3.org/2000/svg"
     >
       <path
-        fill-rule="evenodd"
-        clip-rule="evenodd"
+        fillRule="evenodd"
+        clipRule="evenodd"
         d="M6.66667 13.8333C10.3486 13.8333 13.3333 10.8486 13.3333 7.16667C13.3333 3.48477 10.3486 0.5 6.66667 0.5C2.98477 0.5 0 3.48477 0 7.16667C0 10.8486 2.98477 13.8333 6.66667 13.8333Z"
         fill={props.textColor}
       />
       <path
         d="M4.75 5.3365C5.07362 4.41653 6.01359 3.86411 6.97478 4.02898C7.93598 4.19385 8.63812 5.02794 8.63667 6.00317C8.63667 7.3365 6.63667 8.00317 6.63667 8.00317"
         stroke="white"
-        stroke-width="2"
-        stroke-linecap="round"
-        stroke-linejoin="round"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
       />
       <ellipse cx="6.5" cy="11.0032" rx="1" ry="1" fill="white" />
     </svg>

--- a/src/assets/images/tildeIcon.tsx
+++ b/src/assets/images/tildeIcon.tsx
@@ -10,8 +10,8 @@ const TildeIcon = (props: { textColor: string }) => {
       xmlns="http://www.w3.org/2000/svg"
     >
       <path
-        fill-rule="evenodd"
-        clip-rule="evenodd"
+        fillRule="evenodd"
+        clipRule="evenodd"
         d="M0 1.5C0 0.947715 0.447715 0.5 1 0.5H11C11.5523 0.5 12 0.947715 12 1.5V11.5C12 12.0523 11.5523 12.5 11 12.5H1C0.447715 12.5 0 12.0523 0 11.5V1.5Z"
         fill={props.textColor}
       />


### PR DESCRIPTION
Components that render SVG should have props such as `stroke-width` should be camelCased. This PR fixes the ones I could find in `/src`