### PR TITLE
Add "sharing ID" to URLs to prevent unwanted caching.

### DIFF
--- a/scripts/generate_index_pages.ts
+++ b/scripts/generate_index_pages.ts
@@ -14,6 +14,7 @@ import US_STATE_DATASET from '../src/components/MapSelectors/datasets/us_states_
 import ShareImageUrlJSON from '../src/assets/data/share_images_url.json';
 import { STATES } from '../src/common';
 import { assert } from '../src/common/utils';
+import * as urls from '../src/common/urls';
 
 // We don't care about the values here, but this is a cheap way to determine all
 // of the counties we have any data for and are therefore share-able.
@@ -76,7 +77,9 @@ function chartPageTags(
 }
 
 async function buildLocationPages(builder: IndexPageBuilder, relativeSiteUrl: string, relativeImageUrl: string, locationName: string) {
-  const canonicalUrl = urlJoin('https://covidactnow.org/', relativeSiteUrl);
+  const canonicalUrlBase = urlJoin('https://covidactnow.org/', relativeSiteUrl);
+
+  const canonicalUrl = urls.addSharingId(canonicalUrlBase);
   const imageUrl = builder.fullImageUrl(`${relativeImageUrl}.png`);
   const page = path.join(relativeSiteUrl, 'index.html');
   await builder.writeTemplatedPage(
@@ -86,7 +89,7 @@ async function buildLocationPages(builder: IndexPageBuilder, relativeSiteUrl: st
 
   for (const metric of ALL_METRICS) {
     const chartPage = path.join(relativeSiteUrl, `/chart/${metric}/index.html`);
-    const chartCanonicalUrl = urlJoin(canonicalUrl, `/chart/${metric}`);
+    const chartCanonicalUrl = urls.addSharingId(urlJoin(canonicalUrlBase, `/chart/${metric}`));
     const chartImageUrl = builder.fullImageUrl(urlJoin(relativeImageUrl, `/chart/${metric}.png`));
     await builder.writeTemplatedPage(
       chartPage,

--- a/src/common/urls.ts
+++ b/src/common/urls.ts
@@ -1,0 +1,50 @@
+import ShareImageUrlJSON from 'assets/data/share_images_url.json';
+import { assert } from 'common/utils';
+
+/**
+ * We append a short unique string corresponding to the currently published
+ * sharing preview images to the URL so that if it gets shared, it's unique
+ * enough that Facebook/Twitter/whoever will fetch a recent version of the page
+ * and the up-to-date sharing image.
+ */
+const SHARING_ID_QUERY_PARAM = 's';
+const SHARING_ID = sharingId();
+const SHARING_ID_QUERYSTRING = `?${SHARING_ID_QUERY_PARAM}=${SHARING_ID}`;
+
+/**
+ * Adds unique sharing querystring to the URL.
+ *
+ * TODO(michael): Remove this and instead have dedicated functions for
+ * generating URLs to the home page / location pages, etc. and use those
+ * everywhere rather than building up URLs piecemeal from strings.
+ *
+ */
+export function addSharingId(url: string) {
+  assert(!url.includes('?'), `Url "${url}" has existing query params.`);
+  return url + SHARING_ID_QUERYSTRING;
+}
+
+/**
+ * Adds/Updates the unique sharing ID to the provided query params as necessary,
+ * returning true if they were modified.
+ */
+export function ensureSharingIdInQueryParams(params: {
+  [key: string]: unknown;
+}): boolean {
+  if (params[SHARING_ID_QUERY_PARAM] !== SHARING_ID) {
+    params[SHARING_ID_QUERY_PARAM] = SHARING_ID;
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Extracts the numeric part of the share images URL and removes the dash.
+ * E.g.: https://content.covidactnow.org/share/373-27/  ==>  37327
+ */
+function sharingId() {
+  const url = ShareImageUrlJSON.share_image_url;
+  const match = /\/([\d-]+)\/?$/.exec(url);
+  assert(match, `${url} did not match share images URL regex.`);
+  return match[1].replace('-', '');
+}

--- a/src/components/AppBar/AppBar.tsx
+++ b/src/components/AppBar/AppBar.tsx
@@ -30,6 +30,7 @@ import ArrowBack from '@material-ui/icons/ArrowBack';
 import { STATES } from 'common';
 import { Location } from 'history';
 import US_STATE_DATASET from '../MapSelectors/datasets/us_states_dataset_01_02_2020.json';
+import * as urls from 'common/urls';
 
 const Panels = ['/', '/about', '/resources', '/blog', '/contact'];
 
@@ -125,7 +126,9 @@ const _AppBar = () => {
     window.location.href = url;
   };
 
-  const shareURL = `https://covidactnow.org${match ? match.url : ''}`;
+  const shareURL = urls.addSharingId(
+    `https://covidactnow.org${match ? match.url : ''}`,
+  );
   const hashtag = 'COVIDActNow';
   const locationShareTitle = `${locationName}'s COVID risk from @CovidActNow, check it out: `;
   const defaultShareTitle =

--- a/src/components/EnsureSharingIdInUrl/EnsureSharingIdInUrl.tsx
+++ b/src/components/EnsureSharingIdInUrl/EnsureSharingIdInUrl.tsx
@@ -1,0 +1,24 @@
+import { useLocation } from 'react-router-dom';
+import { useHistory } from 'react-router-dom';
+import * as QueryString from 'query-string';
+import { ensureSharingIdInQueryParams } from 'common/urls';
+
+/**
+ * Component that adds a short unique string to the URL, corresponding to the
+ * currently published sharing preview images. This is important to make sure
+ * that the URL is unique enough so that if somebody shares it, then
+ * Facebook/Twitter/whoever will re-fetch it and get the latest sharing image.
+ */
+export default function EnsureSharingIdInUrl() {
+  const location = useLocation();
+  const history = useHistory();
+  const params = QueryString.parse(location.search);
+  if (ensureSharingIdInQueryParams(params)) {
+    history.replace({
+      ...location,
+      search: QueryString.stringify(params),
+    });
+  }
+
+  return null;
+}

--- a/src/components/EnsureSharingIdInUrl/index.ts
+++ b/src/components/EnsureSharingIdInUrl/index.ts
@@ -1,0 +1,3 @@
+import EnsureSharingIdInUrl from './EnsureSharingIdInUrl';
+
+export default EnsureSharingIdInUrl;

--- a/src/components/LocationPage/ShareButtons.js
+++ b/src/components/LocationPage/ShareButtons.js
@@ -11,6 +11,7 @@ import {
 import { ClickAwayListener } from '@material-ui/core';
 import makeChartShareQuote from 'common/utils/makeChartShareQuote';
 import ShareImageUrlJSON from 'assets/data/share_images_url.json';
+import * as urls from 'common/urls';
 
 const InnerContent = props => {
   const {
@@ -103,7 +104,9 @@ const ShareButtons = props => {
   const shareBaseURL = `https://covidactnow.org/us/${stateId.toLowerCase()}${
     county ? `/county/${county.county_url_name}` : ''
   }`;
-  const shareURL = `${shareBaseURL}/chart/${chartIdentifier}`;
+  const shareURL = urls.addSharingId(
+    `${shareBaseURL}/chart/${chartIdentifier}`,
+  );
 
   const innerContentProps = {
     shareURL,

--- a/src/components/ShareBlock/ShareBlock.tsx
+++ b/src/components/ShareBlock/ShareBlock.tsx
@@ -11,6 +11,7 @@ import {
 import Newsletter from 'components/Newsletter/Newsletter';
 import SocialLocationPreview from 'components/SocialLocationPreview/SocialLocationPreview';
 import { Projections } from 'common/models/Projections';
+import * as urls from 'common/urls';
 import NewsletterMockup from 'assets/images/newsletterMockup';
 import {
   ShareButtonContainer,
@@ -54,7 +55,7 @@ const ShareBlock = ({
 }) => {
   const locationPath = useLocation();
 
-  const url = shareURL || 'https://covidactnow.org/';
+  const url = urls.addSharingId(shareURL || 'https://covidactnow.org/');
   const quote =
     shareQuote ||
     '@CovidActNow has real-time COVID data and risk level for your community. Check it out: ';

--- a/src/screens/HomePage/HomePage.js
+++ b/src/screens/HomePage/HomePage.js
@@ -2,6 +2,7 @@ import React from 'react';
 import HomePageHeader from 'components/Header/HomePageHeader';
 import Map from 'components/Map/Map';
 import AppMetaTags from 'components/AppMetaTags/AppMetaTags';
+import EnsureSharingIdInUrl from 'components/EnsureSharingIdInUrl';
 import ShareBlock from 'components/ShareBlock/ShareBlock';
 import CriteriaExplanation from './CriteriaExplanation/CriteriaExplanation';
 import { PartnerLogoGrid, PressLogoGrid } from 'components/LogoGrid/LogoGrid';
@@ -16,6 +17,7 @@ import {
 export default function HomePage() {
   return (
     <>
+      <EnsureSharingIdInUrl />
       <AppMetaTags
         canonicalUrl="/"
         pageTitle={undefined}

--- a/src/screens/LocationPage/LocationPage.js
+++ b/src/screens/LocationPage/LocationPage.js
@@ -6,6 +6,7 @@ import { MAP_FILTERS } from './Enums/MapFilterEnums';
 import SearchHeader from 'components/Header/SearchHeader';
 import AppMetaTags from 'components/AppMetaTags/AppMetaTags';
 import MiniMap from 'components/MiniMap/MiniMap';
+import EnsureSharingIdInUrl from 'components/EnsureSharingIdInUrl';
 import ChartsHolder from 'components/LocationPage/ChartsHolder';
 import { LoadingScreen } from './LocationPage.style';
 import { useProjections } from 'common/utils/model';
@@ -49,6 +50,7 @@ function LocationPage() {
 
   return (
     <div>
+      <EnsureSharingIdInUrl />
       <AppMetaTags
         canonicalUrl={`/us/${stateId.toLowerCase()}`}
         pageTitle={actionTitle}


### PR DESCRIPTION
This adds a unique ?s=123 ID to our homepage / location URLs to ensure that Facebook / Twitter / etc. fetch fresh versions of them instead of using an old cached version of the page (and therefore the sharing preview image).

The ID corresponds to the ID in our sharing URL so it'll always update whenever we update our sharing images.

Fixes https://trello.com/c/iPbx5dC5/