### PR TITLE
Scroll to top when navigating to a new county/state

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -21,6 +21,7 @@ import CompareModels from 'screens/internal/CompareModels/CompareModels';
 import ShareImage from 'screens/internal/ShareImage/ShareImage';
 import AppBar from 'components/AppBar/AppBar';
 import Footer from 'components/Footer/Footer';
+import ScrollToTop from 'components/ScrollToTop';
 import theme from 'assets/theme';
 
 export default function App() {
@@ -30,6 +31,7 @@ export default function App() {
         <StylesProvider injectFirst>
           <CssBaseline />
           <BrowserRouter>
+            <ScrollToTop />
             <AppBar />
             <Switch>
               <Route exact path="/" component={HomePage} />

--- a/src/components/ScrollToTop/ScrollToTop.tsx
+++ b/src/components/ScrollToTop/ScrollToTop.tsx
@@ -1,0 +1,12 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+export default function ScrollToTop() {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+}

--- a/src/components/ScrollToTop/index.tsx
+++ b/src/components/ScrollToTop/index.tsx
@@ -1,0 +1,3 @@
+import ScrollToTop from './ScrollToTop';
+
+export default ScrollToTop;


### PR DESCRIPTION
Fix [Bug: Clicking on county often scrolls to bottom of location page.](https://trello.com/c/CQpybrw0/114-bug-clicking-on-county-often-scrolls-to-bottom-of-location-page) - Clicking on county often scrolls to the bottom of the location page

I found a solution here https://reacttraining.com/react-router/web/guides/scroll-restoration. The `useEffect` hook is triggered every time `pathname` is updated, scrolling the client to the top.

## Testing
- Go to a location page, scroll all the way to the bottom (https://covid-projections-git-pablo-scroll-to-top.covidactnow.now.sh/us/wa)
- Click on a county
- In `develop`, the browser will navigate to the county, but will be scrolled down all the way to the bottom. In this branch, the browser scrolls to the top as it renders the county page.