### PR TITLE
update the Rt chart to dot the most recent 7 days

### DIFF
--- a/src/components/Charts/utils.ts
+++ b/src/components/Charts/utils.ts
@@ -27,6 +27,8 @@ export const currentValueAnnotation = (
   x: number,
   y: number,
   text: string,
+  xOffset = 12,
+  yOffset = -16,
 ): Highcharts.AnnotationsOptions => ({
   draggable: '',
   labelOptions: {
@@ -37,7 +39,8 @@ export const currentValueAnnotation = (
       align: 'left',
       // @ts-ignore - Bug in Highchart types
       verticalAlign: 'center',
-      x: 12,
+      x: xOffset,
+      y: yOffset,
       shape: 'rect',
       point: {
         xAxis: 0,
@@ -53,7 +56,6 @@ export const currentValueAnnotation = (
       className: 'ZoneAnnotation ZoneAnnotation--CurrentValue',
     },
   ],
-  zIndex: -1,
 });
 
 export const getTickPositions = (
@@ -95,6 +97,7 @@ export const baseOptions: Highcharts.Options = {
       animation: false,
       marker: {
         enabled: false,
+        symbol: 'circle',
       },
     },
   },


### PR DESCRIPTION
Close https://trello.com/c/XaDBcNF8/106-make-the-last-week-of-rt-dotted-and-use-the-value-from-7-days-ago-in-the-metric-ui

![image](https://user-images.githubusercontent.com/114084/81459217-a5e85000-9153-11ea-8193-4f63a9ec3133.png)

cc @mikelehen @igorkofman 