### PR TITLE
Truncate 'Hospital Overload Date' to 30 days.

### DIFF
--- a/src/common/models/Projection.ts
+++ b/src/common/models/Projection.ts
@@ -213,6 +213,12 @@ export class Projection {
       summaryWithTimeseries.projections.totalHospitalBeds.shortageStartDate;
     this.dateOverwhelmed =
       shortageStart === null ? null : new Date(shortageStart);
+    if (
+      moment(this.dateOverwhelmed).diff(moment(), 'days') >
+      PROJECTIONS_TRUNCATION_DAYS
+    ) {
+      this.dateOverwhelmed = null;
+    }
 
     this.currentCumulativeDeaths =
       summaryWithTimeseries.actuals.cumulativeDeaths;


### PR DESCRIPTION
@BrettBoval noticed that we were showing overload dates beyond the truncated chart, e.g. CA on prod:

![image](https://user-images.githubusercontent.com/206364/84964756-c7791780-b0c1-11ea-921e-57cf2d6a729a.png)
