### PR TITLE
Chart Remake - Positive Test Rate

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@material-ui/core": "^4.9.7",
     "@material-ui/icons": "^4.9.1",
     "@types/d3-array": "^2.0.0",
+    "@types/d3-shape": "^1.3.2",
     "@vx/axis": "^0.0.196",
     "@vx/clip-path": "^0.0.196",
     "@vx/curve": "^0.0.196",

--- a/src/components/Charts/ChartContainer.tsx
+++ b/src/components/Charts/ChartContainer.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { localPoint } from '@vx/event';
+import { Group } from '@vx/group';
+import { useTooltip } from '@vx/tooltip';
+import HoverOverlay from './HoverOverlay';
+import * as Style from './Charts.style';
+
+const ChartContainer = <T extends unknown>({
+  width,
+  height,
+  marginTop = 5,
+  marginBottom = 40,
+  marginLeft = 40,
+  marginRight = 5,
+  x,
+  y,
+  data,
+  renderMarker,
+  renderTooltip,
+  children,
+}: {
+  width: number;
+  height: number;
+  marginTop?: number;
+  marginBottom?: number;
+  marginLeft?: number;
+  marginRight?: number;
+  x: (d: T) => number;
+  y: (d: T) => number;
+  data: T[];
+  renderMarker: (d: T) => React.ReactNode;
+  renderTooltip: (d: T) => React.ReactNode;
+  children: React.ReactNode;
+}) => {
+  const chartWidth = width - marginLeft - marginRight;
+  const chartHeight = height - marginTop - marginBottom;
+
+  const tooltip = useTooltip<T>();
+  const { tooltipData, tooltipOpen, showTooltip, hideTooltip } = tooltip;
+
+  const onMouseOver = (
+    event: React.MouseEvent<SVGPathElement, MouseEvent>,
+    d: T,
+  ) => {
+    // @ts-ignore - typing bug
+    const coords = localPoint(event.target.ownerSVGElement, event);
+    if (!coords) return;
+    showTooltip({
+      tooltipLeft: coords.x,
+      tooltipTop: coords.y,
+      tooltipData: d,
+    });
+  };
+
+  return (
+    <Style.PositionRelative>
+      <svg width={width} height={height}>
+        <Group left={marginLeft} top={marginTop}>
+          {children}
+          {tooltipOpen && tooltipData && renderMarker(tooltipData)}
+          <HoverOverlay
+            width={chartWidth}
+            height={chartHeight}
+            data={data}
+            x={x}
+            y={y}
+            onMouseOver={onMouseOver}
+            onMouseOut={hideTooltip}
+          />
+        </Group>
+      </svg>
+      {tooltipOpen && tooltipData && renderTooltip(tooltipData)}
+    </Style.PositionRelative>
+  );
+};
+
+export default ChartContainer;

--- a/src/components/Charts/ChartPositiveTestRate.tsx
+++ b/src/components/Charts/ChartPositiveTestRate.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import ChartZones from './ChartZones';
+import { POSITIVE_TESTS_LEVEL_INFO_MAP } from 'common/metrics/positive_rate';
+import { formatPercent } from './utils';
+
+const CAP_Y = 0.4;
+
+const getTooltipText = (valueY: number) =>
+  valueY > CAP_Y
+    ? `Positive Tests > ${formatPercent(CAP_Y, 1)}`
+    : `Positive Tests ${formatPercent(valueY, 1)}`;
+
+const ChartPositiveTests = ({
+  columnData,
+  height = 400,
+}: {
+  columnData: any[];
+  height?: number;
+}) => (
+  <ChartZones
+    height={height}
+    columnData={columnData}
+    capY={CAP_Y}
+    zones={POSITIVE_TESTS_LEVEL_INFO_MAP}
+    getTooltipText={getTooltipText}
+  />
+);
+
+export default ChartPositiveTests;

--- a/src/components/Charts/ChartRt.tsx
+++ b/src/components/Charts/ChartRt.tsx
@@ -1,48 +1,35 @@
 import React from 'react';
 import moment from 'moment';
-import { isUndefined } from 'lodash';
+import { isDate } from 'lodash';
 import { min as d3min, max as d3max } from 'd3-array';
+import { AxisBottom, AxisLeft } from '@vx/axis';
+import { curveNatural } from '@vx/curve';
+import { GridRows } from '@vx/grid';
 import { Group } from '@vx/group';
 import { ParentSize } from '@vx/responsive';
 import { scaleLinear, scaleTime } from '@vx/scale';
-import { GridRows } from '@vx/grid';
-import { curveNatural } from '@vx/curve';
-import { AxisBottom, AxisLeft } from '@vx/axis';
-import { LinePath, Area } from '@vx/shape';
-import { useTooltip } from '@vx/tooltip';
-import { localPoint } from '@vx/event';
-import { LevelInfoMap, Level } from 'common/level';
+import { Area } from '@vx/shape';
 import { Column, RtRange, RT_TRUNCATION_DAYS } from 'common/models/Projection';
-import { CASE_GROWTH_RATE_LEVEL_INFO_MAP } from 'common/metrics/case_growth';
+import { CASE_GROWTH_RATE_LEVEL_INFO_MAP as zones } from 'common/metrics/case_growth';
 import BoxedAnnotation from './BoxedAnnotation';
-import HoverOverlay from './HoverOverlay';
 import RectClipGroup from './RectClipGroup';
+import ZoneAnnotation from './ZoneAnnotation';
+import ZoneLinePath from './ZoneLinePath';
+import ChartContainer from './ChartContainer';
+import Tooltip from './Tooltip';
+import * as Style from './Charts.style';
 import {
+  computeTickPositions,
   formatDecimal,
   getChartRegions,
   getTruncationDate,
   getZoneByValue,
   last,
+  getAxisLimits,
 } from './utils';
-import * as Style from './Charts.style';
 
 type PointRt = Omit<Column, 'y'> & {
   y: RtRange;
-};
-
-const computeTickPositions = (
-  minY: number,
-  maxY: number,
-  zones: LevelInfoMap,
-) => {
-  const maxZones = zones[Level.MEDIUM].upperLimit;
-  const maxTick = maxY < maxZones ? 1.5 * maxZones : maxY;
-  return [
-    minY,
-    zones[Level.LOW].upperLimit,
-    zones[Level.MEDIUM].upperLimit,
-    maxTick,
-  ];
 };
 
 const getDate = (d: PointRt) => new Date(d.x);
@@ -51,13 +38,10 @@ const getYAreaHigh = (d: PointRt) => d?.y?.high;
 const getYAreaLow = (d: PointRt) => d?.y?.low;
 
 const hasData = (d: any) =>
-  !isUndefined(getDate(d)) &&
-  !isUndefined(getRt(d)) &&
-  !isUndefined(getYAreaLow(d)) &&
-  !isUndefined(getYAreaHigh(d));
-
-const getTooltipTitle = (d: PointRt): string =>
-  moment(getDate(d)).format('dddd, MMM D, YYYY');
+  isDate(getDate(d)) &&
+  Number.isFinite(getRt(d)) &&
+  Number.isFinite(getYAreaLow(d)) &&
+  Number.isFinite(getYAreaHigh(d));
 
 const ChartRt = ({
   columnData,
@@ -80,12 +64,14 @@ const ChartRt = ({
   const chartHeight = height - marginTop - marginBottom;
 
   const data: PointRt[] = columnData.filter(hasData);
+  const dates: Date[] = columnData.map(getDate).filter(isDate);
 
-  const minDate = d3min(data, getDate) || new Date('2020-01-01');
+  const minDate = d3min(dates) || new Date('2020-01-01');
   const maxDate = moment().add(2, 'weeks').toDate();
 
   const yDataMin = 0;
   const yDataMax = d3max(data, getRt) || 1;
+  const [yAxisMin, yAxisMax] = getAxisLimits(yDataMin, yDataMax, zones);
 
   const xScale = scaleTime({
     domain: [minDate, maxDate],
@@ -93,23 +79,15 @@ const ChartRt = ({
   });
 
   const yScale = scaleLinear({
-    domain: [yDataMin, yDataMax],
+    domain: [yAxisMin, yAxisMax],
     range: [chartHeight, 0],
   });
 
   const getXCoord = (d: PointRt) => xScale(getDate(d));
   const getYCoord = (d: PointRt) => yScale(getRt(d));
 
-  const yTicks = computeTickPositions(
-    yDataMin,
-    yDataMax,
-    CASE_GROWTH_RATE_LEVEL_INFO_MAP,
-  );
-  const regions = getChartRegions(
-    yDataMin,
-    yDataMax,
-    CASE_GROWTH_RATE_LEVEL_INFO_MAP,
-  );
+  const yTicks = computeTickPositions(yAxisMin, yAxisMax, zones);
+  const regions = getChartRegions(yAxisMin, yAxisMax, zones);
 
   const lastValidDate = getDate(last(data));
 
@@ -119,156 +97,119 @@ const ChartRt = ({
   const truncationPoint = last(prevData);
   const truncationRt = getRt(truncationPoint);
   const yTruncationRt = yScale(truncationRt);
-  const truncationZone = getZoneByValue(
-    truncationRt,
-    CASE_GROWTH_RATE_LEVEL_INFO_MAP,
+  const truncationZone = getZoneByValue(truncationRt, zones);
+
+  const renderTooltip = (d: PointRt) => {
+    const date = getDate(d);
+    const disclaimer = date < truncationDate ? '' : '(preliminary)';
+    return (
+      <Tooltip
+        left={marginLeft + getXCoord(d)}
+        top={marginTop + getYCoord(d)}
+        date={date}
+        text={`Rt ${formatDecimal(getRt(d), 1)} ${disclaimer}`}
+      />
+    );
+  };
+
+  const renderMarker = (d: PointRt) => (
+    <Style.CircleMarker
+      cx={getXCoord(d)}
+      cy={getYCoord(d)}
+      r={6}
+      fill={getZoneByValue(getRt(d), zones).color}
+    />
   );
 
-  const { tooltipData, tooltipOpen, showTooltip, hideTooltip } = useTooltip<
-    PointRt
-  >();
-
-  const onMouseOver = (
-    event: React.MouseEvent<SVGPathElement, MouseEvent>,
-    d: PointRt,
-  ) => {
-    // @ts-ignore - typing bug
-    const coords = localPoint(event.target.ownerSVGElement, event);
-    if (!coords) return;
-    showTooltip({
-      tooltipLeft: coords.x,
-      tooltipTop: coords.y,
-      tooltipData: d,
-    });
-  };
-
-  const getTooltipBody = (d: PointRt): string => {
-    const Rt = formatDecimal(getRt(d));
-    return getDate(d) <= truncationDate ? `Rt ${Rt}` : `Rt ${Rt} (preliminary)`;
-  };
-
   return (
-    <Style.PositionRelative>
-      <svg width={width} height={height}>
-        <Group left={marginLeft} top={marginTop}>
-          <RectClipGroup width={chartWidth} height={chartHeight}>
-            <Style.SeriesArea>
-              <Area
-                data={data}
-                x={getXCoord}
-                y0={(d: PointRt) => yScale(getYAreaLow(d))}
-                y1={(d: PointRt) => yScale(getYAreaHigh(d))}
-                curve={curveNatural}
-              />
-            </Style.SeriesArea>
-            {regions.map((region, i) => (
-              <Group key={`chart-region-${i}`}>
-                <RectClipGroup
-                  y={yScale(region.valueTo)}
-                  width={chartWidth}
-                  height={yScale(region.valueFrom) - yScale(region.valueTo)}
-                >
-                  <Style.SeriesLine stroke={region.color}>
-                    <LinePath
-                      data={prevData}
-                      x={getXCoord}
-                      y={getYCoord}
-                      curve={curveNatural}
-                    />
-                  </Style.SeriesLine>
-                  <Style.SeriesDashed stroke={region.color}>
-                    <LinePath
-                      data={restData}
-                      x={getXCoord}
-                      y={getYCoord}
-                      curve={curveNatural}
-                    />
-                  </Style.SeriesDashed>
-                </RectClipGroup>
-                <Style.RegionAnnotation
-                  color={region.color}
-                  isActive={truncationZone.name === region.name}
-                >
-                  <BoxedAnnotation
-                    x={xScale(maxDate) - 10}
-                    y={yScale(0.5 * (region.valueFrom + region.valueTo))}
-                    text={region.name}
-                  />
-                </Style.RegionAnnotation>
-              </Group>
-            ))}
-          </RectClipGroup>
-          <Style.LineGrid>
-            <GridRows width={chartWidth} scale={yScale} tickValues={yTicks} />
-          </Style.LineGrid>
-          {/* R(t) value and marker, adjusts the position if the text is too close to the top */}
-          <Style.TextAnnotation>
-            <BoxedAnnotation
-              x={xScale(getDate(truncationPoint))}
-              y={yTruncationRt < 60 ? yTruncationRt + 30 : yTruncationRt - 30}
-              text={formatDecimal(truncationRt)}
-            />
-          </Style.TextAnnotation>
-          <Style.CircleMarker
-            cx={xScale(getDate(truncationPoint))}
-            cy={yTruncationRt}
-            r={6}
-          />
-          <Style.Axis>
-            <AxisBottom
-              top={chartHeight}
-              scale={xScale}
-              numTicks={Math.round(chartWidth / 100)}
-            />
-          </Style.Axis>
-          <Style.Axis>
-            <AxisLeft
-              top={marginTop}
-              scale={yScale}
-              tickValues={yTicks}
-              hideAxisLine
-              hideTicks
-              hideZero
-            />
-          </Style.Axis>
-          {tooltipOpen && tooltipData && (
-            <Style.CircleMarker
-              cx={getXCoord(tooltipData)}
-              cy={getYCoord(tooltipData)}
-              r={6}
-              fill={
-                getZoneByValue(
-                  getRt(tooltipData),
-                  CASE_GROWTH_RATE_LEVEL_INFO_MAP,
-                ).color
-              }
-            />
-          )}
-          <HoverOverlay
-            width={chartWidth}
-            height={chartHeight}
+    <ChartContainer<PointRt>
+      data={data}
+      x={getXCoord}
+      y={getYCoord}
+      renderMarker={renderMarker}
+      renderTooltip={renderTooltip}
+      width={width}
+      height={height}
+      marginTop={marginTop}
+      marginBottom={marginBottom}
+      marginLeft={marginLeft}
+      marginRight={marginRight}
+    >
+      <RectClipGroup width={chartWidth} height={chartHeight}>
+        <Style.SeriesArea>
+          <Area
             data={data}
             x={getXCoord}
-            y={getYCoord}
-            onMouseOver={onMouseOver}
-            onMouseOut={hideTooltip}
+            y0={(d: PointRt) => yScale(getYAreaLow(d))}
+            y1={(d: PointRt) => yScale(getYAreaHigh(d))}
+            curve={curveNatural}
           />
-        </Group>
-      </svg>
-      {tooltipOpen && tooltipData && (
-        <Style.Tooltip
-          style={{
-            top: marginTop + getYCoord(tooltipData),
-            left: marginLeft + getXCoord(tooltipData),
-          }}
-        >
-          <Style.TooltipTitle>
-            {getTooltipTitle(tooltipData)}
-          </Style.TooltipTitle>
-          <div>{getTooltipBody(tooltipData)}</div>
-        </Style.Tooltip>
-      )}
-    </Style.PositionRelative>
+        </Style.SeriesArea>
+        {regions.map((region, i) => (
+          <Group key={`chart-region-${i}`}>
+            <Style.SeriesLine stroke={region.color}>
+              <ZoneLinePath<PointRt>
+                data={prevData}
+                x={getXCoord}
+                y={getYCoord}
+                region={region}
+                width={chartWidth}
+                yScale={yScale}
+              />
+            </Style.SeriesLine>
+            <Style.SeriesDashed stroke={region.color}>
+              <ZoneLinePath<PointRt>
+                data={restData}
+                x={getXCoord}
+                y={getYCoord}
+                region={region}
+                width={chartWidth}
+                yScale={yScale}
+              />
+            </Style.SeriesDashed>
+            <ZoneAnnotation
+              color={region.color}
+              name={region.name}
+              isActive={truncationZone.name === region.name}
+              x={xScale(maxDate) - 10}
+              y={yScale(0.5 * (region.valueFrom + region.valueTo))}
+            />
+          </Group>
+        ))}
+      </RectClipGroup>
+      <Style.LineGrid>
+        <GridRows width={chartWidth} scale={yScale} tickValues={yTicks} />
+      </Style.LineGrid>
+      <Style.TextAnnotation>
+        <BoxedAnnotation
+          x={xScale(getDate(truncationPoint))}
+          y={yTruncationRt < 60 ? yTruncationRt + 30 : yTruncationRt - 30}
+          text={formatDecimal(truncationRt)}
+        />
+      </Style.TextAnnotation>
+      <Style.CircleMarker
+        cx={xScale(getDate(truncationPoint))}
+        cy={yTruncationRt}
+        r={6}
+      />
+      <Style.Axis>
+        <AxisBottom
+          top={chartHeight}
+          scale={xScale}
+          numTicks={Math.round(chartWidth / 100)}
+        />
+      </Style.Axis>
+      <Style.Axis>
+        <AxisLeft
+          top={marginTop}
+          scale={yScale}
+          tickValues={yTicks}
+          hideAxisLine
+          hideTicks
+          hideZero
+        />
+      </Style.Axis>
+    </ChartContainer>
   );
 };
 
@@ -281,16 +222,14 @@ const ChartRtAutosize = ({
 }) => (
   <Style.ChartContainer>
     <ParentSize>
-      {({ width }) => {
-        return (
-          <ChartRt
-            width={width}
-            height={height}
-            marginLeft={48}
-            columnData={columnData}
-          />
-        );
-      }}
+      {({ width }) => (
+        <ChartRt
+          width={width}
+          height={height}
+          marginLeft={48}
+          columnData={columnData}
+        />
+      )}
     </ParentSize>
   </Style.ChartContainer>
 );

--- a/src/components/Charts/ChartZones.tsx
+++ b/src/components/Charts/ChartZones.tsx
@@ -1,0 +1,211 @@
+import React from 'react';
+import moment from 'moment';
+import { isDate } from 'lodash';
+import { min as d3min, max as d3max } from 'd3-array';
+import { AxisBottom, AxisLeft } from '@vx/axis';
+import { curveLinear } from '@vx/curve';
+import { GridRows } from '@vx/grid';
+import { Group } from '@vx/group';
+import { ParentSize } from '@vx/responsive';
+import { scaleLinear, scaleTime } from '@vx/scale';
+import { Column } from 'common/models/Projection';
+import { LevelInfoMap } from 'common/level';
+import RectClipGroup from './RectClipGroup';
+import BoxedAnnotation from './BoxedAnnotation';
+import ZoneAnnotation from './ZoneAnnotation';
+import ZoneLinePath from './ZoneLinePath';
+import ChartContainer from './ChartContainer';
+import Tooltip from './Tooltip';
+import * as Style from './Charts.style';
+import {
+  getChartRegions,
+  computeTickPositions,
+  last,
+  formatPercent,
+  getZoneByValue,
+  getAxisLimits,
+} from './utils';
+
+type Point = Omit<Column, 'y'> & {
+  y: number;
+};
+
+const getDate = (d: Point) => new Date(d.x);
+const getY = (d: Point) => d.y;
+const hasData = (d: any) => isDate(getDate(d)) && Number.isFinite(getY(d));
+
+const ChartZones = ({
+  width,
+  height,
+  columnData,
+  zones,
+  marginTop = 5,
+  marginBottom = 40,
+  marginLeft = 40,
+  marginRight = 5,
+  capY,
+  getTooltipText,
+}: {
+  width: number;
+  height: number;
+  columnData: Point[];
+  zones: LevelInfoMap;
+  capY: number;
+  getTooltipText: (valueY: number) => string;
+  marginTop?: number;
+  marginBottom?: number;
+  marginLeft?: number;
+  marginRight?: number;
+}) => {
+  const chartWidth = width - marginLeft - marginRight;
+  const chartHeight = height - marginTop - marginBottom;
+
+  const data: Point[] = columnData.filter(hasData);
+  const dates: Date[] = columnData.map(getDate).filter(isDate);
+
+  const minDate = d3min(dates) || new Date('2020-01-01');
+  const maxDate = moment().add(2, 'weeks').toDate();
+
+  const xScale = scaleTime({
+    domain: [minDate, maxDate],
+    range: [0, chartWidth],
+  });
+
+  const yDataMin = 0;
+  const yDataMax = d3max(data, getY) || 1;
+  const [yAxisMin, yAxisMax] = getAxisLimits(yDataMin, yDataMax, zones);
+  const yMax = Math.min(capY, yAxisMax);
+
+  const yScale = scaleLinear({
+    domain: [yAxisMin, yMax],
+    range: [chartHeight, 0],
+  });
+
+  const getXCoord = (d: Point) => xScale(getDate(d));
+  const getYCoord = (d: Point) => yScale(Math.min(getY(d), capY));
+
+  const regions = getChartRegions(yAxisMin, yMax, zones);
+  const yTicks = computeTickPositions(yAxisMin, yMax, zones);
+
+  const lastPoint = last(data);
+  const lastPointY = getY(lastPoint);
+  const lastPointZone = getZoneByValue(lastPointY, zones);
+
+  const renderMarker = (d: Point) => (
+    <Style.CircleMarker
+      cx={getXCoord(d)}
+      cy={getYCoord(d)}
+      r={6}
+      fill={getZoneByValue(getY(d), zones).color}
+    />
+  );
+
+  const renderTooltip = (d: Point) => (
+    <Tooltip
+      top={marginTop + getYCoord(d)}
+      left={marginLeft + getXCoord(d)}
+      date={getDate(d)}
+      text={getTooltipText(getY(d))}
+    />
+  );
+
+  return (
+    <ChartContainer<Point>
+      data={data}
+      x={getXCoord}
+      y={getYCoord}
+      renderMarker={renderMarker}
+      renderTooltip={renderTooltip}
+      width={width}
+      height={height}
+      marginTop={marginTop}
+      marginBottom={marginBottom}
+      marginLeft={marginLeft}
+      marginRight={marginRight}
+    >
+      <RectClipGroup width={chartWidth} height={chartHeight}>
+        {regions.map((region, i) => (
+          <Group key={`chart-region-${i}`}>
+            <Style.SeriesLine stroke={region.color}>
+              <ZoneLinePath<Point>
+                data={data}
+                x={getXCoord}
+                y={getYCoord}
+                region={region}
+                width={chartWidth}
+                yScale={yScale}
+                curve={curveLinear}
+              />
+            </Style.SeriesLine>
+            <ZoneAnnotation
+              color={region.color}
+              name={region.name}
+              isActive={lastPointZone.name === region.name}
+              x={xScale(maxDate) - 10}
+              y={yScale(0.5 * (region.valueFrom + region.valueTo))}
+            />
+          </Group>
+        ))}
+      </RectClipGroup>
+      <Style.LineGrid>
+        <GridRows width={chartWidth} scale={yScale} tickValues={yTicks} />
+      </Style.LineGrid>
+      <Style.TextAnnotation>
+        <BoxedAnnotation
+          x={getXCoord(lastPoint) + 30}
+          y={getYCoord(lastPoint)}
+          text={formatPercent(lastPointY, 1)}
+        />
+      </Style.TextAnnotation>
+      <Style.Axis>
+        <AxisBottom
+          top={chartHeight}
+          scale={xScale}
+          numTicks={Math.round(chartWidth / 100)}
+        />
+      </Style.Axis>
+      <Style.Axis>
+        <AxisLeft
+          top={marginTop}
+          scale={yScale}
+          tickValues={yTicks}
+          hideAxisLine
+          hideTicks
+          hideZero
+          tickFormat={(num: number) => formatPercent(num, 0)}
+        />
+      </Style.Axis>
+    </ChartContainer>
+  );
+};
+
+const ChartZoneAutosize = ({
+  columnData,
+  zones,
+  capY,
+  getTooltipText,
+  height = 400,
+}: {
+  columnData: Point[];
+  zones: LevelInfoMap;
+  capY: number;
+  getTooltipText: (valueY: number) => string;
+  height?: number;
+}) => (
+  <Style.ChartContainer>
+    <ParentSize>
+      {({ width }) => (
+        <ChartZones
+          width={width}
+          height={height}
+          columnData={columnData}
+          zones={zones}
+          capY={capY}
+          getTooltipText={getTooltipText}
+        />
+      )}
+    </ParentSize>
+  </Style.ChartContainer>
+);
+
+export default ChartZoneAutosize;

--- a/src/components/Charts/Charts.style.ts
+++ b/src/components/Charts/Charts.style.ts
@@ -17,7 +17,7 @@ const charts = {
 };
 
 const tooltip = {
-  width: '160px',
+  width: '200px',
   boxShadow: `3px 3px 5px ${palette.chart.tooltip.shadow}`,
   fontSizeTitle: '11px',
 };

--- a/src/components/Charts/Tooltip.tsx
+++ b/src/components/Charts/Tooltip.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import moment from 'moment';
+import * as Style from './Charts.style';
+
+const formatDate = (date: Date): string =>
+  moment(date).format('dddd, MMM D, YYYY');
+
+const Tooltip = ({
+  date,
+  text,
+  left,
+  top,
+}: {
+  date: Date;
+  text: string;
+  left: number;
+  top: number;
+}) => (
+  <Style.Tooltip style={{ top, left }}>
+    <Style.TooltipTitle>{formatDate(date)}</Style.TooltipTitle>
+    {text}
+  </Style.Tooltip>
+);
+
+export default Tooltip;

--- a/src/components/Charts/ZoneAnnotation.tsx
+++ b/src/components/Charts/ZoneAnnotation.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import BoxedAnnotation from './BoxedAnnotation';
+import * as Style from './Charts.style';
+
+const ZoneAnnotation = ({
+  color,
+  name,
+  isActive,
+  x,
+  y,
+}: {
+  color: string;
+  name: string;
+  isActive: boolean;
+  x: number;
+  y: number;
+}) => (
+  <Style.RegionAnnotation color={color} isActive={isActive}>
+    <BoxedAnnotation x={x} y={y} text={name} />
+  </Style.RegionAnnotation>
+);
+
+export default ZoneAnnotation;

--- a/src/components/Charts/ZoneLinePath.tsx
+++ b/src/components/Charts/ZoneLinePath.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import RectClipGroup from './RectClipGroup';
+import { curveNatural } from '@vx/curve';
+import { CurveFactory } from 'd3-shape';
+import { LinePath } from '@vx/shape';
+import { Region } from './utils';
+
+const ZoneLinePath = <T extends unknown>({
+  data,
+  x,
+  y,
+  width,
+  region,
+  yScale,
+  curve = curveNatural,
+}: {
+  data: T[];
+  x: (d: T) => number;
+  y: (d: T) => number;
+  width: number;
+  region: Region;
+  yScale: (num: number) => number;
+  curve?: CurveFactory;
+}) => (
+  <RectClipGroup
+    y={yScale(region.valueTo)}
+    width={width}
+    height={yScale(region.valueFrom) - yScale(region.valueTo)}
+  >
+    <LinePath data={data} x={x} y={y} curve={curve} />
+  </RectClipGroup>
+);
+
+export default ZoneLinePath;

--- a/src/components/Charts/index.tsx
+++ b/src/components/Charts/index.tsx
@@ -1,1 +1,3 @@
 export { default as ChartRt } from './ChartRt';
+export { default as ChartZones } from './ChartZones';
+export { default as ChartPositiveTestRate } from './ChartPositiveTestRate';

--- a/src/components/Charts/utils.ts
+++ b/src/components/Charts/utils.ts
@@ -221,7 +221,18 @@ export const getTruncationDate = (date: Date, truncationDays: number) =>
 export const randomizeId = (name: string): string =>
   `${name}-${Math.random().toFixed(9)}`;
 
-export const getChartRegions = (minY: number, maxY: number, zones: Zones) => [
+export interface Region {
+  valueFrom: number;
+  valueTo: number;
+  name: string;
+  color: string;
+}
+
+export const getChartRegions = (
+  minY: number,
+  maxY: number,
+  zones: Zones,
+): Region[] => [
   {
     valueFrom: minY,
     valueTo: zones[Level.LOW].upperLimit,
@@ -249,4 +260,26 @@ export const getZoneByValue = (value: number, zones: Zones) => {
   return value > zones[Level.MEDIUM].upperLimit
     ? zones[Level.HIGH]
     : zones[Level.MEDIUM];
+};
+
+export const computeTickPositions = (
+  minY: number,
+  maxY: number,
+  zones: Zones,
+) => {
+  const maxZones = zones[Level.MEDIUM].upperLimit;
+  const maxTick = maxY < maxZones ? 1.5 * maxZones : maxY;
+  return [
+    minY,
+    zones[Level.LOW].upperLimit,
+    zones[Level.MEDIUM].upperLimit,
+    maxTick,
+  ];
+};
+
+export const getAxisLimits = (minY: number, maxY: number, zones: Zones) => {
+  const tickPositions = computeTickPositions(minY, maxY, zones);
+  const minTickPosition = _.min(tickPositions) || minY;
+  const maxTickPosition = _.max(tickPositions) || maxY;
+  return roundAxisLimits(minTickPosition, maxTickPosition);
 };

--- a/src/components/LocationPage/ChartsHolder.tsx
+++ b/src/components/LocationPage/ChartsHolder.tsx
@@ -19,8 +19,7 @@ import { ZoneChartWrapper } from 'components/Charts/ZoneChart.style';
 import Chart from 'components/Charts/Chart';
 import ClaimStateBlock from 'components/ClaimStateBlock/ClaimStateBlock';
 import ShareModelBlock from '../../components/ShareBlock/ShareModelBlock';
-import { ChartRt } from '../../components/Charts';
-
+import { ChartRt, ChartPositiveTestRate } from '../../components/Charts';
 import {
   caseGrowthStatusText,
   CASE_GROWTH_DISCLAIMER,
@@ -35,14 +34,11 @@ import {
 } from 'common/metrics/hospitalizations';
 import { generateChartDescription } from 'common/metrics/future_projection';
 import { contactTracingStatusText } from 'common/metrics/contact_tracing';
-
 import {
   optionsHospitalUsage,
-  optionsPositiveTests,
   optionsContactTracing,
 } from 'components/Charts/zoneUtils';
-import { getMetricName } from 'common/metric';
-import { Metric } from 'common/metric';
+import { Metric, getMetricName } from 'common/metric';
 
 // TODO(michael): figure out where this type declaration should live.
 type County = {
@@ -138,11 +134,7 @@ const ChartsHolder = (props: {
               </ChartDescription>
               {testPositiveData && (
                 <>
-                  <ZoneChartWrapper>
-                    <Chart
-                      options={optionsPositiveTests(testPositiveData) as any}
-                    />
-                  </ZoneChartWrapper>
+                  <ChartPositiveTestRate columnData={testPositiveData} />
                   <Disclaimer metricName="positive test rate">
                     {POSITIVE_RATE_DISCLAIMER}
                   </Disclaimer>

--- a/src/screens/internal/AllStates/AllStates.js
+++ b/src/screens/internal/AllStates/AllStates.js
@@ -4,11 +4,8 @@ import { useProjections } from 'common/utils/model';
 import { STATES } from 'common';
 import { ZoneChartWrapper } from 'components/Charts/ZoneChart.style';
 import Chart from 'components/Charts/Chart';
-import { ChartRt } from 'components/Charts';
-import {
-  optionsHospitalUsage,
-  optionsPositiveTests,
-} from 'components/Charts/zoneUtils';
+import { ChartRt, ChartPositiveTestRate } from 'components/Charts';
+import { optionsHospitalUsage } from 'components/Charts/zoneUtils';
 import { getChartData } from 'components/LocationPage/ChartsHolder';
 
 function AllStates() {
@@ -46,9 +43,7 @@ function State({ stateId }) {
         </div>
         <div style={{ width: '32%', height: '450px' }}>
           {testPositiveData && (
-            <ZoneChartWrapper>
-              <Chart options={optionsPositiveTests(testPositiveData)} />
-            </ZoneChartWrapper>
+            <ChartPositiveTestRate columnData={testPositiveData} />
           )}
         </div>
         <div style={{ width: '32%', height: '450px' }}>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2303,7 +2303,7 @@
   dependencies:
     "@types/d3-time" "*"
 
-"@types/d3-shape@^1.3.1":
+"@types/d3-shape@^1.3.1", "@types/d3-shape@^1.3.2":
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/@types/d3-shape/-/d3-shape-1.3.2.tgz#a41d9d6b10d02e221696b240caf0b5d0f5a588ec"
   integrity sha512-LtD8EaNYCaBRzHzaAiIPrfcL3DdIysc81dkGlQvv7WQP3+YXV7b0JJTtR1U3bzeRieS603KF4wUo+ZkJVenh8w==


### PR DESCRIPTION
Closes https://trello.com/c/2IEGjPVL/150-rewriting-charts-positive-tests

This chart re-implements the Positive Test Rate chart and extracts common code from `ChartRt` into components so it can be reused. The `ChartZone` component can be also used for ICU hospitalization rate and contact tracing, but I prefer to change those in separate PRs to make it easier to test.

![image](https://user-images.githubusercontent.com/114084/82702629-32e8da00-9c27-11ea-93cd-7a16660424d9.png)

Can @goldblatt review?