### PR TITLE
Adjust decomp factor from 30% to 25% (#932)

### DIFF
--- a/src/common/models/Projection.ts
+++ b/src/common/models/Projection.ts
@@ -29,9 +29,16 @@ export const TRACERS_NEEDED_PER_CASE = 5;
  * get from the API to account for hospitals being able to decrease their utilization
  * (by cancelling elective surgeries, using surge capacity, etc.).
  */
-const ICU_DECOMP_FACTOR = 0.3;
+const ICU_DECOMP_FACTOR = 0.25;
 const ICU_DECOMP_FACTOR_STATE_OVERRIDES: { [key: string]: number } = {
+  Alabama: 0.2,
   Arizona: 0,
+  Delaware: 0.3,
+  'District of Columbia': 0.1,
+  Georgia: 0.2,
+  Mississippi: 0.2,
+  Nevada: 0.3,
+  'Rhode Island': 0.15,
 };
 
 const DEFAULT_UTILIZATION = 0.75;
@@ -248,7 +255,7 @@ export class Projection {
     return this.cumulativeDeaths[this.cumulativeDeaths.length - 1];
   }
 
-  get icuDecompFactor(): number {
+  get nonCovidICUUtilization(): number {
     if (this.stateName in ICU_DECOMP_FACTOR_STATE_OVERRIDES) {
       return Math.max(
         0,
@@ -270,7 +277,7 @@ export class Projection {
       );
       return latestCurrentUssage! - latestUsageCovid!;
     }
-    return this.totalICUCapacity! * this.icuDecompFactor;
+    return this.totalICUCapacity! * this.nonCovidICUUtilization;
   }
 
   /** Returns the date when projections end (should be 90 days out). */
@@ -588,7 +595,7 @@ export class Projection {
           row.ICUBedsInUse !== null
         ) {
           const predictedNonCovidPatientsAtDate =
-            this.totalICUCapacity! * this.icuDecompFactor;
+            this.totalICUCapacity! * this.nonCovidICUUtilization;
 
           const icuHeadroomUsed =
             row.ICUBedsInUse /


### PR DESCRIPTION
Update default decomp factor to 25% and override states that are >5% off of the 25% (based on CDC estimates)