### PR TITLE
Asserts that the charts have data

### DIFF
--- a/src/components/Charts/ChartContainer.tsx
+++ b/src/components/Charts/ChartContainer.tsx
@@ -58,7 +58,7 @@ const ChartContainer = <T extends unknown>({
         <Group left={marginLeft} top={marginTop}>
           {children}
           {tooltipOpen && tooltipData && renderMarker(tooltipData)}
-          <HoverOverlay
+          <HoverOverlay<T>
             width={chartWidth}
             height={chartHeight}
             data={data}

--- a/src/components/Charts/ChartZones.tsx
+++ b/src/components/Charts/ChartZones.tsx
@@ -26,6 +26,7 @@ import {
   getAxisLimits,
   formatDate,
 } from './utils';
+import { assert } from 'common/utils';
 
 type Point = Omit<Column, 'y'> & {
   y: number;
@@ -66,8 +67,9 @@ const ChartZones = ({
   const data: Point[] = columnData.filter(hasData);
   const dates: Date[] = columnData.map(getDate).filter(isDate);
 
-  const minDate = d3min(dates) || new Date('2020-01-01');
+  const minDate = d3min(dates);
   const maxDate = moment().add(2, 'weeks').toDate();
+  assert(minDate !== undefined, 'Data must not be empty');
 
   const xScale = scaleTime({
     domain: [minDate, maxDate],
@@ -75,7 +77,8 @@ const ChartZones = ({
   });
 
   const yDataMin = 0;
-  const yDataMax = d3max(data, getY) || 1;
+  const yDataMax = d3max(data, getY);
+  assert(yDataMax !== undefined, 'Data must not be empty');
   const [yAxisMin, yAxisMax] = getAxisLimits(yDataMin, yDataMax, zones);
   const yMax = Math.min(capY, yAxisMax);
 

--- a/src/components/Charts/HoverOverlay.tsx
+++ b/src/components/Charts/HoverOverlay.tsx
@@ -2,7 +2,7 @@ import React, { useMemo } from 'react';
 import { Group } from '@vx/group';
 import { voronoi, VoronoiPolygon } from '@vx/voronoi';
 
-const HoverOverlay = ({
+const HoverOverlay = <T extends unknown>({
   data,
   x,
   y,
@@ -11,14 +11,14 @@ const HoverOverlay = ({
   onMouseOver,
   onMouseOut,
 }: {
-  data: any[];
-  x: (d: any) => number;
-  y: (d: any) => number;
+  data: T[];
+  x: (d: T) => number;
+  y: (d: T) => number;
   width: number;
   height: number;
   onMouseOver: (
     event: React.MouseEvent<SVGPathElement, MouseEvent>,
-    d: any,
+    d: T,
   ) => void;
   onMouseOut: (event: React.MouseEvent<SVGPathElement, MouseEvent>) => void;
 }) => {


### PR DESCRIPTION
Follow up from https://github.com/covid-projections/covid-projections/pull/822

This PR adds assertions to check that the charts have enough data to have a min/max for x and y, and remove some default values that were there as safeguards.