### PR TITLE
Tweak scaling homepage share card image so that legend isn't truncated.

### DIFF
--- a/src/screens/internal/ShareImage/ShareCardImage.style.ts
+++ b/src/screens/internal/ShareImage/ShareCardImage.style.ts
@@ -8,7 +8,7 @@ export const ShareCardWrapper = styled.div<{ isHomePage?: boolean }>`
   margin: 50px auto;
   width: 400px;
   height: 262px;
-  transform: scale(${props => (props.isHomePage ? 2.5 : 1.75)});
+  transform: scale(${props => (props.isHomePage ? 2.25 : 1.75)});
   transform-origin: top center;
 `;
 


### PR DESCRIPTION
**Trello:** https://trello.com/c/C1ypJQvo/224-home-page-share-card-is-truncated

**Before:**
![image](https://user-images.githubusercontent.com/206364/84317110-1acaf300-ab21-11ea-8026-ba17bb10e185.png)

**After:**
![image](https://user-images.githubusercontent.com/206364/84317119-1ef71080-ab21-11ea-9367-c50eaf379fd3.png)
