### PR TITLE
Remove use of county_summaries/XX.summary.json files in the frontend.

### DIFF
--- a/src/components/CountyMap/CountyMap.js
+++ b/src/components/CountyMap/CountyMap.js
@@ -12,24 +12,17 @@ import { FIPS_CODE_TO_CALCULATED_INTERVENTION_COLOR } from 'enums/interventions'
 import { COLOR_MAP } from 'enums/interventions';
 import { CountyMapWrapper, CountyMapLayerWrapper } from './CountyMap.style';
 
-const CountyMap = ({
-  selectedCounty,
-  setSelectedCounty,
-  fill,
-  stateSummary = {},
-}) => {
+const CountyMap = ({ selectedCounty, setSelectedCounty }) => {
   let { stateId } = useParams();
   stateId = stateId.toUpperCase();
   const state = STATE_CENTERS[stateId];
   const counties = require(`./countyTopoJson/${stateId}.json`);
-  const countiesWithData =
-    stateSummary && stateSummary.counties_with_data
-      ? stateSummary.counties_with_data
-      : [];
   const [content, setContent] = useState('');
 
   const getFillColor = geoId => {
-    return FIPS_CODE_TO_CALCULATED_INTERVENTION_COLOR[geoId] || fill;
+    return (
+      FIPS_CODE_TO_CALCULATED_INTERVENTION_COLOR[geoId] || COLOR_MAP.GRAY.LIGHT
+    );
   };
 
   return (
@@ -49,11 +42,7 @@ const CountyMap = ({
             <Geography
               key={geo.rsmKey}
               geography={geo}
-              fill={
-                countiesWithData.includes(geo.properties.GEOID)
-                  ? getFillColor(geo.properties.GEOID)
-                  : COLOR_MAP.GRAY.LIGHT
-              }
+              fill={getFillColor(geo.properties.GEOID)}
               stroke={'white'}
             />
           );

--- a/src/components/MiniMap/MiniMap.tsx
+++ b/src/components/MiniMap/MiniMap.tsx
@@ -13,7 +13,6 @@ import Map from 'components/Map/Map';
 import CountyMap from 'components/CountyMap/CountyMap';
 import _ from 'lodash';
 import { MAP_FILTERS } from 'screens/ModelPage/Enums/MapFilterEnums';
-import { useStateSummary } from 'utils/model';
 import { useHistory } from 'react-router-dom';
 import US_STATE_DATASET from '../MapSelectors/datasets/us_states_dataset_01_02_2020.json';
 import { Projections } from 'models/Projections';
@@ -37,7 +36,6 @@ const MiniMap: FunctionComponent<MiniMapProperties> = (
   props: MiniMapProperties,
 ) => {
   const history = useHistory();
-  const stateSummary = useStateSummary(props.stateId);
 
   const goTo = (route: string) => {
     history.push(route);
@@ -73,12 +71,6 @@ const MiniMap: FunctionComponent<MiniMapProperties> = (
         {props.stateId !== MAP_FILTERS.DC && (
           <CountyMapAltWrapper visible={props.mapOption === MAP_FILTERS.STATE}>
             <CountyMap
-              fill={
-                props.projections.primary
-                  ? props.projections.getAlarmLevelColor()
-                  : '#e3e3e3'
-              }
-              stateSummary={stateSummary}
               selectedCounty={props.selectedCounty}
               setSelectedCounty={(fullFips: string) => {
                 const county = _.find(

--- a/src/utils/model.js
+++ b/src/utils/model.js
@@ -47,19 +47,6 @@ export async function fetchStateSummary(stateId) {
   return response.json();
 }
 
-export function useStateSummary(stateId) {
-  const [countySummaries, setCountySummaries] = useState();
-
-  useEffect(() => {
-    async function fetchData() {
-      setCountySummaries(await fetchStateSummary(stateId));
-    }
-    fetchData();
-  }, [stateId]);
-
-  return countySummaries;
-}
-
 export function useStateSummaryData(state) {
   const [summaryData, setSummaryData] = useState(null);
   useEffect(() => {


### PR DESCRIPTION
We used to need these files to render the county map without having to read all the projection files. But the calculated_county_interventions.json file took the place of that a while ago so it's been redundant for a while.

Additionally, the summary files are slightly wrong. E.g. they indicate Weber County, UT (fips 49057) should have data, but it does not. I'm not sure why the summary file is wrong, but we don't need it anymore, so who cares.

My next PR (to move the calculated interventions script onto the batch API will remove use of the summary file completely).