### PR TITLE
Jt sharing text update

### DIFF
--- a/src/components/AppBar/AppBar.tsx
+++ b/src/components/AppBar/AppBar.tsx
@@ -115,9 +115,9 @@ const _AppBar = () => {
 
   const shareURL = `https://covidactnow.org${match ? match.url : ''}`;
   const hashtag = 'COVIDActNow';
-  const locationShareTitle = `@CovidActNow has real-time modeling and metrics to help assess how ${locationName} can reopen safely. Check it out: `;
+  const locationShareTitle = `See ${locationName}'s reopening risk on @CovidActNow, a dashboard to help America reopen safely: `;
   const defaultShareTitle =
-    '@CovidActNow has real-time modeling and metrics to help America reopen safely. Check it out:';
+    'Check out @CovidActNow, clear data and a simple dashboard to help America reopen safely: ';
 
   const shareTitle = locationName ? locationShareTitle : defaultShareTitle;
 

--- a/src/components/AppBar/AppBar.tsx
+++ b/src/components/AppBar/AppBar.tsx
@@ -117,7 +117,7 @@ const _AppBar = () => {
   const hashtag = 'COVIDActNow';
   const locationShareTitle = `See ${locationName}'s reopening risk on @CovidActNow, dashboards to help America reopen safely: `;
   const defaultShareTitle =
-    'Check out @CovidActNow, clear data and a simple dashboard to help America reopen safely: ';
+    'Check out @CovidActNow, data and dashboards to help America reopen safely: ';
 
   const shareTitle = locationName ? locationShareTitle : defaultShareTitle;
 

--- a/src/components/AppBar/AppBar.tsx
+++ b/src/components/AppBar/AppBar.tsx
@@ -115,7 +115,7 @@ const _AppBar = () => {
 
   const shareURL = `https://covidactnow.org${match ? match.url : ''}`;
   const hashtag = 'COVIDActNow';
-  const locationShareTitle = `See ${locationName}'s reopening risk on @CovidActNow, a dashboard to help America reopen safely: `;
+  const locationShareTitle = `See ${locationName}'s reopening risk on @CovidActNow, dashboards to help America reopen safely: `;
   const defaultShareTitle =
     'Check out @CovidActNow, clear data and a simple dashboard to help America reopen safely: ';
 

--- a/src/components/ShareBlock/ShareBlock.tsx
+++ b/src/components/ShareBlock/ShareBlock.tsx
@@ -57,7 +57,7 @@ const ShareBlock = ({
   const url = shareURL || 'https://covidactnow.org/';
   const quote =
     shareQuote ||
-    '@CovidActNow has real-time modeling and metrics to help America reopen safely. Check it out:';
+    'Check out @CovidActNow, data and predictions to help America reopen safely: ';
   const hashtag = 'COVIDActNow';
 
   const trackShare = (target: string) => {

--- a/src/components/ShareBlock/ShareModelBlock.js
+++ b/src/components/ShareBlock/ShareModelBlock.js
@@ -17,7 +17,7 @@ const ShareModelBlock = ({
   const shareURL = `https://covidactnow.org/us/${stateId.toLowerCase()}${
     county ? `/county/${county.county_url_name}` : ''
   }`;
-  const shareQuote = `@CovidActNow has real-time modeling and metrics to help assess how ${displayName} can reopen safely. Check it out: `;
+  const shareQuote = `See ${displayName}'s COVID statistics, predictions, and reopening risk on @CovidActNow: `;
   const [showEmbedPreviewModal, setShowEmbedPreviewModal] = useState(false);
 
   return (


### PR DESCRIPTION
I noticed that all our share text started with '@covidactnow...' If you start a tweet with an “@handle...”, only people who follow both the tweeter and the @handle will see the tweet. 

So, net-net, virtually nobody is seeing tweets about us from our sharing buttons.

This PR fixes that (updating 3 different files)

cc @schlosser @igorkofman @mikelehen for one of you to review