### PR TITLE
Fix county sharing and About page typo

### DIFF
--- a/src/components/LocationPage/ChartsHolder.tsx
+++ b/src/components/LocationPage/ChartsHolder.tsx
@@ -43,6 +43,7 @@ import {
   formatInteger,
 } from 'components/Charts/utils';
 
+// TODO(michael): figure out where this type declaration should live.
 type County = {
   county: string;
   county_url_name: string;
@@ -81,7 +82,7 @@ const ChartsHolder = (props: {
     <>
       {!projection ? (
         <NoCountyDetail
-          countyId={props.county.county_url_name}
+          countyId={props.county?.county_url_name}
           stateId={props.stateId}
         />
       ) : (
@@ -172,7 +173,7 @@ const ChartsHolder = (props: {
             </MainContentInner>
             <ClaimStateBlock
               stateId={props.stateId}
-              countyId={props.county && props.county.county_url_name}
+              countyId={props.county?.county_url_name}
             />
           </ChartContentWrapper>
           <ShareModelBlock

--- a/src/components/LocationPage/ChartsHolder.tsx
+++ b/src/components/LocationPage/ChartsHolder.tsx
@@ -43,10 +43,21 @@ import {
   formatInteger,
 } from 'components/Charts/utils';
 
+type County = {
+  county: string;
+  county_url_name: string;
+  county_fips_code: string;
+  state_fips_code: string;
+  state_code: string;
+  full_fips_code: string;
+  cities: string[];
+  population: string;
+};
+
 const ChartsHolder = (props: {
   projections: Projections;
   stateId: string;
-  countyId: string;
+  county: County;
 }) => {
   const projection: Projection = props.projections.primary;
   const noInterventionProjection: Projection = props.projections.baseline;
@@ -69,7 +80,10 @@ const ChartsHolder = (props: {
   return (
     <>
       {!projection ? (
-        <NoCountyDetail countyId={props.countyId} stateId={props.stateId} />
+        <NoCountyDetail
+          countyId={props.county.county_url_name}
+          stateId={props.stateId}
+        />
       ) : (
         <>
           <ChartContentWrapper>
@@ -158,13 +172,13 @@ const ChartsHolder = (props: {
             </MainContentInner>
             <ClaimStateBlock
               stateId={props.stateId}
-              countyId={props.countyId}
+              countyId={props.county.county_url_name}
             />
           </ChartContentWrapper>
           <ShareModelBlock
             condensed={false}
             stateId={props.stateId}
-            county={props.countyId}
+            county={props.county}
             projections={props.projections}
             stats={getChartSummarys(projection)}
           />

--- a/src/components/LocationPage/ChartsHolder.tsx
+++ b/src/components/LocationPage/ChartsHolder.tsx
@@ -172,7 +172,7 @@ const ChartsHolder = (props: {
             </MainContentInner>
             <ClaimStateBlock
               stateId={props.stateId}
-              countyId={props.county.county_url_name}
+              countyId={props.county && props.county.county_url_name}
             />
           </ChartContentWrapper>
           <ShareModelBlock

--- a/src/components/SocialLocationPreview/SocialLocationPreview.tsx
+++ b/src/components/SocialLocationPreview/SocialLocationPreview.tsx
@@ -82,7 +82,11 @@ const SocialLocationPreview = (props: {
     <Wrapper>
       <PreviewHeader>
         <HeaderText>
-          <HeaderHeader>{props.projections.stateName}</HeaderHeader>
+          <HeaderHeader>
+            {props.projections.countyName
+              ? `${props.projections.countyName}, ${props.projections.stateCode}`
+              : props.projections.stateName}
+          </HeaderHeader>
           <HeaderSubhead>Overall risk if reopening</HeaderSubhead>
         </HeaderText>
         <AlarmLevel color={fillColor}>{levelInfo.name}</AlarmLevel>

--- a/src/models/Projection.ts
+++ b/src/models/Projection.ts
@@ -98,8 +98,10 @@ export class Projection {
     this.rtRange = this.calcRtRange(timeseries);
     this.testPositiveRate = this.calcTestPositiveRate();
     // disable icuUtilization for counties for now
-    this.icuUtilization = (this.isCounty && summaryWithTimeseries.stateName === "Nevada" ) ? [null] :
-      this.calcIcuUtilization(timeseries, lastUpdated);
+    this.icuUtilization =
+      this.isCounty && summaryWithTimeseries.stateName === 'Nevada'
+        ? [null]
+        : this.calcIcuUtilization(timeseries, lastUpdated);
 
     const ICUBeds = summaryWithTimeseries?.actuals?.ICUBeds;
     this.totalICUCapacity = ICUBeds && ICUBeds.capacity;

--- a/src/screens/About/About.tsx
+++ b/src/screens/About/About.tsx
@@ -54,7 +54,7 @@ const About = ({ children }: { children: React.ReactNode }) => {
             </a>
             , Covid Act Now is a multidisciplinary team of technologists,
             epidemiologists, health experts, and public policy leaders working
-            to provide disease intelligence and data analysis how COVID in the
+            to provide disease intelligence and data analysis on COVID in the
             U.S.
           </Typography>
           <Typography variant="body1" component="p">

--- a/src/screens/ModelPage/ModelPage.js
+++ b/src/screens/ModelPage/ModelPage.js
@@ -67,7 +67,7 @@ function ModelPage() {
         <ChartsHolder
           projections={projections}
           stateId={stateId}
-          countyId={countyId}
+          county={countyOption}
         />
         <MiniMap
           projections={projections}


### PR DESCRIPTION
I wasn't sure where to put the `County` type declaration.