### PR TITLE
Charts Remake - Future Hospitalizations

### DIFF
--- a/src/assets/theme/palette.tsx
+++ b/src/assets/theme/palette.tsx
@@ -60,9 +60,9 @@ export default {
     grid: black,
     area: colors.grey[200],
     tooltip: {
-      background: black,
-      text: lightGray,
-      shadow: colors.grey[400],
+      background: colors.grey[900],
+      text: white,
+      shadow: colors.grey[500],
     },
     annotation: black,
   },

--- a/src/components/Charts/BoxedAnnotation.tsx
+++ b/src/components/Charts/BoxedAnnotation.tsx
@@ -31,8 +31,8 @@ export const BoxedAnnotation = ({
       <rect
         y={top - padding}
         x={left - padding}
-        width={width + 2 * padding}
-        height={height + 2 * padding}
+        width={Math.abs(width + 2 * padding)}
+        height={Math.abs(height + 2 * padding)}
       />
       <text ref={textRef}>{text}</text>
     </Group>

--- a/src/components/Charts/ChartContactTracing.tsx
+++ b/src/components/Charts/ChartContactTracing.tsx
@@ -8,7 +8,7 @@ const CAP_Y = 1;
 
 const getPointText = (valueY: number) => formatPercent(valueY, 0);
 
-const getTooltipText = (valueY: number) =>
+const getTooltipBody = (valueY: number) =>
   `Contacts traced ${getPointText(valueY)}`;
 
 const ChartContactTracing = ({
@@ -23,7 +23,7 @@ const ChartContactTracing = ({
     columnData={columnData}
     capY={CAP_Y}
     zones={CONTACT_TRACING_LEVEL_INFO_MAP}
-    getTooltipText={getTooltipText}
+    getTooltipBody={getTooltipBody}
     getPointText={getPointText}
   />
 );

--- a/src/components/Charts/ChartFutureHospitalization.tsx
+++ b/src/components/Charts/ChartFutureHospitalization.tsx
@@ -1,0 +1,239 @@
+import React, { ReactNode } from 'react';
+import moment from 'moment';
+import { last, isDate } from 'lodash';
+import { min as d3min, max as d3max } from 'd3-array';
+import { AxisBottom, AxisLeft } from '@vx/axis';
+import { LinePath } from '@vx/shape';
+import { ParentSize } from '@vx/responsive';
+import { scaleLinear, scaleTime } from '@vx/scale';
+import { Projections } from 'common/models/Projections';
+import { COLORS } from 'common';
+import BoxedAnnotation from './BoxedAnnotation';
+import ChartContainer from './ChartContainer';
+import RectClipGroup from './RectClipGroup';
+import Tooltip from './Tooltip';
+import { LegendMarker, LegendLine } from './Legend';
+import * as Style from './Charts.style';
+import { formatDate, formatInteger } from './utils';
+import palette from 'assets/theme/palette';
+
+type Point = {
+  x: number;
+  y: number;
+};
+
+type PointTooltip = Point & {
+  color: string;
+  name: string;
+};
+
+const getDate = (p: Point) => new Date(p.x);
+const getY = (p: Point) => p.y;
+const hasData = (d: any) => isDate(getDate(d)) && Number.isFinite(getY(d));
+const getLastPoint = (points: Point[]): Point => last(points) || { x: 0, y: 0 };
+const isFuture = (p: Point) => getDate(p) > new Date();
+
+const getTooltipPoint = (
+  points: Point[],
+  color: string,
+  name: string,
+): PointTooltip[] => points.map(p => ({ ...p, color, name }));
+
+const getTooltipBody = (p: PointTooltip): ReactNode => (
+  <span>
+    <b>{formatInteger(getY(p))}</b>{' '}
+    {p.name === 'beds' ? 'beds available on' : 'hospitalizations expected by'}{' '}
+    <b>{formatDate(getDate(p), 'MMMM D')}</b>
+  </span>
+);
+
+const ChartFutureHospitalization = ({
+  projections,
+  width,
+  height,
+  marginTop = 5,
+  marginBottom = 40,
+  marginLeft = 48,
+  marginRight = 5,
+}: {
+  projections: Projections;
+  width: number;
+  height: number;
+  marginTop?: number;
+  marginBottom?: number;
+  marginLeft?: number;
+  marginRight?: number;
+}) => {
+  const chartWidth = width - marginLeft - marginRight;
+  const chartHeight = height - marginTop - marginBottom;
+
+  const dataNoAction = projections.baseline.getDataset('hospitalizations');
+  const dataNoActionFuture: Point[] = dataNoAction
+    .filter(hasData)
+    .filter(isFuture);
+
+  const dataProjected = projections.projected.getDataset('hospitalizations');
+  const dataProjectedFuture: Point[] = dataProjected
+    .filter(hasData)
+    .filter(isFuture);
+  const dataProjectedPast: Point[] = dataProjected
+    .filter(hasData)
+    .filter((p: Point) => !isFuture(p));
+
+  const dataBeds = projections.primary.getDataset('beds');
+
+  const allData: PointTooltip[] = [
+    ...getTooltipPoint(dataProjectedFuture, COLORS.PROJECTED, 'projected'),
+    ...getTooltipPoint(dataNoActionFuture, COLORS.LIMITED_ACTION, 'no-action'),
+    ...getTooltipPoint(dataProjectedPast, palette.black, 'past'),
+    ...getTooltipPoint(dataBeds, palette.chart.axis, 'beds'),
+  ];
+
+  const dateTwoWeeks = moment().add(2, 'weeks').toDate();
+  const minDate = d3min(allData, getDate) || new Date('2020-01-01');
+  const maxDate = d3max(allData, getDate) || dateTwoWeeks;
+  const xScale = scaleTime({
+    domain: [minDate, maxDate],
+    range: [0, chartWidth],
+  });
+
+  const minY = d3min(allData, getY) || 0;
+  const maxY = d3max(allData, getY) || 1;
+
+  const yScale = scaleLinear({
+    domain: [minY, maxY],
+    range: [chartHeight, 0],
+  });
+
+  const getXCoord = (p: Point): number => xScale(getDate(p));
+  const getYCoord = (p: Point): number => yScale(getY(p));
+
+  const firstPointBeds = dataBeds[0];
+  const lastPastPoint = getLastPoint(dataProjectedPast);
+
+  const renderTooltip = (p: PointTooltip) => (
+    <Tooltip left={marginLeft + getXCoord(p)} top={marginTop + getYCoord(p)}>
+      {getTooltipBody(p)}
+    </Tooltip>
+  );
+  const renderMarker = (p: PointTooltip) => (
+    <Style.CircleMarker
+      cx={getXCoord(p)}
+      cy={getYCoord(p)}
+      r={6}
+      fill={p.color}
+    />
+  );
+
+  return (
+    <>
+      <ChartContainer
+        data={allData}
+        x={getXCoord}
+        y={getYCoord}
+        renderMarker={renderMarker}
+        renderTooltip={renderTooltip}
+        width={width}
+        height={height}
+        marginTop={marginTop}
+        marginBottom={marginBottom}
+        marginLeft={marginLeft}
+        marginRight={marginRight}
+      >
+        <RectClipGroup width={chartWidth} height={chartHeight}>
+          <Style.SeriesDashed stroke={COLORS.LIMITED_ACTION}>
+            <LinePath data={dataNoActionFuture} x={getXCoord} y={getYCoord} />
+          </Style.SeriesDashed>
+          <Style.SeriesDashed stroke={COLORS.PROJECTED}>
+            <LinePath data={dataProjectedFuture} x={getXCoord} y={getYCoord} />
+          </Style.SeriesDashed>
+          <Style.SeriesLine stroke={palette.black}>
+            <LinePath data={dataProjectedPast} x={getXCoord} y={getYCoord} />
+          </Style.SeriesLine>
+          <Style.TextAnnotation
+            textAnchor={'start'}
+            dominantBaseline={'baseline'}
+          >
+            <BoxedAnnotation
+              x={getXCoord(firstPointBeds)}
+              y={getYCoord(firstPointBeds) - 5}
+              text={`${formatInteger(getY(firstPointBeds))} beds`}
+            />
+          </Style.TextAnnotation>
+          <Style.LineGrid>
+            <LinePath data={dataBeds} x={getXCoord} y={getYCoord} />
+          </Style.LineGrid>
+          <Style.CircleMarker
+            cx={getXCoord(lastPastPoint)}
+            cy={getYCoord(lastPastPoint)}
+            r={6}
+          />
+          <AxisLeft
+            top={marginTop}
+            scale={yScale}
+            hideAxisLine
+            hideTicks
+            hideZero
+          />
+        </RectClipGroup>
+        <Style.Axis>
+          <AxisBottom
+            top={chartHeight}
+            scale={xScale}
+            numTicks={Math.round(chartWidth / 100)}
+          />
+        </Style.Axis>
+      </ChartContainer>
+      <Style.LegendContainer>
+        <Style.LegendItem>
+          <LegendMarker>
+            <Style.SeriesLine>
+              <LegendLine />
+            </Style.SeriesLine>
+          </LegendMarker>
+          <Style.LegendLabel>Hospitalizations</Style.LegendLabel>
+        </Style.LegendItem>
+        <Style.LegendItem>
+          <LegendMarker>
+            <Style.SeriesDashed stroke={COLORS.LIMITED_ACTION}>
+              <LegendLine />
+            </Style.SeriesDashed>
+          </LegendMarker>
+          <Style.LegendLabel>If all restrictions are lifted</Style.LegendLabel>
+        </Style.LegendItem>
+        <Style.LegendItem>
+          <LegendMarker>
+            <Style.SeriesDashed stroke={COLORS.PROJECTED}>
+              <LegendLine />
+            </Style.SeriesDashed>
+          </LegendMarker>
+          <Style.LegendLabel>
+            Projected based on current trends
+          </Style.LegendLabel>
+        </Style.LegendItem>
+      </Style.LegendContainer>
+    </>
+  );
+};
+
+const ChartAutosize = ({
+  projections,
+  height = 400,
+}: {
+  projections: Projections;
+  height?: number;
+}) => (
+  <Style.ChartContainer>
+    <ParentSize>
+      {({ width }) => (
+        <ChartFutureHospitalization
+          width={width}
+          height={height}
+          projections={projections}
+        />
+      )}
+    </ParentSize>
+  </Style.ChartContainer>
+);
+
+export default ChartAutosize;

--- a/src/components/Charts/ChartICUHeadroom.tsx
+++ b/src/components/Charts/ChartICUHeadroom.tsx
@@ -8,7 +8,7 @@ const CAP_Y = 1;
 
 const getPointText = (valueY: number) => formatPercent(valueY, 0);
 
-const getTooltipText = (valueY: number) =>
+const getTooltipBody = (valueY: number) =>
   valueY > CAP_Y
     ? `ICU headroom used > ${getPointText(CAP_Y)}`
     : `ICU headroom used ${getPointText(valueY)}`;
@@ -25,7 +25,7 @@ const ChartICUHeadroom = ({
     columnData={columnData}
     capY={CAP_Y}
     zones={HOSPITAL_USAGE_LEVEL_INFO_MAP}
-    getTooltipText={getTooltipText}
+    getTooltipBody={getTooltipBody}
     getPointText={getPointText}
   />
 );

--- a/src/components/Charts/ChartPositiveTestRate.tsx
+++ b/src/components/Charts/ChartPositiveTestRate.tsx
@@ -10,7 +10,7 @@ const getPointText = (valueY: number) => formatPercent(valueY, 1);
 
 // It shows one decimal point for tooltip values, except for
 // values over the cap (it shows > 40%)
-const getTooltipText = (valueY: number) =>
+const getTooltipBody = (valueY: number) =>
   valueY > CAP_Y
     ? `Positive Tests > ${formatPercent(CAP_Y, 0)}`
     : `Positive Tests ${getPointText(valueY)}`;
@@ -27,7 +27,7 @@ const ChartPositiveTests = ({
     columnData={columnData}
     capY={CAP_Y}
     zones={POSITIVE_TESTS_LEVEL_INFO_MAP}
-    getTooltipText={getTooltipText}
+    getTooltipBody={getTooltipBody}
     getPointText={getPointText}
   />
 );

--- a/src/components/Charts/ChartRt.tsx
+++ b/src/components/Charts/ChartRt.tsx
@@ -106,7 +106,7 @@ const ChartRt = ({
       top={marginTop + getYCoord(d)}
       title={formatDate(getDate(d))}
     >
-      {`Rt ${formatDecimal(getRt(d), 1)}`}{' '}
+      {`Rt ${formatDecimal(getRt(d), 2)}`}{' '}
       {getDate(d) < truncationDate ? '' : '(preliminary)'}
     </Tooltip>
   );

--- a/src/components/Charts/ChartRt.tsx
+++ b/src/components/Charts/ChartRt.tsx
@@ -158,7 +158,7 @@ const ChartRt = ({
                 yScale={yScale}
               />
             </Style.SeriesLine>
-            <Style.SeriesDashed stroke={region.color}>
+            <Style.SeriesDotted stroke={region.color}>
               <ZoneLinePath<PointRt>
                 data={restData}
                 x={getXCoord}
@@ -167,7 +167,7 @@ const ChartRt = ({
                 width={chartWidth}
                 yScale={yScale}
               />
-            </Style.SeriesDashed>
+            </Style.SeriesDotted>
             <ZoneAnnotation
               color={region.color}
               name={region.name}

--- a/src/components/Charts/ChartRt.tsx
+++ b/src/components/Charts/ChartRt.tsx
@@ -136,15 +136,17 @@ const ChartRt = ({
       marginRight={marginRight}
     >
       <RectClipGroup width={chartWidth} height={chartHeight}>
-        <Style.SeriesArea>
-          <Area
-            data={data}
-            x={getXCoord}
-            y0={(d: PointRt) => yScale(getYAreaLow(d))}
-            y1={(d: PointRt) => yScale(getYAreaHigh(d))}
-            curve={curveNatural}
-          />
-        </Style.SeriesArea>
+        <RectClipGroup width={chartWidth} height={chartHeight} topPadding={0}>
+          <Style.SeriesArea>
+            <Area
+              data={data}
+              x={getXCoord}
+              y0={(d: PointRt) => yScale(getYAreaLow(d))}
+              y1={(d: PointRt) => yScale(getYAreaHigh(d))}
+              curve={curveNatural}
+            />
+          </Style.SeriesArea>
+        </RectClipGroup>
         {regions.map((region, i) => (
           <Group key={`chart-region-${i}`}>
             <Style.SeriesLine stroke={region.color}>

--- a/src/components/Charts/ChartRt.tsx
+++ b/src/components/Charts/ChartRt.tsx
@@ -106,7 +106,7 @@ const ChartRt = ({
       top={marginTop + getYCoord(d)}
       title={formatDate(getDate(d))}
     >
-      {`Rt ${formatDecimal(getRt(d), 2)}`}{' '}
+      {`Infection rate ${formatDecimal(getRt(d), 2)}`}{' '}
       {getDate(d) < truncationDate ? '' : '(preliminary)'}
     </Tooltip>
   );

--- a/src/components/Charts/ChartRt.tsx
+++ b/src/components/Charts/ChartRt.tsx
@@ -26,6 +26,7 @@ import {
   getZoneByValue,
   last,
   getAxisLimits,
+  formatDate,
 } from './utils';
 
 type PointRt = Omit<Column, 'y'> & {
@@ -99,18 +100,16 @@ const ChartRt = ({
   const yTruncationRt = yScale(truncationRt);
   const truncationZone = getZoneByValue(truncationRt, zones);
 
-  const renderTooltip = (d: PointRt) => {
-    const date = getDate(d);
-    const disclaimer = date < truncationDate ? '' : '(preliminary)';
-    return (
-      <Tooltip
-        left={marginLeft + getXCoord(d)}
-        top={marginTop + getYCoord(d)}
-        date={date}
-        text={`Rt ${formatDecimal(getRt(d), 1)} ${disclaimer}`}
-      />
-    );
-  };
+  const renderTooltip = (d: PointRt) => (
+    <Tooltip
+      left={marginLeft + getXCoord(d)}
+      top={marginTop + getYCoord(d)}
+      title={formatDate(getDate(d))}
+    >
+      {`Rt ${formatDecimal(getRt(d), 1)}`}{' '}
+      {getDate(d) < truncationDate ? '' : '(preliminary)'}
+    </Tooltip>
+  );
 
   const renderMarker = (d: PointRt) => (
     <Style.CircleMarker

--- a/src/components/Charts/ChartZones.tsx
+++ b/src/components/Charts/ChartZones.tsx
@@ -24,6 +24,7 @@ import {
   formatPercent,
   getZoneByValue,
   getAxisLimits,
+  formatDate,
 } from './utils';
 
 type Point = Omit<Column, 'y'> & {
@@ -44,7 +45,7 @@ const ChartZones = ({
   marginLeft = 40,
   marginRight = 5,
   capY,
-  getTooltipText,
+  getTooltipBody,
   getPointText,
 }: {
   width: number;
@@ -52,7 +53,7 @@ const ChartZones = ({
   columnData: Point[];
   zones: LevelInfoMap;
   capY: number;
-  getTooltipText: (valueY: number) => string;
+  getTooltipBody: (valueY: number) => string;
   getPointText: (valueY: number) => string;
   marginTop?: number;
   marginBottom?: number;
@@ -106,9 +107,10 @@ const ChartZones = ({
     <Tooltip
       top={marginTop + getYCoord(d)}
       left={marginLeft + getXCoord(d)}
-      date={getDate(d)}
-      text={getTooltipText(getY(d))}
-    />
+      title={formatDate(getDate(d))}
+    >
+      {getTooltipBody(getY(d))}
+    </Tooltip>
   );
 
   return (
@@ -185,14 +187,14 @@ const ChartZoneAutosize = ({
   columnData,
   zones,
   capY,
-  getTooltipText,
+  getTooltipBody,
   getPointText,
   height = 400,
 }: {
   columnData: Point[];
   zones: LevelInfoMap;
   capY: number;
-  getTooltipText: (valueY: number) => string;
+  getTooltipBody: (valueY: number) => string;
   getPointText: (valueY: number) => string;
   height?: number;
 }) => (
@@ -205,7 +207,7 @@ const ChartZoneAutosize = ({
           columnData={columnData}
           zones={zones}
           capY={capY}
-          getTooltipText={getTooltipText}
+          getTooltipBody={getTooltipBody}
           getPointText={getPointText}
         />
       )}

--- a/src/components/Charts/Charts.style.ts
+++ b/src/components/Charts/Charts.style.ts
@@ -155,7 +155,7 @@ export const LegendContainer = styled.div`
   }
   justify-content: center;
   > * {
-    margin-right: 15px;
+    margin-right: 20px;
     &:last-child {
       margin-right: 0;
     }
@@ -166,7 +166,7 @@ export const LegendItem = styled.div`
   flex: 0 1 auto;
   align-items: center;
   > * {
-    margin-right: 5px;
+    margin-right: 4px;
     &:last-child {
       margin-right: 0;
     }
@@ -178,4 +178,5 @@ export const LegendLabel = styled.span`
   font-size: 11px;
   font-weight: bold;
   color: ${palette.chart.axis};
+  white-space: nowrap;
 `;

--- a/src/components/Charts/Charts.style.ts
+++ b/src/components/Charts/Charts.style.ts
@@ -117,19 +117,24 @@ export const RegionAnnotation = styled(TextAnnotation)<{ isActive: boolean }>`
 
 export const Tooltip = styled.div`
   position: absolute;
-  transform: translate(-50%, calc(-100% - 15px));
   pointer-events: none;
+  transform: translate(-50%, calc(-100% - 15px));
+  width: ${tooltip.width};
+  padding: 12px;
+  border-radius: 3px;
   font-family: ${charts.fontFamily};
   font-weight: ${charts.fontWeight};
   font-size: ${charts.fontSize};
-  width: ${tooltip.width};
+  line-height: 1.4;
   color: ${palette.chart.tooltip.text};
   background-color: ${palette.chart.tooltip.background};
-  box-shadow: ${palette.chart.tooltip.shadow};
-  padding: 5px 10px;
-  border-radius: 3px;
+  box-shadow: 2px 2px 6px ${palette.chart.tooltip.shadow};
 `;
 
 export const TooltipTitle = styled.div`
   font-size: ${tooltip.fontSizeTitle};
+`;
+
+export const TooltipBody = styled.div`
+  font-size: 11px;
 `;

--- a/src/components/Charts/Charts.style.ts
+++ b/src/components/Charts/Charts.style.ts
@@ -66,10 +66,18 @@ export const SeriesLine = styled.g`
   }
 `;
 
+export const SeriesDotted = styled(SeriesLine)`
+  line,
+  path {
+    stroke-dasharray: 1, 6;
+  }
+`;
+
 export const SeriesDashed = styled(SeriesLine)`
   line,
   path {
     stroke-dasharray: 1, 6;
+    stroke-linecap: square;
   }
 `;
 
@@ -98,8 +106,8 @@ export const TextAnnotation = styled.g`
     font-weight: ${charts.fontWeight};
     font-size: ${charts.fontSize};
     fill: ${palette.chart.annotation};
-    text-anchor: middle;
-    dominant-baseline: middle;
+    text-anchor: ${props => props.textAnchor || 'middle'};
+    dominant-baseline: ${props => props.dominantBaseline || 'middle'};
   }
 `;
 
@@ -137,4 +145,37 @@ export const TooltipTitle = styled.div`
 
 export const TooltipBody = styled.div`
   font-size: 11px;
+`;
+
+export const LegendContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  @media (min-width: 600px) {
+    flex-direction: row;
+  }
+  justify-content: center;
+  > * {
+    margin-right: 15px;
+    &:last-child {
+      margin-right: 0;
+    }
+  }
+`;
+
+export const LegendItem = styled.div`
+  flex: 0 1 auto;
+  align-items: center;
+  > * {
+    margin-right: 5px;
+    &:last-child {
+      margin-right: 0;
+    }
+  }
+`;
+
+export const LegendLabel = styled.span`
+  font-family: ${charts.fontFamily};
+  font-size: 11px;
+  font-weight: bold;
+  color: ${palette.chart.axis};
 `;

--- a/src/components/Charts/Legend.tsx
+++ b/src/components/Charts/Legend.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { Group } from '@vx/group';
+
+const DEFAULT_WIDTH = 20;
+const DEFAULT_HEIGHT = 6;
+
+export const LegendMarker: React.FunctionComponent<{
+  width?: number;
+  height?: number;
+}> = ({ children, width = DEFAULT_WIDTH, height = DEFAULT_HEIGHT }) => (
+  <svg width={width} height={height}>
+    <Group top={height / 2}>{children}</Group>
+  </svg>
+);
+
+export const LegendLine: React.FunctionComponent<{ width?: number }> = ({
+  width = DEFAULT_WIDTH,
+}) => <line x1={0} x2={width} y1={0} y2={0} />;

--- a/src/components/Charts/RectClipGroup.tsx
+++ b/src/components/Charts/RectClipGroup.tsx
@@ -18,12 +18,19 @@ const RectClipGroup: React.FunctionComponent<{
   height: number;
   x?: number;
   y?: number;
-}> = ({ width, height, x = 0, y = 0, children }) => {
+  topPadding?: number;
+}> = ({ width, height, x = 0, y = 0, children, topPadding = 5 }) => {
   // Random ID for the clipping shape, to ensure that is unique in the DOM tree.
   const clipPathId = randomizeId('clip-path');
   return (
     <>
-      <RectClipPath x={x} y={y} id={clipPathId} width={width} height={height} />
+      <RectClipPath
+        x={x}
+        y={y - topPadding}
+        id={clipPathId}
+        width={width}
+        height={height + topPadding}
+      />
       <Group clipPath={`url(#${clipPathId})`}>{children}</Group>
     </>
   );

--- a/src/components/Charts/RectClipGroup.tsx
+++ b/src/components/Charts/RectClipGroup.tsx
@@ -28,8 +28,8 @@ const RectClipGroup: React.FunctionComponent<{
         x={x}
         y={y - topPadding}
         id={clipPathId}
-        width={width}
-        height={height + topPadding}
+        width={Math.abs(width)}
+        height={Math.abs(height + topPadding)}
       />
       <Group clipPath={`url(#${clipPathId})`}>{children}</Group>
     </>

--- a/src/components/Charts/Tooltip.tsx
+++ b/src/components/Charts/Tooltip.tsx
@@ -1,24 +1,20 @@
 import React from 'react';
-import moment from 'moment';
 import * as Style from './Charts.style';
 
-const formatDate = (date: Date): string =>
-  moment(date).format('dddd, MMM D, YYYY');
-
 const Tooltip = ({
-  date,
-  text,
+  title,
   left,
   top,
+  children,
 }: {
-  date: Date;
-  text: string;
   left: number;
   top: number;
+  title?: string;
+  children?: React.ReactNode;
 }) => (
   <Style.Tooltip style={{ top, left }}>
-    <Style.TooltipTitle>{formatDate(date)}</Style.TooltipTitle>
-    {text}
+    {title && <Style.TooltipTitle>{title}</Style.TooltipTitle>}
+    {children && <Style.TooltipBody>{children}</Style.TooltipBody>}
   </Style.Tooltip>
 );
 

--- a/src/components/Charts/index.tsx
+++ b/src/components/Charts/index.tsx
@@ -3,3 +3,4 @@ export { default as ChartZones } from './ChartZones';
 export { default as ChartPositiveTestRate } from './ChartPositiveTestRate';
 export { default as ChartICUHeadroom } from './ChartICUHeadroom';
 export { default as ChartContactTracing } from './ChartContactTracing';
+export { default as ChartFutureHospitalization } from './ChartFutureHospitalization';

--- a/src/components/Charts/utils.ts
+++ b/src/components/Charts/utils.ts
@@ -283,3 +283,6 @@ export const getAxisLimits = (minY: number, maxY: number, zones: Zones) => {
   const maxTickPosition = _.max(tickPositions) || maxY;
   return roundAxisLimits(minTickPosition, maxTickPosition);
 };
+
+export const formatDate = (date: Date, format = 'dddd, MMM D, YYYY'): string =>
+  moment(date).format(format);

--- a/src/components/LocationPage/ChartsHolder.tsx
+++ b/src/components/LocationPage/ChartsHolder.tsx
@@ -10,18 +10,19 @@ import {
 } from './ChartsHolder.style';
 import LocationPageHeader from 'components/LocationPage/LocationPageHeader';
 import NoCountyDetail from './NoCountyDetail';
-import ModelChart from 'components/Charts/ModelChart';
 import { Projections } from 'common/models/Projections';
 import { Projection } from 'common/models/Projection';
 import SummaryStats from 'components/SummaryStats/SummaryStats';
 import Disclaimer from 'components/Disclaimer/Disclaimer';
 import ClaimStateBlock from 'components/ClaimStateBlock/ClaimStateBlock';
-import ShareModelBlock from '../../components/ShareBlock/ShareModelBlock';
+import ShareModelBlock from 'components/ShareBlock/ShareModelBlock';
+import Outcomes from 'components/Outcomes/Outcomes';
 import {
   ChartRt,
   ChartPositiveTestRate,
   ChartICUHeadroom,
   ChartContactTracing,
+  ChartFutureHospitalization,
 } from 'components/Charts';
 import {
   caseGrowthStatusText,
@@ -38,6 +39,8 @@ import {
 import { generateChartDescription } from 'common/metrics/future_projection';
 import { contactTracingStatusText } from 'common/metrics/contact_tracing';
 import { Metric, getMetricName } from 'common/metric';
+import { COLORS } from 'common';
+import { formatDate } from 'common/utils';
 
 // TODO(michael): figure out where this type declaration should live.
 type County = {
@@ -89,6 +92,12 @@ const ChartsHolder = (props: {
       [Metric.CONTACT_TRACING]: projection.currentContactTracerMetric,
     };
   };
+
+  let outcomesProjections = [
+    props.projections.baseline,
+    props.projections.projected,
+  ];
+  let outcomesColors = [COLORS.LIMITED_ACTION, COLORS.PROJECTED];
 
   return (
     <>
@@ -213,11 +222,13 @@ const ChartsHolder = (props: {
               <ChartDescription>
                 {generateChartDescription(projection, noInterventionProjection)}
               </ChartDescription>
-              <ModelChart
-                projections={props.projections}
-                height={''}
-                condensed={false}
-                forCompareModels={false}
+              <ChartFutureHospitalization projections={props.projections} />
+              <Outcomes
+                title={`Predicted outcomes by ${formatDate(
+                  props.projections.projected.finalDate,
+                )} (90 days from now)`}
+                projections={outcomesProjections}
+                colors={outcomesColors}
               />
             </MainContentInner>
             <ClaimStateBlock


### PR DESCRIPTION
This PR re-implements the Future Hospitalizations chart

![image](https://user-images.githubusercontent.com/114084/82762786-de289900-9db7-11ea-9c66-6efb92f767dc.png)

**Other Changes**
- beb01cfb629f0ecde29d442c965b64921af3e90b Added padding to the clipping region, to avoid cutting half of the line when they hit the top of the chart.
- 04d8c55fbf1fdc9eaae48d2521abf989eec5ad52 Update the Tooltip component so it can receive children and minor styling fixes. This is needed because the tooltip for the Future Hospitalizations chart is formatted (some text is in bold).

## Notes
- The Highcharts version allows us to toggle the series on and off by clicking on the legend. I vaguely remember that this behavior wasn't desired, because it allowed the user to hide all of them, so I didn't implement that. We can implement it if that's something we want to have (or a variation of it)
- I haven't removed the old chart code yet - I want to make sure that this is stable in production before removing it.