### PR TITLE
Charts - Fix the default and fallback fonts

### DIFF
--- a/src/components/Charts/Charts.style.ts
+++ b/src/components/Charts/Charts.style.ts
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 
 const charts = {
-  fontFamily: "'Source Code Pro', 'Roboto', sans-serif",
+  fontFamily: "'Source Code Pro', 'Roboto Mono', monospace",
   fontWeight: 'bold',
   fontSize: '13px',
   series: {


### PR DESCRIPTION
Fixes the default font for the charts

While working on #850 - Implement 4th color, I noticed that the box around the "Critical" didn't enclose the text correctly. This happens because during the first render the browser uses the default font to measure the box, and doesn't measure it again when the fonts are loaded.

#### Not so good 😢 
![image](https://user-images.githubusercontent.com/114084/83363284-1b0f0580-a34d-11ea-8953-49e668668077.png)

If we change the default font to `monospace`, the discrepancy between size of the box calculated with the default font and with `Source Code Pro` is almost unnoticeable.

### Better 👌 
![image](https://user-images.githubusercontent.com/114084/83363300-4691f000-a34d-11ea-9a42-5e3d147c9058.png)

It also changes the fallback `Roboto` to `Roboto Mono` since we expect the font of the chart to be monospaced.

#### Testing

- Change the `text` to `"Critical"` on [src/components/Charts/BoxedAnnotation.tsx#L37](https://github.com/covid-projections/covid-projections/blob/master/src/components/Charts/BoxedAnnotation.tsx#L37) and render the charts, compare with `develop`.

Can @goldblatt review?



