### PR TITLE
Redirect if invalid state or county in URL

### DIFF
--- a/src/components/AppBar/AppBar.tsx
+++ b/src/components/AppBar/AppBar.tsx
@@ -49,7 +49,7 @@ function locationNameFromMatch(
   const state = STATES[stateId];
   const countyId = match.params.county;
   if (!state) {
-    // if an invalid state is typed into the URL, redirect to homepage
+    // if invalid state entered in URL, redirect to homepage
     window.location.href = '/';
   }
 
@@ -64,7 +64,7 @@ function locationNameFromMatch(
   );
 
   if (!countyData) {
-    // if an invalid county is typed into the URL, redirect to homepage
+    // if invalid county entered in URL, redirect to homepage
     window.location.href = '/';
   }
 

--- a/src/components/AppBar/AppBar.tsx
+++ b/src/components/AppBar/AppBar.tsx
@@ -48,15 +48,27 @@ function locationNameFromMatch(
   const stateId = match.params.id.toUpperCase() as keyof typeof STATES;
   const state = STATES[stateId];
   const countyId = match.params.county;
+  if (!state) {
+    // if an invalid state is typed into the URL, redirect to homepage
+    window.location.href = '/';
+  }
+
   if (!countyId) {
     return state;
   }
 
-  const county = _.find(
+  const countyData = _.find(
     // @ts-ignore TODO(aj): Fix this when features/typescript3 merges
     US_STATE_DATASET.state_county_map_dataset[stateId].county_dataset,
     ['county_url_name', countyId],
-  ).county;
+  );
+
+  if (!countyData) {
+    // if an invalid county is typed into the URL, redirect to homepage
+    window.location.href = '/';
+  }
+
+  const county = countyData.county;
   return `${county}, ${state}`;
 }
 


### PR DESCRIPTION
- Redirects to homepage if an invalid state or county is entered into URL
- Previously: invalid county would return a blank page, invalid state would return a blank page with CAN header/footer