### PR TITLE
Make charts 'theme-able' and add a 'dark' theme.

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,7 +1,11 @@
 import React from 'react';
 import CssBaseline from '@material-ui/core/CssBaseline';
-import { ThemeProvider, StylesProvider } from '@material-ui/core/styles';
+import {
+  ThemeProvider as MuiThemeProvider,
+  StylesProvider,
+} from '@material-ui/core/styles';
 import { BrowserRouter, Route, Redirect, Switch } from 'react-router-dom';
+import { ThemeProvider as ScThemeProvider } from 'styled-components';
 
 import LocationPage from 'screens/LocationPage/LocationPage';
 import HomePage from 'screens/HomePage/HomePage';
@@ -21,89 +25,95 @@ import theme from 'assets/theme';
 
 export default function App() {
   return (
-    <ThemeProvider theme={theme}>
-      <StylesProvider injectFirst>
-        <CssBaseline />
-        <BrowserRouter>
-          <AppBar />
-          <Switch>
-            <Route exact path="/" component={HomePage} />
+    <MuiThemeProvider theme={theme}>
+      <ScThemeProvider theme={theme}>
+        <StylesProvider injectFirst>
+          <CssBaseline />
+          <BrowserRouter>
+            <AppBar />
+            <Switch>
+              <Route exact path="/" component={HomePage} />
 
-            <Route exact path="/us/:stateId" component={LocationPage} />
-            <Route
-              exact
-              path="/us/:stateId/county/:countyId"
-              component={LocationPage}
-            />
-            {/* /state/ routes are deprecated but still supported. */}
-            <Route exact path="/state/:stateId" component={LocationPage} />
-            <Route
-              exact
-              path="/state/:stateId/county/:countyId"
-              component={LocationPage}
-            />
+              <Route exact path="/us/:stateId" component={LocationPage} />
+              <Route
+                exact
+                path="/us/:stateId/county/:countyId"
+                component={LocationPage}
+              />
+              {/* /state/ routes are deprecated but still supported. */}
+              <Route exact path="/state/:stateId" component={LocationPage} />
+              <Route
+                exact
+                path="/state/:stateId/county/:countyId"
+                component={LocationPage}
+              />
 
-            <Route path="/about" component={About} />
-            <Route path="/resources" component={Resources} />
-            <Route path="/contact" component={Contact} />
-            <Route path="/terms" component={Terms} />
-            <Route path="/privacy" component={Privacy} />
+              <Route path="/about" component={About} />
+              <Route path="/resources" component={Resources} />
+              <Route path="/contact" component={Contact} />
+              <Route path="/terms" component={Terms} />
+              <Route path="/privacy" component={Privacy} />
 
-            <Route exact path="/embed/us/:stateId" component={Embed} />
-            <Route
-              exact
-              path="/embed/us/:stateId/county/:countyId"
-              component={Embed}
-            />
-            {/* TODO: We might want to support non-embed fips-code URLs too for consistency? */}
-            <Route
-              exact
-              path="/embed/us/county/:countyFipsId"
-              component={Embed}
-            />
+              <Route exact path="/embed/us/:stateId" component={Embed} />
+              <Route
+                exact
+                path="/embed/us/:stateId/county/:countyId"
+                component={Embed}
+              />
+              {/* TODO: We might want to support non-embed fips-code URLs too for consistency? */}
+              <Route
+                exact
+                path="/embed/us/county/:countyFipsId"
+                component={Embed}
+              />
 
-            {/* <Route path="/donate" component={ComingSoon} /> */}
-            {/* /model, /contact, and /about are deprecated in favor of /faq */}
-            <Route path="/model">
-              <Redirect to="/faq" />
-            </Route>
-            <Route path="/contact">
-              <Redirect to="/faq" />
-            </Route>
+              {/* <Route path="/donate" component={ComingSoon} /> */}
+              {/* /model, /contact, and /about are deprecated in favor of /faq */}
+              <Route path="/model">
+                <Redirect to="/faq" />
+              </Route>
+              <Route path="/contact">
+                <Redirect to="/faq" />
+              </Route>
 
-            {/** Internal endpoint that shows all the state charts. */}
-            <Route path="/all">
-              <Redirect to="/internal/all" />
-            </Route>
-            <Route path="/internal/all" component={AllStates} />
+              {/** Internal endpoint that shows all the state charts. */}
+              <Route path="/all">
+                <Redirect to="/internal/all" />
+              </Route>
+              <Route path="/internal/all" component={AllStates} />
 
-            {/** Internal endpoint for comparing API snapshots. */}
-            <Route path="/compare">
-              <Redirect to="/internal/compare" />
-            </Route>
-            <Route path="/internal/compare" component={CompareModels} />
+              {/** Internal endpoint for comparing API snapshots. */}
+              <Route path="/compare">
+                <Redirect to="/internal/compare" />
+              </Route>
+              <Route path="/internal/compare" component={CompareModels} />
 
-            {/** Internal endpoints we use to generate the content that we want to
+              {/** Internal endpoints we use to generate the content that we want to
             screenshot for our social sharing images (OpenGraph / Twitter Card). */}
-            <Route exact path="/internal/share-image/" component={ShareImage} />
-            <Route
-              exact
-              path="/internal/share-image/states/:stateId"
-              component={ShareImage}
-            />
-            <Route
-              exact
-              path="/internal/share-image/counties/:countyFipsId"
-              component={ShareImage}
-            />
+              <Route
+                exact
+                path="/internal/share-image/"
+                component={ShareImage}
+              />
+              <Route
+                exact
+                path="/internal/share-image/states/:stateId"
+                component={ShareImage}
+              />
+              <Route
+                exact
+                path="/internal/share-image/counties/:countyFipsId"
+                component={ShareImage}
+              />
 
-            <Route path="/*">
-              <Redirect to="/" />
-            </Route>
-          </Switch>
-          <Footer />
-        </BrowserRouter>
-      </StylesProvider>
-    </ThemeProvider>
+              <Route path="/*">
+                <Redirect to="/" />
+              </Route>
+            </Switch>
+            <Footer />
+          </BrowserRouter>
+        </StylesProvider>
+      </ScThemeProvider>
+    </MuiThemeProvider>
   );
 }

--- a/src/assets/theme/palette.tsx
+++ b/src/assets/theme/palette.tsx
@@ -16,10 +16,6 @@ const chart = {
     shadow: colors.grey[500],
   },
   annotation: black,
-
-  // TODO(michael): Not loving this complexity. Perhaps we could just always use regionColor?
-  regionAnnotationStroke: (isActive: boolean, regionColor: string) =>
-    isActive ? regionColor : lightGray,
 };
 
 // Used for share image charts (e.g. http://localhost:3000/internal/share-image/states/wa/chart/0)
@@ -30,8 +26,7 @@ export const chartDarkMode = {
   grid: '#fbfbfb80',
   area: '#ffffff26',
   annotation: white,
-  regionAnnotationStroke: (isActive: boolean, regionColor: string) =>
-    regionColor,
+  isDarkMode: true,
 };
 
 export default {

--- a/src/assets/theme/palette.tsx
+++ b/src/assets/theme/palette.tsx
@@ -4,6 +4,36 @@ const white = '#FFFFFF';
 const black = '#000000';
 const lightGray = '#f2f2f2';
 
+const chart = {
+  background: white,
+  foreground: black,
+  axis: colors.grey[700],
+  grid: black,
+  area: colors.grey[200],
+  tooltip: {
+    background: colors.grey[900],
+    text: white,
+    shadow: colors.grey[500],
+  },
+  annotation: black,
+
+  // TODO(michael): Not loving this complexity. Perhaps we could just always use regionColor?
+  regionAnnotationStroke: (isActive: boolean, regionColor: string) =>
+    isActive ? regionColor : lightGray,
+};
+
+// Used for share image charts (e.g. http://localhost:3000/internal/share-image/states/wa/chart/0)
+export const chartDarkMode = {
+  ...chart,
+  background: black,
+  foreground: white,
+  grid: '#fbfbfb80',
+  area: '#ffffff26',
+  annotation: white,
+  regionAnnotationStroke: (isActive: boolean, regionColor: string) =>
+    regionColor,
+};
+
 export default {
   black,
   white,
@@ -55,15 +85,5 @@ export default {
   },
   icon: colors.blueGrey[600],
   divider: colors.grey[200],
-  chart: {
-    axis: colors.grey[700],
-    grid: black,
-    area: colors.grey[200],
-    tooltip: {
-      background: colors.grey[900],
-      text: white,
-      shadow: colors.grey[500],
-    },
-    annotation: black,
-  },
+  chart,
 };

--- a/src/components/Charts/ChartFutureHospitalization.tsx
+++ b/src/components/Charts/ChartFutureHospitalization.tsx
@@ -1,4 +1,5 @@
-import React, { ReactNode } from 'react';
+import React, { useContext, ReactNode } from 'react';
+import { ThemeContext } from 'styled-components';
 import moment from 'moment';
 import { last, isDate } from 'lodash';
 import { min as d3min, max as d3max } from 'd3-array';
@@ -15,7 +16,6 @@ import Tooltip from './Tooltip';
 import { LegendMarker, LegendLine } from './Legend';
 import * as Style from './Charts.style';
 import { formatDate, formatInteger } from './utils';
-import palette from 'assets/theme/palette';
 
 type Point = {
   x: number;
@@ -64,6 +64,8 @@ const ChartFutureHospitalization = ({
   marginLeft?: number;
   marginRight?: number;
 }) => {
+  const theme = useContext(ThemeContext);
+
   const chartWidth = width - marginLeft - marginRight;
   const chartHeight = height - marginTop - marginBottom;
 
@@ -85,8 +87,12 @@ const ChartFutureHospitalization = ({
   const allData: PointTooltip[] = [
     ...getTooltipPoint(dataProjectedFuture, COLORS.PROJECTED, 'projected'),
     ...getTooltipPoint(dataNoActionFuture, COLORS.LIMITED_ACTION, 'no-action'),
-    ...getTooltipPoint(dataProjectedPast, palette.black, 'past'),
-    ...getTooltipPoint(dataBeds, palette.chart.axis, 'beds'),
+    ...getTooltipPoint(
+      dataProjectedPast,
+      theme.palette.chart.foreground,
+      'past',
+    ),
+    ...getTooltipPoint(dataBeds, theme.palette.chart.axis, 'beds'),
   ];
 
   const dateTwoWeeks = moment().add(2, 'weeks').toDate();
@@ -147,7 +153,7 @@ const ChartFutureHospitalization = ({
           <Style.SeriesDashed stroke={COLORS.PROJECTED}>
             <LinePath data={dataProjectedFuture} x={getXCoord} y={getYCoord} />
           </Style.SeriesDashed>
-          <Style.SeriesLine stroke={palette.black}>
+          <Style.SeriesLine stroke={theme.palette.chart.foreground}>
             <LinePath data={dataProjectedPast} x={getXCoord} y={getYCoord} />
           </Style.SeriesLine>
           <Style.TextAnnotation

--- a/src/components/Charts/Charts.style.ts
+++ b/src/components/Charts/Charts.style.ts
@@ -1,11 +1,4 @@
 import styled from 'styled-components';
-import palette from 'assets/theme/palette';
-
-const color = {
-  lightGrey: palette.lightGray,
-  black: palette.black,
-  white: palette.white,
-};
 
 const charts = {
   fontFamily: "'Source Code Pro', 'Roboto', sans-serif",
@@ -18,9 +11,13 @@ const charts = {
 
 const tooltip = {
   width: '200px',
-  boxShadow: `3px 3px 5px ${palette.chart.tooltip.shadow}`,
   fontSizeTitle: '11px',
 };
+
+/** Gets the chart palette based on the current theme. */
+function palette(props: any) {
+  return props.theme.palette.chart;
+}
 
 export const ChartContainer = styled.div`
   /* TODO(@pnavarrc): This negative margin breaks the auto-size of the chart */
@@ -38,10 +35,10 @@ export const Axis = styled.g`
     font-family: ${charts.fontFamily};
     font-weight: ${charts.fontWeight};
     font-size: ${charts.fontSize};
-    fill: ${palette.chart.axis};
+    fill: ${props => palette(props).axis};
   }
   line {
-    stroke: ${palette.chart.axis};
+    stroke: ${props => palette(props).axis};
   }
 `;
 
@@ -49,7 +46,7 @@ export const LineGrid = styled.g`
   line,
   path {
     fill: none;
-    stroke: ${palette.chart.grid};
+    stroke: ${props => palette(props).grid};
     stroke-opacity: 0.6;
     stroke-dasharray: 4, 3;
     stroke-width: 1px;
@@ -60,7 +57,8 @@ export const SeriesLine = styled.g`
   line,
   path {
     fill: none;
-    stroke: ${props => (props.stroke ? props.stroke : palette.black)};
+    stroke: ${props =>
+      props.stroke ? props.stroke : palette(props).foreground};
     stroke-width: ${charts.series.lineWidth};
     stroke-linecap: round;
   }
@@ -83,7 +81,7 @@ export const SeriesDashed = styled(SeriesLine)`
 
 export const SeriesArea = styled.g`
   path {
-    fill: ${palette.chart.area};
+    fill: ${props => palette(props).area};
     stroke: none;
   }
 `;
@@ -95,7 +93,7 @@ export const CircleMarker = styled.circle`
 
 export const TextAnnotation = styled.g`
   rect {
-    fill: ${color.white};
+    fill: ${props => palette(props).background};
     fill-opacity: 1;
     stroke: none;
     rx: 3;
@@ -105,7 +103,7 @@ export const TextAnnotation = styled.g`
     font-family: ${charts.fontFamily};
     font-weight: ${charts.fontWeight};
     font-size: ${charts.fontSize};
-    fill: ${palette.chart.annotation};
+    fill: ${props => palette(props).annotation};
     text-anchor: ${props => props.textAnchor || 'middle'};
     dominant-baseline: ${props => props.dominantBaseline || 'middle'};
   }
@@ -113,12 +111,15 @@ export const TextAnnotation = styled.g`
 
 export const RegionAnnotation = styled(TextAnnotation)<{ isActive: boolean }>`
   rect {
-    fill: ${props => (props.isActive ? props.color : palette.white)};
-    stroke: ${props => (props.isActive ? props.color : palette.lightGray)};
+    fill: ${props =>
+      props.isActive ? props.color : palette(props).background};
+    stroke: ${props =>
+      palette(props).regionAnnotationStroke(props.isActive, props.color)};
     stroke-width: 1px;
   }
   text {
-    fill: ${props => (props.isActive ? palette.white : props.color)};
+    fill: ${props =>
+      props.isActive ? palette(props).background : props.color};
     text-anchor: end;
   }
 `;
@@ -134,9 +135,9 @@ export const Tooltip = styled.div`
   font-weight: ${charts.fontWeight};
   font-size: ${charts.fontSize};
   line-height: 1.4;
-  color: ${palette.chart.tooltip.text};
-  background-color: ${palette.chart.tooltip.background};
-  box-shadow: 2px 2px 6px ${palette.chart.tooltip.shadow};
+  color: ${props => palette(props).tooltip.text};
+  background-color: ${props => palette(props).tooltip.background};
+  box-shadow: 2px 2px 6px ${props => palette(props).tooltip.shadow};
 `;
 
 export const TooltipTitle = styled.div`
@@ -177,6 +178,6 @@ export const LegendLabel = styled.span`
   font-family: ${charts.fontFamily};
   font-size: 11px;
   font-weight: bold;
-  color: ${palette.chart.axis};
+  color: ${props => palette(props).axis};
   white-space: nowrap;
 `;

--- a/src/components/Charts/Charts.style.ts
+++ b/src/components/Charts/Charts.style.ts
@@ -114,7 +114,9 @@ export const RegionAnnotation = styled(TextAnnotation)<{ isActive: boolean }>`
     fill: ${props =>
       props.isActive ? props.color : palette(props).background};
     stroke: ${props =>
-      palette(props).regionAnnotationStroke(props.isActive, props.color)};
+      props.isActive || palette(props).isDarkMode
+        ? props.color
+        : props.theme.palette.lightGray};
     stroke-width: 1px;
   }
   text {


### PR DESCRIPTION
This makes the charts minimally "theme-able" and adds a dark set of colors for them.

To see how this gets used in the chart sharing, see [here](https://github.com/covid-projections/covid-projections/pull/825/files#diff-f5680937bf6b070548b0898693f6fc04R69)

And preview: https://covid-projections-git-mikelehen-share-charts.covidactnow.now.sh/internal/share-image/states/wa/chart/0