### PR TITLE
Implement LocationMap component

### DIFF
--- a/src/common/metrics/location_summary.ts
+++ b/src/common/metrics/location_summary.ts
@@ -1,5 +1,6 @@
 import { COLOR_MAP } from 'common/colors';
 import { Level, LevelInfoMap } from 'common/level';
+import { LEVEL_COLOR } from 'common/colors';
 
 // Note: These names are used on SocialLocationPreview
 const LOW_NAME = 'Low';
@@ -7,6 +8,29 @@ const MEDIUM_NAME = 'Medium';
 const MEDIUM_HIGH_NAME = 'High';
 const HIGH_NAME = 'Critical';
 const UNKNOWN = 'Unknown';
+
+export const MAP_LEGEND = {
+  [Level.LOW]: {
+    color: LEVEL_COLOR[Level.LOW],
+    legend: 'On track to contain COVID',
+  },
+  [Level.MEDIUM]: {
+    color: LEVEL_COLOR[Level.MEDIUM],
+    legend: 'Controlled disease growth',
+  },
+  [Level.MEDIUM_HIGH]: {
+    color: LEVEL_COLOR[Level.MEDIUM_HIGH],
+    legend: 'At risk',
+  },
+  [Level.HIGH]: {
+    color: LEVEL_COLOR[Level.HIGH],
+    legend: 'Active or imminent outbreak',
+  },
+  [Level.UNKNOWN]: {
+    color: LEVEL_COLOR[Level.UNKNOWN],
+    legend: 'Unknown',
+  },
+};
 
 export const LOCATION_SUMMARY_LEVELS: LevelInfoMap = {
   [Level.LOW]: {

--- a/src/components/LocationMap/LocationMap.style.tsx
+++ b/src/components/LocationMap/LocationMap.style.tsx
@@ -1,0 +1,18 @@
+import styled from 'styled-components';
+import Typography from '@material-ui/core/Typography';
+
+export const Container = styled.div`
+  margin: 3.5rem 0 0.25rem;
+`;
+
+export const MapInstructions = styled(Typography)`
+  margin-bottom: 0.625rem;
+  font-size: 0.875rem;
+  line-height: 1.125rem;
+  color: #828282;
+`;
+
+export const MapTitle = styled(Typography)`
+  font-size: 1.5rem;
+  font-weight: 700;
+`;

--- a/src/components/LocationMap/LocationMap.tsx
+++ b/src/components/LocationMap/LocationMap.tsx
@@ -1,0 +1,126 @@
+import React from 'react';
+import { useHistory } from 'react-router-dom';
+import { find as _find } from 'lodash';
+import Grid from '@material-ui/core/Grid';
+import Hidden from '@material-ui/core/Hidden';
+import { useTheme } from '@material-ui/core/styles';
+import useMediaQuery from '@material-ui/core/useMediaQuery';
+import { ParentSize } from '@vx/responsive';
+import { Level } from 'common/level';
+import { MAP_LEGEND } from 'common/metrics/location_summary';
+import CountyMap from 'components/CountyMap/CountyMap';
+import { LegendItem } from 'components/Map/Legend';
+import { County } from 'components/LocationPage/ChartsHolder';
+import US_STATE_DATASET from 'components/MapSelectors/datasets/us_states_dataset_01_02_2020.json';
+import * as Style from './LocationMap.style';
+
+const getCounty = (stateId: string, fullFips: string) =>
+  _find(
+    // @ts-ignore: US_STATE_DATASET is .js, but this is valid
+    US_STATE_DATASET.state_county_map_dataset[stateId].county_dataset,
+    ['full_fips_code', fullFips],
+  );
+
+const LEVELS = [
+  Level.LOW,
+  Level.MEDIUM,
+  Level.MEDIUM_HIGH,
+  Level.HIGH,
+  Level.UNKNOWN,
+];
+
+// Note: There is no Level for "no data", and adding it to the MAP_LEGEND
+// object would mean to add it for the metrics as well.
+const LEGEND_ITEMS = [
+  ...LEVELS.map(level => ({
+    title: MAP_LEGEND[level].legend,
+    color: MAP_LEGEND[level].color,
+  })),
+  {
+    title: 'No data',
+    color: '#e3e3e3',
+  },
+];
+
+// On mobile, the order of the legend items needs to be changed so the items
+// can be read vertically. It's easier to change the order of the items on
+// mobile than setting the layout to work that way.
+//
+// The order of the items (reading from left to rigth and top to bottom)
+// should be:
+//
+// 0. LOW           3. HIGH
+// 1. MEDIUM        4. UNKNOWN
+// 2. MEDIUM_HIGH   5. NO_DATA
+const LEGEND_ITEMS_MOBILE = [
+  LEGEND_ITEMS[0],
+  LEGEND_ITEMS[3],
+  LEGEND_ITEMS[1],
+  LEGEND_ITEMS[4],
+  LEGEND_ITEMS[2],
+  LEGEND_ITEMS[5],
+];
+
+const LocationMap: React.FunctionComponent<{
+  selectedCounty: County;
+  setSelectedCounty: (input: string) => {};
+  stateId: string;
+}> = ({ selectedCounty, setSelectedCounty, stateId }) => {
+  const history = useHistory();
+  const theme = useTheme();
+
+  const goTo = (route: string) => {
+    history.push(route);
+  };
+
+  const isMobile = useMediaQuery(theme.breakpoints.down('xs'));
+  const legendItems = isMobile ? LEGEND_ITEMS_MOBILE : LEGEND_ITEMS;
+
+  const onClickCounty = (fullFips: string): void => {
+    const county = getCounty(stateId, fullFips);
+    goTo(`/us/${stateId.toLowerCase()}/county/${county.county_url_name}`);
+    setSelectedCounty(county);
+  };
+
+  return (
+    <Style.Container>
+      <Grid container>
+        <Grid item xs={12}>
+          <Hidden smUp>
+            <Style.MapTitle>COVID Threat Level</Style.MapTitle>
+          </Hidden>
+        </Grid>
+        <Grid item xs={12} sm={8}>
+          <ParentSize>
+            {({ width }) => (
+              // The map has a default aspect ratio of 800x600. Since the width is
+              // determined by the device, we scale the height keeping the ratio.
+              <div style={{ width, height: 0.75 * width }}>
+                <CountyMap
+                  selectedCounty={selectedCounty}
+                  setSelectedCounty={onClickCounty}
+                />
+              </div>
+            )}
+          </ParentSize>
+        </Grid>
+        <Grid container item xs={12} sm={4} alignContent="space-between">
+          <Grid item sm={12}>
+            <Hidden xsDown>
+              <Style.MapTitle>COVID Threat Level</Style.MapTitle>
+            </Hidden>
+          </Grid>
+          <Grid container item sm={12}>
+            {legendItems.map(({ title, color }, idx) => (
+              <Grid item xs={6} sm={12} key={`legend-item-${idx}`}>
+                <LegendItem title={title} color={color} />
+              </Grid>
+            ))}
+          </Grid>
+        </Grid>
+      </Grid>
+    </Style.Container>
+  );
+};
+
+export default LocationMap;

--- a/src/components/LocationMap/index.ts
+++ b/src/components/LocationMap/index.ts
@@ -1,0 +1,3 @@
+import LocationMap from './LocationMap';
+
+export default LocationMap;

--- a/src/components/LocationPage/ChartsHolder.tsx
+++ b/src/components/LocationPage/ChartsHolder.tsx
@@ -18,6 +18,7 @@ import ShareModelBlock from 'components/ShareBlock/ShareModelBlock';
 import LocationPageHeader from 'components/LocationPage/LocationPageHeader';
 import Outcomes from 'components/Outcomes/Outcomes';
 import ShareButtons from 'components/LocationPage/ShareButtons';
+import LocationMap from 'components/LocationMap';
 import useMediaQuery from '@material-ui/core/useMediaQuery';
 import { useTheme } from '@material-ui/core/styles';
 import {
@@ -40,7 +41,7 @@ import { formatUtcDate } from 'common/utils';
 const FUTURE_PROJECTIONS_DISABLED_STATES: string[] = ['HI'];
 
 // TODO(michael): figure out where this type declaration should live.
-type County = {
+export type County = {
   county: string;
   county_url_name: string;
   county_fips_code: string;
@@ -68,6 +69,8 @@ const ChartsHolder = (props: {
   county: County;
   chartId: string;
   countyId: string;
+  selectedCounty: County;
+  setSelectedCounty: (input: string) => {};
 }) => {
   const projection: Projection | null = props.projections.primary;
   const noInterventionProjection: Projection = props.projections.baseline;
@@ -164,6 +167,11 @@ const ChartsHolder = (props: {
               isMobile={isMobile}
             />
             <MainContentInner>
+              <LocationMap
+                stateId={props.stateId}
+                selectedCounty={props.selectedCounty}
+                setSelectedCounty={props.setSelectedCounty}
+              />
               <ChartHeaderWrapper>
                 <ChartHeader ref={rtRangeRef}>
                   {getMetricName(Metric.CASE_GROWTH_RATE)}

--- a/src/components/Map/Legend.js
+++ b/src/components/Map/Legend.js
@@ -5,7 +5,6 @@ import {
   LegendTitle,
   LegendContainer,
   LegendItemHeader,
-  LegendItemContainer,
   LegendWrapper,
 } from './Legend.style';
 
@@ -22,14 +21,9 @@ export function Legend(props) {
   );
 }
 
-export function LegendItem(props) {
-  const { title, color, condensed } = props;
-  return (
-    <LegendItemContainer condensed={condensed}>
-      <LegendItemHeader>
-        <ColorBox color={color} />
-        {title}
-      </LegendItemHeader>
-    </LegendItemContainer>
-  );
-}
+export const LegendItem = ({ title, color }) => (
+  <LegendItemHeader>
+    <ColorBox color={color} />
+    {title}
+  </LegendItemHeader>
+);

--- a/src/components/Map/Map.js
+++ b/src/components/Map/Map.js
@@ -3,18 +3,13 @@ import '../../App.css'; /* optional for styling like the :hover pseudo-class */
 import { useHistory } from 'react-router-dom';
 import { REVERSED_STATES } from 'common';
 import { Level } from 'common/level';
-import { LOCATION_SUMMARY_LEVELS } from 'common/metrics/location_summary';
 import { Legend, LegendItem } from './Legend';
 import USACountyMap from './USACountyMap';
 import { MAP_FILTERS } from '../../screens/LocationPage/Enums/MapFilterEnums';
 import ReactTooltip from 'react-tooltip';
 import { MapInstructions, MobileLineBreak } from './Map.style';
-
-// TODO(@pablo): We might want to move this to LOCATION_SUMMARY_LEVELS
-const LEGEND_LOW = 'On track to contain COVID';
-const LEGEND_MEDIUM = 'Controlled disease growth';
-const LEGEND_MEDIUM_HIGH = 'At risk';
-const LEGEND_HIGH = 'Active or imminent outbreak';
+import { MAP_LEGEND } from 'common/metrics/location_summary';
+import * as StyleLegend from 'components/Map/Legend.style';
 
 function Map({ hideLegend = false, setMobileMenuOpen, setMapOption }) {
   const history = useHistory();
@@ -43,26 +38,30 @@ function Map({ hideLegend = false, setMobileMenuOpen, setMapOption }) {
     <div className="Map">
       {!hideLegend && (
         <Legend>
-          <LegendItem
-            key={'legend-4'}
-            title={LEGEND_HIGH}
-            color={LOCATION_SUMMARY_LEVELS[Level.HIGH].color}
-          />
-          <LegendItem
-            key={'legend-3'}
-            title={LEGEND_MEDIUM_HIGH}
-            color={LOCATION_SUMMARY_LEVELS[Level.MEDIUM_HIGH].color}
-          />
-          <LegendItem
-            key={'legend-2'}
-            title={LEGEND_MEDIUM}
-            color={LOCATION_SUMMARY_LEVELS[Level.MEDIUM].color}
-          />
-          <LegendItem
-            key={'legend-1'}
-            title={LEGEND_LOW}
-            color={LOCATION_SUMMARY_LEVELS[Level.LOW].color}
-          />
+          <StyleLegend.LegendItemContainer key="legend-4">
+            <LegendItem
+              title={MAP_LEGEND[Level.HIGH].legend}
+              color={MAP_LEGEND[Level.HIGH].color}
+            />
+          </StyleLegend.LegendItemContainer>
+          <StyleLegend.LegendItemContainer key="legend-3">
+            <LegendItem
+              title={MAP_LEGEND[Level.MEDIUM_HIGH].legend}
+              color={MAP_LEGEND[Level.MEDIUM_HIGH].color}
+            />
+          </StyleLegend.LegendItemContainer>
+          <StyleLegend.LegendItemContainer key="legend-2">
+            <LegendItem
+              title={MAP_LEGEND[Level.MEDIUM].legend}
+              color={MAP_LEGEND[Level.MEDIUM].color}
+            />
+          </StyleLegend.LegendItemContainer>
+          <StyleLegend.LegendItemContainer key="legend-1">
+            <LegendItem
+              title={MAP_LEGEND[Level.LOW].legend}
+              color={MAP_LEGEND[Level.LOW].color}
+            />
+          </StyleLegend.LegendItemContainer>
         </Legend>
       )}
       <div className="us-state-map">

--- a/src/components/SocialLocationPreview/SocialLocationPreview.tsx
+++ b/src/components/SocialLocationPreview/SocialLocationPreview.tsx
@@ -21,6 +21,7 @@ import Map from 'components/Map/Map';
 import { COLOR_MAP } from 'common/colors';
 import SummaryStats from 'components/SummaryStats/SummaryStats';
 import { Legend, LegendItem } from 'components/Map/Legend';
+import * as StyleLegend from 'components/Map/Legend.style';
 
 const SocialLocationPreview = (props: {
   projections?: Projections;
@@ -45,26 +46,30 @@ const SocialLocationPreview = (props: {
             <MapHeaderHeader>America’s COVID warning system</MapHeaderHeader>
             <HeaderSubhead>Risk levels</HeaderSubhead>
             <Legend condensed={true}>
-              <LegendItem
-                key={'legend-4'}
-                title={LOCATION_SUMMARY_LEVELS[Level.HIGH].name}
-                color={LOCATION_SUMMARY_LEVELS[Level.HIGH].color}
-              />
-              <LegendItem
-                key={'legend-3'}
-                title={LOCATION_SUMMARY_LEVELS[Level.MEDIUM_HIGH].name}
-                color={LOCATION_SUMMARY_LEVELS[Level.MEDIUM_HIGH].color}
-              />
-              <LegendItem
-                key={'legend-2'}
-                title={LOCATION_SUMMARY_LEVELS[Level.MEDIUM].name}
-                color={LOCATION_SUMMARY_LEVELS[Level.MEDIUM].color}
-              />
-              <LegendItem
-                key={'legend-1'}
-                title={LOCATION_SUMMARY_LEVELS[Level.LOW].name}
-                color={LOCATION_SUMMARY_LEVELS[Level.LOW].color}
-              />
+              <StyleLegend.LegendItemContainer key={'legend-4'}>
+                <LegendItem
+                  title={LOCATION_SUMMARY_LEVELS[Level.HIGH].name}
+                  color={LOCATION_SUMMARY_LEVELS[Level.HIGH].color}
+                />
+              </StyleLegend.LegendItemContainer>
+              <StyleLegend.LegendItemContainer key={'legend-3'}>
+                <LegendItem
+                  title={LOCATION_SUMMARY_LEVELS[Level.MEDIUM_HIGH].name}
+                  color={LOCATION_SUMMARY_LEVELS[Level.MEDIUM_HIGH].color}
+                />
+              </StyleLegend.LegendItemContainer>
+              <StyleLegend.LegendItemContainer key={'legend-2'}>
+                <LegendItem
+                  title={LOCATION_SUMMARY_LEVELS[Level.MEDIUM].name}
+                  color={LOCATION_SUMMARY_LEVELS[Level.MEDIUM].color}
+                />
+              </StyleLegend.LegendItemContainer>
+              <StyleLegend.LegendItemContainer key={'legend-1'}>
+                <LegendItem
+                  title={LOCATION_SUMMARY_LEVELS[Level.LOW].name}
+                  color={LOCATION_SUMMARY_LEVELS[Level.LOW].color}
+                />
+              </StyleLegend.LegendItemContainer>
             </Legend>
           </HeaderText>
         </PreviewHeader>

--- a/src/screens/LocationPage/LocationPage.js
+++ b/src/screens/LocationPage/LocationPage.js
@@ -68,6 +68,8 @@ function LocationPage() {
           county={countyOption}
           chartId={chartId}
           countyId={countyId}
+          selectedCounty={selectedCounty}
+          setSelectedCounty={setSelectedCounty}
         />
         <MiniMap
           projections={projections}


### PR DESCRIPTION
Implements the map component to move the county map above the charts, to make space for the prevalence metric. See designs in [Figma](https://www.figma.com/file/Y0XivjSNr3kolTDWBy6kIz/Design-Sprint-v2?node-id=476%3A31787)

![image](https://user-images.githubusercontent.com/114084/85508943-e2f48e80-b5a9-11ea-8ad3-a9c2cadab817.png)

### Notes
- The style change from the designs will be implemented later, the style of this component should ideally match what we have in the site today.
- @mikelehen do you know where we got the scale factor for the states? This one is a bit off, so it looks like the state has a lot of padding around.