### PR TITLE
Update generate_index_pages and generate_share_images for chart sharing.

### DIFF
--- a/scripts/generate_index_pages.ts
+++ b/scripts/generate_index_pages.ts
@@ -78,7 +78,7 @@ function chartPageTags(
 
 async function buildLocationPages(builder: IndexPageBuilder, relativeSiteUrl: string, relativeImageUrl: string, locationName: string) {
   const canonicalUrl = urlJoin('https://covidactnow.org/', relativeSiteUrl);
-  const imageUrl = builder.fullImageUrl(relativeImageUrl + '.png');
+  const imageUrl = builder.fullImageUrl(`${relativeImageUrl}.png`);
   const page = path.join(relativeSiteUrl, 'index.html');
   await builder.writeTemplatedPage(
     page,

--- a/scripts/generate_index_pages.ts
+++ b/scripts/generate_index_pages.ts
@@ -41,8 +41,8 @@ function locationPageTags(
   canonicalUrl: string,
   locationName: string,
 ): MetaTags {
-  const title = `Is ${locationName} ready to reopen?`;
-  const description = 'Metrics and modeling to help America reopen safely.';
+  const title = `America’s COVID warning system`;
+  const description = `Covid Act Now has real-time COVID data and risk level for your community. See how ${locationName} is doing at covidactnow.org.`;
   return {
     'og:url': canonicalUrl,
     'og:image:url': fullImageUrl,
@@ -61,9 +61,8 @@ function chartPageTags(
   locationName: string,
   metricName: string,
 ): MetaTags {
-  // TODO(michael): What should these tags say?
   const title = `${locationName}: ${metricName}`;
-  const description = 'Metrics and modeling to help America reopen safely.';
+  const description = `Covid Act Now has real-time COVID data and risk level for your community. See how ${locationName} is doing at covidactnow.org.`;
   return {
     'og:url': canonicalUrl,
     'og:image:url': fullImageUrl,

--- a/scripts/generate_share_images/index.ts
+++ b/scripts/generate_share_images/index.ts
@@ -55,6 +55,8 @@ const BLACKLISTED_COUNTIES = [
     // Chart images.
     for (const metric of ALL_METRICS) {
       if (metric === Metric.FUTURE_PROJECTIONS || projections.getMetricValue(metric) !== null) {
+        // TODO(michael): Unify the generation of these URLs somehow to make
+        // sure we don't end up with accidental mismatches, etc.
         const shareUrl = urlJoin(relativeUrl, '/chart/', '' + metric);
         const exportUrl = urlJoin(shareUrl, '/export');
         screenshots.push({

--- a/src/assets/data/share_images_url.json
+++ b/src/assets/data/share_images_url.json
@@ -1,3 +1,3 @@
 {
-    "share_image_url": "https://content.covidactnow.org/share/373-26/"
+    "share_image_url": "https://content.covidactnow.org/share/373-27/"
 }


### PR DESCRIPTION
* Modify generate_share_images to generate the additional share / export images (e.g. /states/wa/chart/0.png)
* Modify generate_index_pages to generate the additional share chart index.html files (e.g. /us/wa/chart/0/index.html)

I had to do some refactoring to combine our handling of states / counties better to avoid duplicating too much code.