### PR TITLE
Fix several issues with conflating null and '0', leading to our metrics disappearing when the metric goes to 0.

### DIFF
--- a/src/common/models/Projection.ts
+++ b/src/common/models/Projection.ts
@@ -550,7 +550,7 @@ export class Projection {
           row &&
           this.totalICUCapacity &&
           this.totalICUCapacity > 0 &&
-          row.ICUBedsInUse > 0
+          row.ICUBedsInUse != null
         ) {
           const predictedNonCovidPatientsAtDate =
             this.totalICUCapacity! *

--- a/src/common/models/Projection.ts
+++ b/src/common/models/Projection.ts
@@ -550,7 +550,7 @@ export class Projection {
           row &&
           this.totalICUCapacity &&
           this.totalICUCapacity > 0 &&
-          row.ICUBedsInUse != null
+          row.ICUBedsInUse !== null
         ) {
           const predictedNonCovidPatientsAtDate =
             this.totalICUCapacity! *

--- a/src/common/models/Projections.ts
+++ b/src/common/models/Projections.ts
@@ -109,12 +109,7 @@ export class Projections {
       contact_tracing_level,
     } = this.getLevels();
 
-    // TODO(https://trello.com/c/ybqacRAN): Hawaii ICU disappeared and we don't
-    // want that to pull the state grey.
-    const levelList =
-      this.stateCode === 'HI'
-        ? [rt_level, test_rate_level]
-        : [rt_level, hospitalizations_level, test_rate_level];
+    const levelList = [rt_level, hospitalizations_level, test_rate_level];
 
     // contact tracing levels are reversed (i.e low is bad, high is good)
     const reverseList = [contact_tracing_level];

--- a/src/components/Charts/MetricChart.tsx
+++ b/src/components/Charts/MetricChart.tsx
@@ -21,7 +21,7 @@ export default function MetricChart({
   height?: number;
 }) {
   const projection = projections.primary;
-  if (projection == null || projections.getMetricValue(metric) == null) {
+  if (projection === null || projections.getMetricValue(metric) === null) {
     return null;
   }
   return (

--- a/src/components/Charts/MetricChart.tsx
+++ b/src/components/Charts/MetricChart.tsx
@@ -21,37 +21,35 @@ export default function MetricChart({
   height?: number;
 }) {
   const projection = projections.primary;
-  if (!projection) {
+  if (projection == null || projections.getMetricValue(metric) == null) {
     return null;
   }
   return (
     <>
-      {metric === Metric.CASE_GROWTH_RATE && projection.rt && (
+      {metric === Metric.CASE_GROWTH_RATE && (
         <ChartRt
           height={height}
           columnData={projection.getDataset('rtRange')}
         />
       )}
-      {metric === Metric.POSITIVE_TESTS &&
-        projection.currentTestPositiveRate && (
-          <ChartPositiveTestRate
-            height={height}
-            columnData={projection.getDataset('testPositiveRate')}
-          />
-        )}
-      {metric === Metric.HOSPITAL_USAGE && projection.currentIcuUtilization && (
+      {metric === Metric.POSITIVE_TESTS && (
+        <ChartPositiveTestRate
+          height={height}
+          columnData={projection.getDataset('testPositiveRate')}
+        />
+      )}
+      {metric === Metric.HOSPITAL_USAGE && (
         <ChartICUHeadroom
           height={height}
           columnData={projection.getDataset('icuUtilization')}
         />
       )}
-      {metric === Metric.CONTACT_TRACING &&
-        projection.currentContactTracerMetric && (
-          <ChartContactTracing
-            height={height}
-            columnData={projection.getDataset('contractTracers')}
-          />
-        )}
+      {metric === Metric.CONTACT_TRACING && (
+        <ChartContactTracing
+          height={height}
+          columnData={projection.getDataset('contractTracers')}
+        />
+      )}
       {metric === Metric.FUTURE_PROJECTIONS && (
         <ChartFutureHospitalization height={height} projections={projections} />
       )}

--- a/src/components/LocationPage/ChartsHolder.tsx
+++ b/src/components/LocationPage/ChartsHolder.tsx
@@ -322,29 +322,29 @@ export function getChartData(
   contactTracingData: any;
 } {
   const rtRangeData =
-    projection &&
-    projection.rt &&
-    projection.getDataset('rtRange').map(d => ({
-      x: d.x,
-      y: d.y?.rt,
-      low: d.y?.low,
-      hi: d.y?.high,
-    }));
+    projection?.rt == null
+      ? null
+      : projection.getDataset('rtRange').map(d => ({
+          x: d.x,
+          y: d.y?.rt,
+          low: d.y?.low,
+          hi: d.y?.high,
+        }));
 
   const testPositiveData =
-    projection &&
-    projection.currentTestPositiveRate &&
-    projection.getDataset('testPositiveRate');
+    projection?.currentTestPositiveRate == null
+      ? null
+      : projection.getDataset('testPositiveRate');
 
   const icuUtilizationData =
-    projection &&
-    projection.currentIcuUtilization &&
-    projection.getDataset('icuUtilization');
+    projection?.currentIcuUtilization == null
+      ? null
+      : projection.getDataset('icuUtilization');
 
   const contactTracingData =
-    projection &&
-    projection.currentContactTracerMetric &&
-    projection.getDataset('contractTracers');
+    projection?.currentContactTracerMetric == null
+      ? null
+      : projection.getDataset('contractTracers');
 
   return {
     rtRangeData,

--- a/src/components/SummaryStats/SummaryStats.tsx
+++ b/src/components/SummaryStats/SummaryStats.tsx
@@ -62,7 +62,7 @@ const SummaryStat = ({
         {!condensed && <StatDetailText>{levelInfo.detail()}</StatDetailText>}
       </StatTextWrapper>
       <StatValueWrapper condensed={condensed}>
-        {value && (
+        {value == null ? null : (
           <>
             <StatValueText condensed={condensed}>
               {formatValueForChart(chartType, value)}


### PR DESCRIPTION
In particular, this fixes:
1. The Montana ICU chart truncating at May 18, due to the value going to 0%.
2. The Hawaii ICU chart disappearing entirely because it was all 0's.

**Before:**
![image](https://user-images.githubusercontent.com/206364/83802016-e954b200-a65e-11ea-9693-562f2f26ce74.png)

**After:**
![image](https://user-images.githubusercontent.com/206364/83802062-f96c9180-a65e-11ea-8593-f3e7b9e1fa39.png)

**Before:**
![image](https://user-images.githubusercontent.com/206364/83802151-1d2fd780-a65f-11ea-9dee-981bd2f925d6.png)

**After:**
![image](https://user-images.githubusercontent.com/206364/83802190-2ae55d00-a65f-11ea-9e26-340595e9bb62.png)
