### PR TITLE
Fix alignment of y-axis ticks on all charts

### DIFF
--- a/src/components/Charts/ChartFutureHospitalization.tsx
+++ b/src/components/Charts/ChartFutureHospitalization.tsx
@@ -8,7 +8,7 @@ import { scaleLinear, scaleTime } from '@vx/scale';
 import { COLORS } from 'common';
 import { Projections } from 'common/models/Projections';
 import { assert, formatDate, formatInteger } from 'common/utils';
-import { AxisBottom, AxisLeft } from './Axis';
+import { AxisBottom } from './Axis';
 import BoxedAnnotation from './BoxedAnnotation';
 import ChartContainer from './ChartContainer';
 import RectClipGroup from './RectClipGroup';
@@ -167,13 +167,6 @@ const ChartFutureHospitalization = ({
             cx={getXCoord(lastPastPoint)}
             cy={getYCoord(lastPastPoint)}
             r={6}
-          />
-          <AxisLeft
-            top={marginTop}
-            scale={yScale}
-            hideAxisLine
-            hideTicks
-            hideZero
           />
         </RectClipGroup>
         <Style.Axis>

--- a/src/components/Charts/ChartRt.tsx
+++ b/src/components/Charts/ChartRt.tsx
@@ -202,7 +202,7 @@ const ChartRt = ({
         r={6}
       />
       <AxisBottom top={chartHeight} scale={xScale} />
-      <AxisLeft top={marginTop} scale={yScale} tickValues={yTicks} />
+      <AxisLeft scale={yScale} tickValues={yTicks} />
     </ChartContainer>
   );
 };

--- a/src/components/Charts/ChartZones.tsx
+++ b/src/components/Charts/ChartZones.tsx
@@ -165,7 +165,6 @@ const ChartZones = ({
       </Style.TextAnnotation>
       <AxisBottom top={chartHeight} scale={xScale} />
       <AxisLeft
-        top={marginTop}
         scale={yScale}
         tickValues={yTicks}
         hideAxisLine


### PR DESCRIPTION
Fixes a bug that was causing the y-axis ticks to be misaligned by 5px.

I noticed this while working on https://github.com/covid-projections/covid-projections/pull/889, I increased the margin-top to accommodate the intervention annotations, and then all the values for the y-axis ticks were misaligned.

In [`ChartContainer.tsx#L58`](https://github.com/covid-projections/covid-projections/blob/master/src/components/Charts/ChartContainer.tsx#L58) component adds the margin-left and margin-top for all its child components, so by setting the `marginTop` property on the `AxisLeft component, we were moving down the y-axis 5px down.

![image](https://user-images.githubusercontent.com/114084/83933109-a546d780-a75a-11ea-82de-8638e0791ec8.png)

I also removed the `AxisLeft` from the `ChartFutureHospitalizations` because this chart doesn't have an axis (I added it during development and forgot to remove it later). Can @chasulin or @mikelehen review?
