### PR TITLE
Header buttons style-fix

### DIFF
--- a/src/components/LocationPage/NewLocationPageHeader.style.tsx
+++ b/src/components/LocationPage/NewLocationPageHeader.style.tsx
@@ -185,11 +185,9 @@ export const ButtonsWrapper = styled(Box)`
   }
 `;
 
-export const HeaderButton = styled(Box)<{
-  hide?: Boolean;
-}>`
+export const HeaderButton = styled(Box)`
   height: 50px;
-  width: 100%;
+  width: 50%;
   font-size: 15px;
   line-height: 1.2;
   cursor: pointer;
@@ -198,15 +196,23 @@ export const HeaderButton = styled(Box)<{
   font-weight: 500;
   text-align: center;
   margin: auto;
-  display: ${props => (props.hide ? 'none' : 'flex')};
+  display: flex;
   align-items: center;
   justify-content: center;
-  border-top: 1px solid #f2f2f2;
+  border-top: 1px solid ${COLORS.LIGHTGRAY};
+
+  &:first-child {
+    border-right: 1px solid ${COLORS.LIGHTGRAY};
+  }
 
   @media (min-width: 600px) {
     border-top: none;
     width: 75px;
     height: 40px;
+
+    &:first-child {
+      border-right: none;
+    }
   }
 `;
 


### PR DESCRIPTION
lil change: adds back in gray border between 'share' and 'get alerts' buttons (mobile only)

<img width="367" alt="Screen Shot 2020-06-11 at 11 30 00 AM" src="https://user-images.githubusercontent.com/44076375/84406010-ef0a4480-abd6-11ea-8280-1d76181231cb.png">
