### PR TITLE
Charts - Fix the tooltip for the current R(t) value

### DIFF
--- a/src/components/Charts/ChartRt.tsx
+++ b/src/components/Charts/ChartRt.tsx
@@ -144,7 +144,7 @@ const ChartRt = ({
 
   const getTooltipBody = (d: PointRt): string => {
     const Rt = formatDecimal(getRt(d));
-    return getDate(d) < truncationDate ? `Rt ${Rt}` : `Rt ${Rt} (preliminary)`;
+    return getDate(d) <= truncationDate ? `Rt ${Rt}` : `Rt ${Rt} (preliminary)`;
   };
 
   return (


### PR DESCRIPTION
The most recent confirmed value for R(t) is shown as "preliminary", this is a bug. This PR fixes that (the screenshot doesn't show it, but the cursor is hovering the highlighted point)

**Production** 
![image](https://user-images.githubusercontent.com/114084/82388277-144bce80-99ee-11ea-87c9-f7b14d06044a.png)

**This branch** (I should have taken a screenshot of the same location, but I didn't, sorry!)
![image](https://user-images.githubusercontent.com/114084/82388262-07c77600-99ee-11ea-852f-b7f7074265e3.png)
