### PR TITLE
Revert "Adding ICU headroom calculation"

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -7,13 +7,11 @@ import DataUrlJson from '../assets/data/data_url.json';
 import {
   CovidActNowStateTimeseries,
   Timeseries as CountyTimeseries,
-  Actualstimeseries as CountyActualTimeseries,
   CovidActNowStatesTimeseries,
 } from './schema/CovidActNowStatesTimeseries';
 import {
   CovidActNowCountyTimeseries,
   Timeseries as StateTimeseries,
-  Actualstimeseries as StateActualTimeseries,
   CovidActNowCountiesTimeseries,
 } from './schema/CovidActNowCountiesTimeseries';
 import { INTERVENTIONS, REVERSED_STATES } from 'enums';
@@ -43,9 +41,6 @@ type InterventionKey = keyof typeof INTERVENTIONS;
 
 /** Represents timeseries for any kind of region. */
 export type Timeseries = CountyTimeseries | StateTimeseries;
-
-/** Represents the actuals timeseries for any kind of region */
-export type ActualsTimeseries = CountyActualTimeseries | StateActualTimeseries;
 
 /** Represents summary+timeseries for any kind of region. */
 export type RegionSummaryWithTimeseries =

--- a/src/assets/data/data_url.json
+++ b/src/assets/data/data_url.json
@@ -1,3 +1,3 @@
 {
-  "data_url": "https://data.covidactnow.org/snapshot/268/"
+  "data_url": "https://data.covidactnow.org/snapshot/267/"
 }

--- a/src/components/LocationPage/ChartsHolder.tsx
+++ b/src/components/LocationPage/ChartsHolder.tsx
@@ -36,7 +36,6 @@ import {
   ChartTypeToTitle,
 } from 'enums/zones';
 import { formatDate } from 'utils';
-
 // TODO(michael): These format helpers should probably live in a more
 // general-purpose location, not just for charts.
 import {
@@ -44,9 +43,6 @@ import {
   formatPercent,
   formatInteger,
 } from 'components/Charts/utils';
-
-// States here that give us specific
-const STATES_WITH_DATA_OVERRIDES = ['Nevada'];
 
 // TODO(michael): figure out where this type declaration should live.
 type County = {
@@ -294,49 +290,38 @@ function positiveTestsStatusText(projection: Projection) {
 }
 
 function hospitalOccupancyStatusText(projection: Projection) {
-  const currentIcuUtilization = projection.currentIcuUtilization;
-  const currentCovidICUPatients = projection.currentCovidICUPatients;
-  const totalICUCapacity = projection.totalICUCapacity;
-  const nonCovidPatients = Math.floor(projection.nonCovidPatients);
-
+  const icuUtilization = projection.currentIcuUtilization;
+  const currentlyInICU = projection.currentICUPatients;
   if (
-    currentIcuUtilization === null ||
-    currentCovidICUPatients === null ||
-    totalICUCapacity === null
+    icuUtilization === null ||
+    currentlyInICU == null ||
+    projection.typicallyFreeICUCapacity == null
   ) {
     return 'No ICU occupancy data is available.';
   }
-  const level = determineZone(HOSPITAL_USAGE, currentIcuUtilization);
+  const level = determineZone(HOSPITAL_USAGE, icuUtilization);
 
   const location = projection.locationName;
+  const capacity = projection.totalICUCapacity;
+  const normallyFree = Math.floor(projection.typicallyFreeICUCapacity);
+  const percentUtilization = Math.round((100 * currentlyInICU) / normallyFree);
 
   const lowText = `This suggests there is likely enough capacity to absorb a wave of new COVID infections.`;
   const mediumText = `This suggests some ability to absorb an increase in COVID cases, but caution is warranted.`;
   const highText = `This suggests the healthcare system is not well positioned  to absorb a wave of new COVID infections without substantial surge capacity.`;
 
-  const noStateOverride =
-    STATES_WITH_DATA_OVERRIDES.indexOf(projection.stateName) < 0 ||
-    !projection.hasActualData;
-
-  return `${location} ${noStateOverride ? 'has about' : 'has'} ${formatInteger(
-    totalICUCapacity,
-  )} ICU Beds.
-   ${
-     noStateOverride ? 'We estimate that currently' : 'Currently'
-   } ${formatPercent(nonCovidPatients / totalICUCapacity)} (${formatInteger(
-    nonCovidPatients,
-  )})
-      are occupied by non-COVID patients. Of the remaining ${formatInteger(
-        totalICUCapacity - nonCovidPatients,
-      )} ICU beds, ${noStateOverride ? 'we estimate ' : ''}
-      ${formatInteger(
-        currentCovidICUPatients,
-      )} are occupied by COVID cases, or ${formatPercent(
-    Math.min(
-      1,
-      currentCovidICUPatients / (totalICUCapacity - nonCovidPatients),
-    ),
-  )} of available beds. ${levelText(level, lowText, mediumText, highText)}`;
+  return `${location} has ${formatInteger(
+    capacity!,
+  )} ICU Beds. Normally, ${formatInteger(normallyFree)} are unoccupied.
+      We estimate there are currently ${formatInteger(
+        currentlyInICU,
+      )} COVID cases in the ICU,
+      or ${percentUtilization}% of typically free beds. ${levelText(
+    level,
+    lowText,
+    mediumText,
+    highText,
+  )}`;
 }
 
 /**

--- a/src/enums/zones.ts
+++ b/src/enums/zones.ts
@@ -155,7 +155,7 @@ export const HOSPITAL_USAGE: Zones = {
   },
   [Level.MEDIUM]: {
     level: Level.MEDIUM,
-    upperLimit: 0.7,
+    upperLimit: 0.95,
     name: 'Medium',
     color: COLOR_MAP.ORANGE.BASE,
     detail: 'At risk to a new wave of COVID',

--- a/src/models/Projection.ts
+++ b/src/models/Projection.ts
@@ -1,8 +1,4 @@
-import {
-  RegionSummaryWithTimeseries,
-  Timeseries,
-  ActualsTimeseries,
-} from 'api';
+import { RegionSummaryWithTimeseries, Timeseries } from 'api';
 
 /**
  * We truncate (or in the case of charts, switch to a dashed line) the last
@@ -10,14 +6,6 @@ import {
  * get future data points.
  */
 export const RT_TRUNCATION_DAYS = 7;
-
-/**
- * We subtract this "decomp" factor from the typical ICU Utilization rates we
- * get from the API to account for hospitals being able to decrease their utilization
- * (by cancelling elective surgeries, using surge capacity, etc.).
- */
-const ICU_DECOMP_FACTOR = 0.3;
-const DEFAULT_UTILIZATION = 0.75;
 
 /** Parameters that can be provided when constructing a Projection. */
 export interface ProjectionParameters {
@@ -71,10 +59,7 @@ export class Projection {
   readonly dateOverwhelmed: Date | null;
   readonly totalICUCapacity: number | null;
   readonly typicallyFreeICUCapacity: number | null;
-  readonly currentCovidICUPatients: number | null;
-  readonly typicalICUUtilization: number;
-  readonly hasActualData: boolean;
-  readonly stateName: string;
+  readonly currentICUPatients: number | null;
 
   private readonly intervention: string;
   private readonly dates: Date[];
@@ -83,7 +68,6 @@ export class Projection {
   // NOTE: These are used dynamically by getColumn()
   private readonly hospitalizations: number[];
   private readonly beds: number[];
-  private readonly actualTimeseries: Array<any>;
   private readonly cumulativeDeaths: number[];
   private readonly cumulativeInfected: number[];
   private readonly cumulativePositiveTests: Array<number | null>;
@@ -99,17 +83,13 @@ export class Projection {
     parameters: ProjectionParameters,
   ) {
     const timeseries = summaryWithTimeseries.timeseries;
-    this.actualTimeseries = summaryWithTimeseries.actualsTimeseries;
-    this.hasActualData = this.useActualTimeseries(this.actualTimeseries);
-
     const lastUpdated = new Date(summaryWithTimeseries.lastUpdatedDate);
     this.locationName = this.getLocationName(summaryWithTimeseries);
-    this.stateName = summaryWithTimeseries.stateName;
     this.intervention = parameters.intervention;
     this.isInferred = parameters.isInferred;
     this.isCounty = parameters.isCounty;
     this.totalPopulation = summaryWithTimeseries.actuals.population;
-    this.dates = this.getDates(this.actualTimeseries, timeseries);
+    this.dates = timeseries.map(row => new Date(row.date));
 
     // Set up our series data exposed via getDataset().
     this.hospitalizations = timeseries.map(row => row.hospitalBedsRequired);
@@ -124,20 +104,17 @@ export class Projection {
     );
     this.rtRange = this.calcRtRange(timeseries);
     this.testPositiveRate = this.calcTestPositiveRate();
+    // disable icuUtilization for counties for now
+    this.icuUtilization =
+      this.isCounty && summaryWithTimeseries.stateName === 'Nevada'
+        ? [null]
+        : this.calcIcuUtilization(timeseries, lastUpdated);
 
     const ICUBeds = summaryWithTimeseries?.actuals?.ICUBeds;
-    this.totalICUCapacity = ICUBeds && ICUBeds.totalCapacity;
-    this.typicalICUUtilization =
-      ICUBeds?.typicalUsageRate || DEFAULT_UTILIZATION;
+    this.totalICUCapacity = ICUBeds && ICUBeds.capacity;
     this.typicallyFreeICUCapacity =
       ICUBeds && ICUBeds.capacity * (1 - ICUBeds.typicalUsageRate);
-    this.currentCovidICUPatients = this.calcCurrentCovidICUPatients(
-      timeseries,
-      lastUpdated,
-    );
-
-    this.icuUtilization = this.calcICUHeadroom(
-      this.actualTimeseries,
+    this.currentICUPatients = this.calcCurrentICUPatients(
       timeseries,
       lastUpdated,
     );
@@ -161,22 +138,6 @@ export class Projection {
 
   get finalCumulativeDeaths() {
     return this.cumulativeDeaths[this.cumulativeDeaths.length - 1];
-  }
-
-  get nonCovidPatients() {
-    if (this.hasActualData) {
-      const latestCurrentUssage = this.lastValue(
-        this.actualTimeseries.map(row => row.ICUBeds.currentUsageTotal),
-      );
-      const latestUsageCovid = this.lastValue(
-        this.actualTimeseries.map(row => row.ICUBeds.currentUsageCovid),
-      );
-      return latestCurrentUssage - latestUsageCovid;
-    }
-    return (
-      this.totalICUCapacity! *
-      Math.max(0, this.typicalICUUtilization - ICU_DECOMP_FACTOR)
-    );
   }
 
   /** Returns the date when projections end (should be 90 days out). */
@@ -226,14 +187,6 @@ export class Projection {
       return range === null ? null : range.rt;
     } else {
       return null;
-    }
-  }
-
-  private getDates(actualTimeseries: Timeseries, timeseries: Timeseries) {
-    if (this.hasActualData) {
-      return actualTimeseries.map(row => new Date(row.date));
-    } else {
-      return timeseries.map(row => new Date(row.date));
     }
   }
 
@@ -330,99 +283,40 @@ export class Projection {
     return result;
   }
 
-  /**
-   * If one of the most recent days has any data for all of:
-   *   - currentUsageCovid
-   *   - totalCapacity
-   *   - currentUsageTotal
-   * Then we want to use the actual timeseries for them
-   */
-  private useActualTimeseries(actualTimeseries: ActualsTimeseries) {
-    for (var i = 0; i < actualTimeseries.length; i++) {
-      const actual = actualTimeseries[i];
-      if (
-        actual.ICUBeds.currentUsageCovid &&
-        actual.ICUBeds.totalCapacity &&
-        actual.ICUBeds.currentUsageTotal
-      ) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  private calcICUHeadroom(
-    actualTimeseries: ActualsTimeseries,
+  private calcIcuUtilization(
     timeseries: Timeseries,
     lastUpdated: Date,
   ): Array<number | null> {
-    let icuUtilization;
+    // The API gives us the beds in use *by covid*, and the total capacity *for
+    // covid*, using an assumption that ICUs are usually 75% full with non-covid
+    // patients. We've decided to show full ICU utilization (not just covid), so
+    // we need to undo that assumption.
+    // TODO(igor): Update this on the API side so we can undo this logic.
+    const icuUtilization = timeseries.map(row => {
+      if (row.ICUBedCapacity > 0 && row.ICUBedsInUse > 0) {
+        return Math.min(1, row.ICUBedsInUse / row.ICUBedCapacity);
+      } else {
+        return null;
+      }
+    });
 
-    if (this.hasActualData) {
-      icuUtilization = actualTimeseries.map(row => {
-        if (
-          row.ICUBeds.currentUsageCovid !== null &&
-          row.ICUBeds.totalCapacity !== null &&
-          row.ICUBeds.currentUsageTotal !== null
-        ) {
-          const nonCovidPatientsAtDate =
-            row.ICUBeds.currentUsageTotal - row.ICUBeds.currentUsageCovid;
-          if (row.ICUBeds.currentUsageCovid === 0) return 0;
-          const icuHeadroomUsed =
-            row.ICUBeds.currentUsageCovid /
-            (row.ICUBeds.totalCapacity - nonCovidPatientsAtDate);
-          // TODO: This metric needs to go to the chart eventually
-          return Math.min(1, icuHeadroomUsed);
-        } else {
-          return null;
-        }
-      });
-    } else {
-      icuUtilization = timeseries.map(row => {
-        if (
-          this.totalICUCapacity &&
-          this.totalICUCapacity > 0 &&
-          row.ICUBedsInUse > 0
-        ) {
-          const predictedNonCovidPatientsAtDate =
-            this.totalICUCapacity! *
-            Math.max(0, this.typicalICUUtilization - ICU_DECOMP_FACTOR);
-
-          const icuHeadroomUsed =
-            row.ICUBedsInUse /
-            (this.totalICUCapacity - predictedNonCovidPatientsAtDate);
-          // TODO: This metric needs to go to the chart eventually
-          return Math.min(1, icuHeadroomUsed);
-        } else {
-          return null;
-        }
-      });
-    }
     // Strip off the future projections.
     // TODO(michael): I'm worried about an off-by-one here. I _think_ we usually
     // update our projections using yesterday's data. So we want to strip
     // everything >= lastUpdatedDate. But since the ICU data is all estimates, I
     // can't really validate that's correct.
+
     return this.omitDataAtOrAfterDate(icuUtilization, lastUpdated);
   }
 
-  private calcCurrentCovidICUPatients(
+  private calcCurrentICUPatients(
     timeseries: Timeseries,
     lastUpdated: Date,
   ): number | null {
-    /** This is specifically current icu patients with covid */
-    let icuPatients;
-    if (this.hasActualData) {
-      icuPatients = this.omitDataAtOrAfterDate(
-        this.actualTimeseries.map(row => row.ICUBeds.currentUsageCovid),
-        lastUpdated,
-      );
-    } else {
-      icuPatients = this.omitDataAtOrAfterDate(
-        timeseries.map(row => row.ICUBedsInUse),
-        lastUpdated,
-      );
-    }
+    const icuPatients = this.omitDataAtOrAfterDate(
+      timeseries.map(row => row.ICUBedsInUse),
+      lastUpdated,
+    );
 
     return this.lastValue(icuPatients);
   }
@@ -455,7 +349,7 @@ export class Projection {
 
   private indexOfLastValue<T>(data: Array<T | null>): number | null {
     for (let i = data.length - 1; i >= 0; i--) {
-      if (data[i] !== null && data[i] !== undefined) {
+      if (data[i] !== null) {
         return i;
       }
     }


### PR DESCRIPTION
Reverts covid-projections/covid-projections#724. There's an issue with the dates aligning between actuals and predicted numbers that needs to be addressed. it's a little tricky so best to keep staging clean. I'll work on a fix tomorrow am