### PR TITLE
Charts - Fix missing label on hospitalizations chart

### DIFF
--- a/src/components/Charts/ChartFutureHospitalization.tsx
+++ b/src/components/Charts/ChartFutureHospitalization.tsx
@@ -27,6 +27,8 @@ type PointProjections = Point & {
   isBeds: boolean;
 };
 
+const MAX_LINE_WIDTH = 3;
+
 const getDate = (p: Point) => new Date(p.x);
 const getY = (p: Point) => p.y;
 const hasData = (d: any) => isDate(getDate(d)) && Number.isFinite(getY(d));
@@ -43,7 +45,7 @@ const ChartFutureHospitalization = ({
   projections,
   width,
   height,
-  marginTop = 5,
+  marginTop = 25,
   marginBottom = 40,
   marginLeft = 48,
   marginRight = 5,
@@ -98,7 +100,7 @@ const ChartFutureHospitalization = ({
   assert(minY !== undefined && maxY !== undefined, 'Data must not be empty');
   const yScale = scaleLinear({
     domain: [minY, maxY],
-    range: [chartHeight, 0],
+    range: [chartHeight - MAX_LINE_WIDTH, 0],
   });
 
   const getXCoord = (p: Point): number => xScale(getDate(p));
@@ -150,16 +152,6 @@ const ChartFutureHospitalization = ({
           <Style.SeriesLine stroke={theme.palette.chart.foreground}>
             <LinePath data={dataProjectedPast} x={getXCoord} y={getYCoord} />
           </Style.SeriesLine>
-          <Style.TextAnnotation
-            textAnchor={'start'}
-            dominantBaseline={'baseline'}
-          >
-            <BoxedAnnotation
-              x={getXCoord(firstPointBeds)}
-              y={getYCoord(firstPointBeds) - 5}
-              text={`${formatInteger(getY(firstPointBeds))} beds`}
-            />
-          </Style.TextAnnotation>
           <Style.LineGrid>
             <LinePath data={dataBeds} x={getXCoord} y={getYCoord} />
           </Style.LineGrid>
@@ -176,6 +168,16 @@ const ChartFutureHospitalization = ({
             hideZero
           />
         </RectClipGroup>
+        <Style.TextAnnotation
+          textAnchor={'start'}
+          dominantBaseline={'baseline'}
+        >
+          <BoxedAnnotation
+            x={getXCoord(firstPointBeds)}
+            y={getYCoord(firstPointBeds) - 10}
+            text={`${formatInteger(getY(firstPointBeds))} beds`}
+          />
+        </Style.TextAnnotation>
         <Style.Axis>
           <AxisBottom
             top={chartHeight}


### PR DESCRIPTION
Close [193](https://trello.com/c/ALh0HTSt/193-make-sure-capacity-horizontal-line-is-labeled-in-projection-charts) - Make sure that the capacity horizontal line is labeled in projections chart

The vertical scale maps the min and max values on the data to the min and max values of the inner chart dimensions in pixels. If the number of beds is the maximum data value, the label ends up outside the chart because it's above the line.

This PR moves the label outside the clipping path boundaries to avoid cropping the label and adjusts the chart margins a bit so it fits. I also adjusted where the minimum value goes (`chartHeight - MAX_LINE_WIDTH`) to avoid hiding the lines if they are too close to the x-axis.

**Before** https://covidactnow.org/us/ak?s=41740
![image](https://user-images.githubusercontent.com/114084/83916878-cdb6dd80-a72a-11ea-90b4-08ea2ac28a0b.png)

**After** https://covid-projections-git-pablo-fix-hospitalization-bed-count.covidactnow.now.sh/us/ak?s=41740
![image](https://user-images.githubusercontent.com/114084/83917483-d1972f80-a72b-11ea-8035-855e228ba1b3.png)

Can @chasulin review?
