### PR TITLE
Tweak site functionality to enable cleanup.

### DIFF
--- a/src/components/Charts/ModelChart.js
+++ b/src/components/Charts/ModelChart.js
@@ -11,6 +11,7 @@ import {
   CondensedLegendItemStyled,
 } from './ModelChart.style';
 import Outcomes from '../Outcomes/Outcomes';
+import { COLORS } from 'enums';
 import { formatDate } from 'utils';
 
 const formatIntervention = (intervention, optCase) =>
@@ -49,33 +50,9 @@ const ModelChart = ({
     },
     visible: !forCompareModels,
     condensedLegend: {
-      bgColor: projections.getChartSeriesColorMap().limitedActionSeries,
+      bgColor: COLORS.LIMITED_ACTION,
     },
     legendIndex: 2,
-  };
-
-  const socialDistancing = {
-    className: 'social-distancing',
-    name:
-      currentIntervention === INTERVENTIONS.SHELTER_IN_PLACE
-        ? formatIntervention(INTERVENTIONS.SHELTER_IN_PLACE, ' (lax)')
-        : formatIntervention(INTERVENTIONS.SOCIAL_DISTANCING),
-    type: projection.isInferred ? 'spline' : 'areaspline',
-    data: data[1].data,
-    marker: {
-      symbol: 'circle',
-    },
-    condensedLegend: {
-      condensedName:
-        currentIntervention === INTERVENTIONS.SHELTER_IN_PLACE
-          ? condensedFormatIntervention(
-              INTERVENTIONS.SHELTER_IN_PLACE,
-              ' (lax)',
-            )
-          : condensedFormatIntervention(INTERVENTIONS.SOCIAL_DISTANCING),
-
-      bgColor: projections.getChartSeriesColorMap().socialDistancingSeries,
-    },
   };
 
   const projected = {
@@ -87,7 +64,7 @@ const ModelChart = ({
       symbol: 'circle',
     },
     condensedLegend: {
-      bgColor: projections.getChartSeriesColorMap().projectedSeries,
+      bgColor: COLORS.PROJECTED,
     },
     legendIndex: 3,
   };
@@ -102,7 +79,7 @@ const ModelChart = ({
       symbol: 'circle',
     },
     condensedLegend: {
-      bgColor: projections.getChartSeriesColorMap().projectedSeries,
+      bgColor: 'black',
     },
     legendIndex: 1,
   };
@@ -288,8 +265,8 @@ const ModelChart = ({
         <Wrapper projections={projections} isInferred={projection.isInferred}>
           <Chart options={options} />
           <CondensedLegend>
-            {[noAction, socialDistancing, shelterInPlace, availableBeds]
-              .filter(intervention => intervention.visible !== false)
+            {[previousEstimates, noAction, projected]
+              .filter(series => series.visible !== false)
               .map(CondensedLegendItem)}
           </CondensedLegend>
         </Wrapper>

--- a/src/components/MapSelectors/GlobalSelector.js
+++ b/src/components/MapSelectors/GlobalSelector.js
@@ -9,7 +9,6 @@ import US_STATE_DATASET from './datasets/us_states_dataset_01_02_2020';
 import useMediaQuery from '@material-ui/core/useMediaQuery';
 
 import {
-  STATE_TO_INTERVENTION,
   STATE_TO_CALCULATED_INTERVENTION_COLOR,
   FIPS_CODE_TO_CALCULATED_INTERVENTION_COLOR,
 } from 'enums/interventions';
@@ -31,7 +30,6 @@ import {
 } from './MapSelectors.style';
 
 const StateItem = ({ dataset }) => {
-  const intervention = STATE_TO_INTERVENTION[dataset.state_code];
   const fillColor = STATE_TO_CALCULATED_INTERVENTION_COLOR[dataset.state_code];
 
   return (
@@ -48,10 +46,7 @@ const StateItem = ({ dataset }) => {
       <div>
         <div>{dataset.state}</div>
         <StyledResultsMenuSubText>
-          <span>
-            {intervention && <span>{intervention} • </span>}{' '}
-            {ShortNumber(dataset.population)} residents
-          </span>
+          <span>{ShortNumber(dataset.population)} residents</span>
         </StyledResultsMenuSubText>
       </div>
     </StyledResultsMenuOption>

--- a/src/models/Projections.ts
+++ b/src/models/Projections.ts
@@ -246,22 +246,6 @@ export class Projections {
   populateInterventions(
     summaryWithTimeseriesMap: RegionSummaryWithTimeseriesMap,
   ) {
-    const fipsBlacklist = [
-      '13275',
-      '18019',
-      '22089',
-      '22101',
-      '24021',
-      '28025',
-      '28083',
-      '31079',
-      '36079',
-      '39035',
-      '39109',
-      '41047',
-      '47065',
-      '50007',
-    ];
     for (const intervention in summaryWithTimeseriesMap) {
       const summaryWithTimeseries = summaryWithTimeseriesMap[intervention];
       let projection = null;
@@ -277,15 +261,8 @@ export class Projections {
       } else if (intervention === INTERVENTIONS.SHELTER_IN_PLACE) {
         this.distancing = { now: projection };
       } else if (intervention === INTERVENTIONS.PROJECTED) {
-        if (
-          !this.county ||
-          fipsBlacklist.indexOf(this.county.full_fips_code) === -1
-        ) {
-          this.projected = projection;
-          this.supportsInferred = !!this.projected;
-        } else {
-          console.log('Blacklisted inference projection');
-        }
+        this.projected = projection;
+        this.supportsInferred = !!this.projected;
       } else if (intervention === INTERVENTIONS.SOCIAL_DISTANCING) {
         this.distancingPoorEnforcement = { now: projection };
       }

--- a/src/screens/Embed/ChartsTab.js
+++ b/src/screens/Embed/ChartsTab.js
@@ -4,7 +4,7 @@ import ModelChart from 'components/Charts/ModelChart';
 
 import { EmbedChartContainer } from './Embed.style';
 
-export default function ChartsTab({ projections, currentIntervention }) {
+export default function ChartsTab({ projections }) {
   return (
     <EmbedChartContainer>
       <ModelChart
@@ -12,7 +12,6 @@ export default function ChartsTab({ projections, currentIntervention }) {
         height={290}
         subtitle="Hospitalizations over time"
         projections={projections}
-        currentIntervention={currentIntervention}
       />
     </EmbedChartContainer>
   );

--- a/src/screens/Embed/Embed.js
+++ b/src/screens/Embed/Embed.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import React, { useState, useMemo } from 'react';
 import { useParams } from 'react-router-dom';
-import { STATES, STATE_TO_INTERVENTION } from 'enums';
+import { STATES } from 'enums';
 import Tabs from '@material-ui/core/Tabs';
 import Tab from '@material-ui/core/Tab';
 import Drawer from '@material-ui/core/Drawer';
@@ -59,7 +59,7 @@ export default function Embed() {
 
   const projections = useProjections(location, selectedCounty);
   const locationName = STATES[location];
-  const intervention = STATE_TO_INTERVENTION[location];
+
   if (!projections) {
     return null;
   }
@@ -87,7 +87,6 @@ export default function Embed() {
           location={location}
           locationName={locationName}
           countyName={selectedCounty?.county}
-          intervention={intervention}
           projections={projections}
         />
         <Tabs value={tabState} variant="fullWidth" onChange={handleTabChange}>
@@ -100,16 +99,12 @@ export default function Embed() {
           <ProjectionsTab
             cases={cases}
             deaths={deaths}
-            intervention={intervention}
             totalPopulation={totalPopulation}
             deathsPercentage={deathsPercentage}
             populationPercentage={populationPercentage}
           />
         ) : (
-          <ChartsTab
-            projections={projections}
-            currentIntervention={intervention}
-          />
+          <ChartsTab projections={projections} />
         )}
       </EmbedContentContainer>
       <EmbedFooter onShare={() => setShareDrawerOpen(true)} />

--- a/src/screens/Embed/ProjectionsTab.js
+++ b/src/screens/Embed/ProjectionsTab.js
@@ -2,8 +2,6 @@ import React from 'react';
 import Grid from '@material-ui/core/Grid';
 import Box from '@material-ui/core/Box';
 import PeopleIcon from '@material-ui/icons/People';
-import InterventionIcon from 'assets/images/interventionIcon';
-import { INTERVENTION_COLOR_MAP } from 'enums';
 import {
   H1Statistic,
   PaddedGridItem,
@@ -17,7 +15,6 @@ import {
 export default function DataPage({
   cases,
   deaths,
-  intervention,
   totalPopulation,
   deathsPercentage,
   populationPercentage,
@@ -55,7 +52,6 @@ export default function DataPage({
       </Grid>
       <Grid container item xs={12}>
         <TotalPopulation population={totalPopulation} />
-        <CurrentIntervention intervention={intervention} />
       </Grid>
     </Grid>
   );
@@ -63,20 +59,10 @@ export default function DataPage({
 
 function TotalPopulation({ population }) {
   return (
-    <PaddedGridItem br bt bb xs={6} direction="column">
+    <PaddedGridItem br bt bb xs={12} direction="column">
       <PeopleIcon />
       <H3Statistic>{new Intl.NumberFormat().format(population)}</H3Statistic>
       <H4Statistic>Total Population</H4Statistic>
-    </PaddedGridItem>
-  );
-}
-
-function CurrentIntervention({ intervention }) {
-  return (
-    <PaddedGridItem bt bb xs={6} direction="column">
-      <InterventionIcon color={INTERVENTION_COLOR_MAP[intervention]} />
-      <H3Statistic>{intervention}</H3Statistic>
-      <H4Statistic>Official Policy</H4Statistic>
     </PaddedGridItem>
   );
 }


### PR DESCRIPTION
This is a precursor to make my next PR possible which deletes ~750 lines of code (related to state interventions, social distancing, stay-at-home, etc.).  The changes are separated into 3 different commits if that's easier to review.

It contains 4 behavioral changes:

### 1. No longer show intervention in search dropdown.
**Before:**
![image](https://user-images.githubusercontent.com/206364/81529188-2b662e80-9313-11ea-9b33-4bfae8f2504f.png)

**After:**
![image](https://user-images.githubusercontent.com/206364/81529195-3325d300-9313-11ea-805d-feac7b6402d0.png)

---
### 2. It removes "current intervention" from embeds:
**Before:**
![image](https://user-images.githubusercontent.com/206364/81529338-8566f400-9313-11ea-857e-5e168157500f.png)

**After:**
![image](https://user-images.githubusercontent.com/206364/81529402-a4658600-9313-11ea-99d9-5f02a4f4a3e7.png)

---
### 3. It fixes the legend on the embed projections tab:
**Before:**
![image](https://user-images.githubusercontent.com/206364/81530343-8a2ca780-9315-11ea-8a95-e847d308d890.png)

**After:**
![image](https://user-images.githubusercontent.com/206364/81530358-90228880-9315-11ea-9d35-2fd26bf905ce.png)

---
### 4. It removes the county blacklist for using inference projections.  
The 14 counties on the blacklist were the only places on the site where we were still showing a "stay at home" projection.  But I checked all of them, and the inference projection is virtually identical to the stay-at-home projection, so I don't think the blacklist is necessary any more.  If we want to keep it, I suggest we just treat these counties as no-data counties rather than showing stay-at-home.

Example: Hall County, NE
**Before:**
![image](https://user-images.githubusercontent.com/206364/81529826-88161900-9314-11ea-92dc-8bd554d2fbee.png)

**After:**
![image](https://user-images.githubusercontent.com/206364/81529866-96643500-9314-11ea-8f05-5b5c38781c55.png)
