### PR TITLE
Better UX for Preliminary Rt Data 

### DIFF
--- a/src/assets/theme/palette.tsx
+++ b/src/assets/theme/palette.tsx
@@ -11,8 +11,9 @@ const chart = {
   grid: black,
   area: colors.grey[200],
   tooltip: {
-    background: colors.grey[900],
+    background: black,
     text: white,
+    textMuted: colors.grey[400],
     shadow: colors.grey[500],
   },
   annotation: black,

--- a/src/common/metrics/case_growth.ts
+++ b/src/common/metrics/case_growth.ts
@@ -2,7 +2,7 @@ import { COLOR_MAP } from 'common/colors';
 import { Level, LevelInfoMap } from 'common/level';
 import { getLevel, Metric } from 'common/metric';
 import { levelText } from 'common/utils/chart';
-import { formatDecimal } from 'components/Charts/utils';
+import { formatDecimal } from 'common/utils';
 import { Projection } from 'common/models/Projection';
 
 export const METRIC_NAME = 'Infection rate';

--- a/src/common/metrics/contact_tracing.ts
+++ b/src/common/metrics/contact_tracing.ts
@@ -2,7 +2,7 @@ import { COLOR_MAP } from 'common/colors';
 import { Level, LevelInfoMap } from 'common/level';
 import { levelText } from 'common/utils/chart';
 import { getLevel, Metric } from 'common/metric';
-import { formatPercent, formatInteger } from 'components/Charts/utils';
+import { formatPercent, formatInteger } from 'common/utils';
 import { Projection, TRACERS_NEEDED_PER_CASE } from 'common/models/Projection';
 
 export const METRIC_NAME = 'Contacts traced';

--- a/src/common/metrics/hospitalizations.ts
+++ b/src/common/metrics/hospitalizations.ts
@@ -2,7 +2,7 @@ import { COLOR_MAP } from 'common/colors';
 import { Level, LevelInfoMap } from 'common/level';
 import { levelText } from 'common/utils/chart';
 import { getLevel, Metric } from 'common/metric';
-import { formatPercent, formatInteger } from 'components/Charts/utils';
+import { formatPercent, formatInteger } from 'common/utils';
 import { Projection } from 'common/models/Projection';
 
 export const METRIC_NAME = 'ICU headroom used';

--- a/src/common/metrics/positive_rate.ts
+++ b/src/common/metrics/positive_rate.ts
@@ -2,7 +2,7 @@ import { COLOR_MAP } from 'common/colors';
 import { Level, LevelInfoMap } from 'common/level';
 import { levelText } from 'common/utils/chart';
 import { getLevel, Metric } from 'common/metric';
-import { formatPercent } from 'components/Charts/utils';
+import { formatPercent } from 'common/utils';
 import { Projection } from 'common/models/Projection';
 
 export const METRIC_NAME = 'Positive test rate';

--- a/src/common/utils/index.ts
+++ b/src/common/utils/index.ts
@@ -22,11 +22,6 @@ export function assertCountyId(id: string) {
   assert(COUNTY_REGEX.test(id), `${id} is not a valid county ID`);
 }
 
-export function formatDate(date: Date) {
-  // Locale-specific, but for US: April 29, 2020
-  return moment(date).format('LL');
-}
-
 export function getFormattedCountyName(stateId: string, countyUrlName: string) {
   const { county: countyName, state_code: stateCode } = _.find(
     // @ts-ignore: US_STATE_DATASET is .js, but this is valid
@@ -36,3 +31,39 @@ export function getFormattedCountyName(stateId: string, countyUrlName: string) {
 
   return `${countyName}, ${stateCode}`;
 }
+
+/**
+ * Returns a date formatted as a string. The default format is locale-specific,
+ * for US: April 29, 2020.
+ *
+ * See https://momentjs.com/docs/#/displaying/format/ for more details.
+ */
+export function formatDate(date: Date, format: string = 'LL'): string {
+  return moment(date).format(format);
+}
+
+/**
+ * Returns a language-sensitive representation of an integer. For US, it
+ * adds commas for thousands, millions, etc.
+ */
+export function formatInteger(num: number): string {
+  return num.toLocaleString();
+}
+
+/**
+ * Format a number using fixed point notation.
+ *
+ *   formatDecimal(1.2345)    // 1.23
+ *   formatDecimal(1.2345, 3) // 1.234
+ */
+export const formatDecimal = (num: number, places = 2): string =>
+  num.toFixed(places);
+
+/**
+ * Returns a percentage representation of a number.
+ *
+ *   formatPercent(0.85)      // 86%
+ *   formatPercent(0.8567, 2) // 85.67%
+ */
+export const formatPercent = (num: number, places = 0): string =>
+  `${formatDecimal(100 * Math.min(1, num), places)}%`;

--- a/src/components/Charts/ChartContactTracing.tsx
+++ b/src/components/Charts/ChartContactTracing.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import ChartZones from './ChartZones';
 import { CONTACT_TRACING_LEVEL_INFO_MAP } from 'common/metrics/contact_tracing';
 import { Column } from 'common/models/Projection';
-import { formatPercent } from './utils';
+import { formatPercent } from 'common/utils';
 
 const CAP_Y = 1;
 

--- a/src/components/Charts/ChartFutureHospitalization.tsx
+++ b/src/components/Charts/ChartFutureHospitalization.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, ReactNode } from 'react';
+import React, { useContext } from 'react';
 import { ThemeContext } from 'styled-components';
 import { last, isDate } from 'lodash';
 import { extent as d3extent } from 'd3-array';
@@ -6,15 +6,15 @@ import { AxisBottom, AxisLeft } from '@vx/axis';
 import { LinePath } from '@vx/shape';
 import { ParentSize } from '@vx/responsive';
 import { scaleLinear, scaleTime } from '@vx/scale';
-import { Projections } from 'common/models/Projections';
 import { COLORS } from 'common';
-import { assert } from 'common/utils';
+import { Projections } from 'common/models/Projections';
+import { assert, formatDate, formatInteger } from 'common/utils';
 import BoxedAnnotation from './BoxedAnnotation';
 import ChartContainer from './ChartContainer';
 import RectClipGroup from './RectClipGroup';
 import Tooltip from './Tooltip';
+import * as TooltipStyle from './Tooltip.style';
 import { LegendMarker, LegendLine } from './Legend';
-import { formatDate, formatInteger } from './utils';
 import * as Style from './Charts.style';
 
 type Point = {
@@ -38,14 +38,6 @@ const getProjectionsPoints = (
   color: string,
   isBeds: boolean,
 ): PointProjections[] => points.map(p => ({ ...p, color, isBeds }));
-
-const getTooltipBody = (p: PointProjections): ReactNode => (
-  <span>
-    <b>{formatInteger(getY(p))}</b>{' '}
-    {p.isBeds ? 'beds available on' : 'hospitalizations expected by'}{' '}
-    <b>{formatDate(getDate(p), 'MMMM D')}</b>
-  </span>
-);
 
 const ChartFutureHospitalization = ({
   projections,
@@ -117,7 +109,11 @@ const ChartFutureHospitalization = ({
 
   const renderTooltip = (p: PointProjections) => (
     <Tooltip left={marginLeft + getXCoord(p)} top={marginTop + getYCoord(p)}>
-      {getTooltipBody(p)}
+      <TooltipStyle.Body style={{ fontWeight: 'normal' }}>
+        <b style={{ color: 'white' }}>{formatInteger(getY(p))}</b>{' '}
+        {p.isBeds ? 'beds available on' : 'hospitalizations expected by'}{' '}
+        <b style={{ color: 'white' }}>{formatDate(getDate(p), 'MMMM D')}</b>
+      </TooltipStyle.Body>
     </Tooltip>
   );
   const renderMarker = (p: PointProjections) => (

--- a/src/components/Charts/ChartICUHeadroom.tsx
+++ b/src/components/Charts/ChartICUHeadroom.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { HOSPITAL_USAGE_LEVEL_INFO_MAP } from 'common/metrics/hospitalizations';
 import { Column } from 'common/models/Projection';
 import ChartZones from './ChartZones';
-import { formatPercent } from './utils';
+import { formatPercent } from 'common/utils';
 
 const CAP_Y = 1;
 

--- a/src/components/Charts/ChartPositiveTestRate.tsx
+++ b/src/components/Charts/ChartPositiveTestRate.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import ChartZones from './ChartZones';
 import { POSITIVE_TESTS_LEVEL_INFO_MAP } from 'common/metrics/positive_rate';
-import { formatPercent } from './utils';
-import { Column } from '../../common/models/Projection';
+import { formatPercent } from 'common/utils';
+import { Column } from 'common/models/Projection';
 
 const CAP_Y = 0.4;
 

--- a/src/components/Charts/ChartZones.tsx
+++ b/src/components/Charts/ChartZones.tsx
@@ -9,6 +9,7 @@ import { Group } from '@vx/group';
 import { ParentSize } from '@vx/responsive';
 import { scaleLinear, scaleTime } from '@vx/scale';
 import { Column } from 'common/models/Projection';
+import { assert, formatDate, formatPercent } from 'common/utils';
 import { LevelInfoMap } from 'common/level';
 import RectClipGroup from './RectClipGroup';
 import BoxedAnnotation from './BoxedAnnotation';
@@ -16,17 +17,15 @@ import ZoneAnnotation from './ZoneAnnotation';
 import ZoneLinePath from './ZoneLinePath';
 import ChartContainer from './ChartContainer';
 import Tooltip from './Tooltip';
+import * as TooltipStyle from './Tooltip.style';
 import * as Style from './Charts.style';
 import {
   getChartRegions,
   computeTickPositions,
   last,
-  formatPercent,
   getZoneByValue,
   getAxisLimits,
-  formatDate,
 } from './utils';
-import { assert } from 'common/utils';
 
 type Point = Omit<Column, 'y'> & {
   y: number;
@@ -110,9 +109,9 @@ const ChartZones = ({
     <Tooltip
       top={marginTop + getYCoord(d)}
       left={marginLeft + getXCoord(d)}
-      title={formatDate(getDate(d))}
+      title={formatDate(getDate(d), 'MMM D, YYYY')}
     >
-      {getTooltipBody(getY(d))}
+      <TooltipStyle.Body>{getTooltipBody(getY(d))}</TooltipStyle.Body>
     </Tooltip>
   );
 

--- a/src/components/Charts/Charts.style.ts
+++ b/src/components/Charts/Charts.style.ts
@@ -142,14 +142,6 @@ export const Tooltip = styled.div`
   box-shadow: 2px 2px 6px ${props => palette(props).tooltip.shadow};
 `;
 
-export const TooltipTitle = styled.div`
-  font-size: ${tooltip.fontSizeTitle};
-`;
-
-export const TooltipBody = styled.div`
-  font-size: 11px;
-`;
-
 export const LegendContainer = styled.div`
   display: flex;
   flex-direction: column;

--- a/src/components/Charts/Tooltip.style.ts
+++ b/src/components/Charts/Tooltip.style.ts
@@ -1,0 +1,79 @@
+import styled from 'styled-components';
+
+/** Gets the chart palette based on the current theme. */
+function palette(props: any) {
+  return props.theme.palette.chart;
+}
+
+const triangleWidth = '7px';
+const triangleHeight = '6px';
+
+export const Tooltip = styled.div`
+  position: absolute;
+  pointer-events: none;
+  transform: translate(-50%, calc(-100% - 20px));
+  width: 220px;
+  padding: 12px;
+  border-radius: 4px;
+  background-color: ${props => palette(props).tooltip.background};
+  box-shadow: 2px 2px 6px ${props => palette(props).tooltip.shadow};
+`;
+
+export const TooltipArrow = styled(Tooltip)`
+  &:after {
+    content: '';
+    position: absolute;
+    width: 0;
+    height: 0;
+    pointer-events: none;
+  }
+`;
+
+export const TooltipArrowDown = styled(TooltipArrow)`
+  &:after {
+    border-left: ${triangleWidth} solid transparent;
+    border-right: ${triangleWidth} solid transparent;
+    border-top: ${triangleHeight} solid
+      ${props => palette(props).tooltip.background};
+    top: 100%;
+    left: calc(50% - ${triangleWidth});
+  }
+`;
+
+export const Title = styled.div`
+  font-family: Roboto;
+  font-style: normal;
+  font-weight: 500;
+  font-size: 10px;
+  line-height: 12px;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  color: ${props => palette(props).tooltip.textMuted};
+  margin-bottom: 8px;
+`;
+
+export const Body = styled.div`
+  font-family: Source Code Pro;
+  font-style: normal;
+  font-weight: bold;
+  font-size: 15px;
+  line-height: 19px;
+  color: ${props => palette(props).tooltip.text};
+`;
+
+export const BodyMuted = styled(Body)`
+  font-weight: 500;
+  font-size: 11px;
+  line-height: 14px;
+  color: ${props => palette(props).tooltip.textMuted};
+`;
+
+export const SubText = styled.div`
+  font-family: Roboto;
+  font-style: normal;
+  font-weight: 500;
+  font-size: 11px;
+  line-height: 13px;
+  color: ${props => palette(props).tooltip.text};
+  margin-top: 8px;
+`;

--- a/src/components/Charts/Tooltip.tsx
+++ b/src/components/Charts/Tooltip.tsx
@@ -1,21 +1,24 @@
 import React from 'react';
-import * as Style from './Charts.style';
+import * as StyleTooltip from './Tooltip.style';
 
 const Tooltip = ({
   title,
   left,
   top,
   children,
+  subtext,
 }: {
   left: number;
   top: number;
   title?: string;
   children?: React.ReactNode;
+  subtext?: string;
 }) => (
-  <Style.Tooltip style={{ top, left }}>
-    {title && <Style.TooltipTitle>{title}</Style.TooltipTitle>}
-    {children && <Style.TooltipBody>{children}</Style.TooltipBody>}
-  </Style.Tooltip>
+  <StyleTooltip.TooltipArrowDown style={{ top, left }}>
+    {title && <StyleTooltip.Title>{title}</StyleTooltip.Title>}
+    {children}
+    {subtext && <StyleTooltip.SubText>{subtext}</StyleTooltip.SubText>}
+  </StyleTooltip.TooltipArrowDown>
 );
 
 export default Tooltip;

--- a/src/components/Charts/utils.ts
+++ b/src/components/Charts/utils.ts
@@ -12,15 +12,6 @@ export const last = (list: any[]) => list[list.length - 1];
 export const lastValidPoint = (data: Highcharts.Point[]) =>
   last(data.filter(isValidPoint));
 
-export const formatDecimal = (num: number, places = 2): string =>
-  num.toFixed(places);
-
-export const formatPercent = (num: number, places = 0): string =>
-  `${formatDecimal(100 * Math.min(1, num), places)}%`;
-
-/** Adds comma's for thousands, millions, etc. */
-export const formatInteger = (num: number): string => num.toLocaleString();
-
 export const parseDate = (date: Date): number => new Date(date).valueOf();
 
 export const titleCase = (str: string) => _.startCase(_.toLower(str));
@@ -283,6 +274,3 @@ export const getAxisLimits = (minY: number, maxY: number, zones: Zones) => {
   const maxTickPosition = _.max(tickPositions) || maxY;
   return roundAxisLimits(minTickPosition, maxTickPosition);
 };
-
-export const formatDate = (date: Date, format = 'dddd, MMM D, YYYY'): string =>
-  moment(date).format(format);

--- a/src/components/Charts/zoneUtils.js
+++ b/src/components/Charts/zoneUtils.js
@@ -2,8 +2,6 @@ import moment from 'moment';
 import {
   baseOptions,
   currentValueAnnotation,
-  formatDecimal,
-  formatPercent,
   getMaxY,
   getTickPositions,
   getYAxisLimits,
@@ -17,7 +15,7 @@ import { HOSPITAL_USAGE_LEVEL_INFO_MAP } from 'common/metrics/hospitalizations';
 import { CONTACT_TRACING_LEVEL_INFO_MAP } from 'common/metrics/contact_tracing';
 import { Level } from '../../common/level';
 import { RT_TRUNCATION_DAYS } from '../../common/models/Projection';
-
+import { formatDecimal, formatPercent } from 'common/utils';
 const CHART_END_DATE = moment().add(2, 'weeks').toDate();
 const toHighchartZone = levelInfo => {
   return {

--- a/src/components/SummaryStats/SummaryStats.tsx
+++ b/src/components/SummaryStats/SummaryStats.tsx
@@ -14,7 +14,7 @@ import {
 } from './SummaryStats.style';
 
 import SignalStatus from 'components/SignalStatus/SignalStatus';
-import { formatDecimal, formatPercent } from 'components/Charts/utils';
+import { formatDecimal, formatPercent } from 'common/utils';
 import { fail } from 'assert';
 import { isNull } from 'util';
 


### PR DESCRIPTION
Close [Better UX for preliminary Rt data + add Confidence Intervals](https://trello.com/c/fQX9Jxxj/115-better-ux-for-preliminary-rt-data-add-confidence-intervals)

I tried to replicate the styles from [Figma - Preliminary Data for Rt](https://www.figma.com/file/xGLbdgTR348eQmmIpvBrvF/Preliminary-data-for-Rt?node-id=0%3A1), but the width of the tooltip wasn't big enough in some cases.

I also updated the tooltips for the other charts (see screenshots below) trying to keep the styles consistent with the new and existing design. The body of the future hospitalizations chart is the one that departs most from the others.

Note: Used the [triangle trick](https://css-tricks.com/snippets/css/css-triangle/) for the tooltip arrow. I only implemented the arrow down since that's the only one we need for now.

## Minor Changes
- Removed the `formatDate` function from `components/Charts/utils.ts` to use `formatDate` from `common/utils` instead. Added a default format to keep backwards compatibility.

### Growth Rate

**Confirmed**
![image](https://user-images.githubusercontent.com/114084/82861835-cd207a80-9ed2-11ea-9d47-c6e73ebd0214.png)

**Preliminary**
![image](https://user-images.githubusercontent.com/114084/82861856-d9a4d300-9ed2-11ea-8b01-d8e28bad37b6.png)

### Positive Tests
![image](https://user-images.githubusercontent.com/114084/82861822-c1cd4f00-9ed2-11ea-9053-d9c9732a8db8.png)

### ICU Headroom Used
![image](https://user-images.githubusercontent.com/114084/82861800-b5e18d00-9ed2-11ea-857e-7c4f8d17794a.png)

### Contacts Traced
![image](https://user-images.githubusercontent.com/114084/82861785-abbf8e80-9ed2-11ea-91a7-00aca7f6e178.png)

### Future Hospitalizations
![image](https://user-images.githubusercontent.com/114084/82861772-99ddeb80-9ed2-11ea-9d3e-b4b34e5b4c68.png)
