### PR TITLE
Ignore negative deltas in cumulatives. Fixes test positive rate for several states.

### DIFF
--- a/src/common/models/Projection.ts
+++ b/src/common/models/Projection.ts
@@ -481,13 +481,16 @@ export class Projection {
     );
 
     return dailyPositives.map((dailyPositive, idx) => {
-      const positive = dailyPositive || 0;
-      const negative = dailyNegatives[idx] || 0;
-      const total = positive + negative;
+      const positive = dailyPositive;
+      const negative = dailyNegatives[idx];
       // If there are no negatives (but there are positives), then this is
       // likely the last data point, else it would have gotten smoothed, and
       // it's probably a reporting lag issue. So just return null.
-      return negative > 0 ? positive / total : null;
+      if (negative !== null && positive !== null && negative > 0) {
+        return positive / (negative + positive);
+      } else {
+        return null;
+      }
     });
   }
 
@@ -510,7 +513,15 @@ export class Projection {
       if (current === null) {
         result.push(null);
       } else {
-        result.push(current - lastNonNull);
+        if (current - lastNonNull < 0) {
+          // Sometimes series have a "correction" that resets the count
+          // backwards. We treat that as a 'null' delta. Note: They could also
+          // have a correction in the opposite direction, forcing an unusually
+          // high delta, but we don't have a way to detect / handle that. :-(
+          result.push(null);
+        } else {
+          result.push(current - lastNonNull);
+        }
         lastNonNull = current;
       }
     }


### PR DESCRIPTION
A number of states seemingly made large corrections to their test reporting in the last week or two resulting in large _negative_ deltas in the day/day numbers, which was wagging the positive test rate metric around...

This PR fixes our deltasFromCumulatives() code to always ignore negative deltas (replace them with a null) and then consequentially our calcTestPositiveRate() needed to deal with nulls properly.

A bunch of states were affected modestly, but a few had big changes, e.g.:

**DC Before**
![image](https://user-images.githubusercontent.com/206364/83808153-26be3d00-a669-11ea-8671-f83578c21cc5.png)

**DC After**
![image](https://user-images.githubusercontent.com/206364/83808163-2d4cb480-a669-11ea-8395-0fb4ec75628c.png)

---
**GA Before**
![image](https://user-images.githubusercontent.com/206364/83808249-566d4500-a669-11ea-855a-2fee0b836646.png)

**GA After**
![image](https://user-images.githubusercontent.com/206364/83808262-5b31f900-a669-11ea-8f1c-90c75321e779.png)

---
**MO Before**
![image](https://user-images.githubusercontent.com/206364/83808310-6c7b0580-a669-11ea-99d3-393265cb374c.png)

**MO After**
![image](https://user-images.githubusercontent.com/206364/83808320-700e8c80-a669-11ea-9414-fd5cb9d15849.png)
