### PR TITLE
Hide the first line in home page subheading on mobile

### DIFF
--- a/src/components/Header/HomePageHeader.style.tsx
+++ b/src/components/Header/HomePageHeader.style.tsx
@@ -49,6 +49,13 @@ export const HeaderSubCopy = styled(Typography)<{ component?: string }>`
   }
 `;
 
+export const HeaderSubCopyItem = styled.span<{ hideOnMobile?: boolean }>`
+  display: ${props => (props.hideOnMobile ? 'none' : 'unset')};
+  @media (min-width: 600px) {
+    display: unset;
+  }
+`;
+
 export const Disclaimer = styled.div`
   padding: 0.7rem 1rem;
   border: 1px solid rgba(0, 0, 0, 0.12);

--- a/src/components/Header/HomePageHeader.tsx
+++ b/src/components/Header/HomePageHeader.tsx
@@ -10,6 +10,7 @@ import {
   HeaderSubCopy,
   HighlightColor,
   HeaderTitle,
+  HeaderSubCopyItem,
 } from './HomePageHeader.style';
 
 const HomePageHeader = () => {
@@ -36,8 +37,13 @@ const HomePageHeader = () => {
         </HeaderTitle>
         <div>
           <HeaderSubCopy color="inherit" component="p" variant="subtitle2">
-            See COVID data and risk level for your community.
-            <br /> All 50 states. 2,100+ counties.
+            <HeaderSubCopyItem hideOnMobile>
+              See COVID data and risk level for your community.
+              <br />
+            </HeaderSubCopyItem>
+            <HeaderSubCopyItem>
+              All 50 states. 2,100+ counties.
+            </HeaderSubCopyItem>
           </HeaderSubCopy>
 
           <SelectorWrapper>


### PR DESCRIPTION
This PR removes the first line of the subheading on mobile.

From [Slack](https://covidactnow.slack.com/archives/C011CKR2B2B/p1591811774012400)

![image](https://user-images.githubusercontent.com/114084/84470449-3b39a100-ac38-11ea-8ad4-0a26632928ff.png)

Can @igorkofman review?