### PR TITLE
Update the MiniMap component

### DIFF
--- a/src/components/MiniMap/MiniMap.style.tsx
+++ b/src/components/MiniMap/MiniMap.style.tsx
@@ -1,104 +1,77 @@
 import styled from 'styled-components';
 import palette from 'assets/theme/palette';
 
-export const MapWrapper = styled.div<{ visible: boolean }>`
-  display: ${props => (props.visible ? 'block' : 'none')};
-  width: 100%;
-`;
+const mapWidth = 300;
+const mapHeight = 280;
+const tabHeight = 70;
+const selectedTabBorder = 3;
+const selectedTabColor = '#00BFEA';
 
-export const CountyMapAltWrapper = styled.div<{ visible: boolean }>`
-  display: ${props => (props.visible ? 'block' : 'none')};
-  width: 100%;
-`;
-
-export const MapContentInner = styled.div`
-  .Map {
-    width: 100%;
-  }
-
-  border-top: 1px solid #e3e3e3;
-  padding-top: 1rem;
-  margin-top: 1rem;
-  margin-left: -1rem;
-  margin-right: -1rem;
-  padding-left: 0.25rem;
-  padding-right: 0.25rem;
-
-  @media (min-width: 1200px) {
-    display: flex;
-    height: inherit;
-    align-items: flex-start;
-  }
-`;
-
-export const MapContentWrapper = styled.div<{ mobileMenuOpen: boolean }>`
-  z-index: 800;
-  display: ${props => (props.mobileMenuOpen ? 'block' : 'none')};
-  height: inherit;
+export const Container = styled.div<{ mobileMenuOpen: boolean }>`
+  display: ${props => (props.mobileMenuOpen ? 'flex' : 'none')};
+  flex-direction: column;
   position: fixed;
   top: calc(85px + 65px);
-  left: 0;
-  right: 0;
   bottom: 0;
-  background: white;
-  padding: 0 1rem 1rem;
+  right: 0;
+  width: 100%;
+  height: inherit;
+  background-color: ${palette.white};
+  border-radius: 4px;
+  box-shadow: 0px 4px 20px rgba(0, 0, 0, 0.1);
+
+  @media (min-width: 321px) {
+    z-index: 901;
+    width: ${mapWidth}px;
+    height: calc(${mapHeight}px + ${tabHeight}px);
+    right: 16px;
+  }
 
   @media (min-width: 700px) {
-    z-index: 901;
-    border: 1px solid rgba(0, 0, 0, 0.12);
-    width: 400px;
-    height: 400px;
     top: calc(85px + 65px + 16px);
-    right: 16px;
-    left: auto;
-    bottom: auto;
-    border-radius: 4px;
   }
 
   @media (min-width: 1350px) {
-    display: block;
-    top: 81px;
-    right: 16px;
-    height: 400px;
-    left: auto;
-    bottom: auto;
-    width: 400px;
-    padding: 0 1rem 1rem;
+    display: flex;
+    top: 94px;
   }
 `;
 
-export const MapMenuMobileWrapper = styled.div`
-  width: 100%;
-  margin-top: 1rem;
-  background: #f2f2f2;
-  border-radius: 4px;
-  padding: 0.25rem;
+export const Tabs = styled.div`
+  flex-grow: 0;
+  height: ${tabHeight}px;
   display: flex;
+  justify-content: space-around;
   align-items: stretch;
+  border-bottom: 1px solid ${palette.lightGray};
 `;
 
-export const MapMenuWrapper = styled.div`
-  flex: 0 0 524px;
-  background: #f2f2f2;
-  border-radius: 4px;
-  padding: 0.25rem;
-  display: flex;
-  align-items: stretch;
-`;
-
-export const MapMenuItem = styled.div<{ selected: boolean }>`
-  flex: 1;
-  height: inherit;
-  font-weight: 600;
-  color: ${props => (props.selected ? palette.secondary.main : 'inherit')};
-  background: ${props => (props.selected ? 'white' : 'transparent')};
-  box-shadow: ${props =>
-    props.selected ? '0px 2px 2px rgba(0, 0, 0, 0.16)' : 'none'};
+export const TabItem = styled.div<{ selected?: boolean }>`
+  font-size: 16px;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen,
+    Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+  text-transform: uppercase;
+  font-weight: 500;
+  line-height: ${tabHeight}px;
+  border-bottom: ${props =>
+    props.selected
+      ? `solid ${selectedTabBorder}px ${selectedTabColor}`
+      : 'none'};
   cursor: pointer;
-  border-radius: 4px;
-  padding: 0.5rem;
-  text-align: center;
+  color: ${props => (props.selected ? palette.black : '#828282')};
+`;
+
+export const MapContainer = styled.div`
+  flex-grow: 1;
   display: flex;
-  align-items: center;
+  flex-direction: column;
   justify-content: center;
+`;
+
+// The default aspect-ratio for the state and US maps is 800x600, so we
+// can use the width to calculate the height of the map container, which
+// makes it possible to center it vertically.
+export const StateMapContainer = styled.div`
+  width: ${mapWidth}px;
+  height: ${0.75 * mapWidth}px;
 `;

--- a/src/components/MiniMap/MiniMap.tsx
+++ b/src/components/MiniMap/MiniMap.tsx
@@ -1,21 +1,12 @@
 import React, { FunctionComponent } from 'react';
-
-import {
-  MapMenuMobileWrapper,
-  MapMenuItem,
-  MapContentWrapper,
-  MapContentInner,
-  MapWrapper,
-  CountyMapAltWrapper,
-} from 'components/MiniMap/MiniMap.style';
-
+import { useHistory } from 'react-router-dom';
+import { find as _find } from 'lodash';
 import Map from 'components/Map/Map';
 import CountyMap from 'components/CountyMap/CountyMap';
-import _ from 'lodash';
 import { MAP_FILTERS } from 'screens/LocationPage/Enums/MapFilterEnums';
-import { useHistory } from 'react-router-dom';
 import US_STATE_DATASET from '../MapSelectors/datasets/us_states_dataset_01_02_2020.json';
 import { Projections } from 'common/models/Projections';
+import * as Styles from './MiniMap.style';
 
 interface MiniMapProperties {
   projections: Projections;
@@ -28,71 +19,81 @@ interface MiniMapProperties {
   setMapOption: (input: string) => {};
 }
 
+const getCounty = (stateId: string, fullFips: string) =>
+  _find(
+    // @ts-ignore: US_STATE_DATASET is .js, but this is valid
+    US_STATE_DATASET.state_county_map_dataset[stateId].county_dataset,
+    ['full_fips_code', fullFips],
+  );
+
 /**
  * TODO(sgoldblatt): Don't pass in the setState vars here and use a provider
  * to set the selected MobileMenu and map options as well
  */
-const MiniMap: FunctionComponent<MiniMapProperties> = (
-  props: MiniMapProperties,
-) => {
+const MiniMap: FunctionComponent<MiniMapProperties> = ({
+  projections,
+  stateId,
+  selectedCounty,
+  setSelectedCounty,
+  mobileMenuOpen,
+  setMobileMenuOpen,
+  mapOption,
+  setMapOption,
+}) => {
   const history = useHistory();
 
   const goTo = (route: string) => {
     history.push(route);
   };
 
+  const showState = stateId !== MAP_FILTERS.DC;
+  const { stateName } = projections;
+
+  const onSelectCounty = (fullFips: string) => {
+    const county = getCounty(stateId, fullFips);
+    setMobileMenuOpen(false);
+    setSelectedCounty(county);
+    goTo(`/us/${stateId.toLowerCase()}/county/${county.county_url_name}`);
+  };
+
   return (
-    <MapContentWrapper mobileMenuOpen={props.mobileMenuOpen}>
-      <MapMenuMobileWrapper>
-        <MapMenuItem
-          onClick={() => props.setMapOption(MAP_FILTERS.NATIONAL)}
-          selected={props.mapOption === MAP_FILTERS.NATIONAL}
-        >
-          United States
-        </MapMenuItem>
-        {props.stateId !== MAP_FILTERS.DC && (
-          <MapMenuItem
-            onClick={() => props.setMapOption(MAP_FILTERS.STATE)}
-            selected={props.mapOption === MAP_FILTERS.STATE}
+    <Styles.Container mobileMenuOpen={mobileMenuOpen}>
+      <Styles.Tabs>
+        {showState && (
+          <Styles.TabItem
+            selected={mapOption === MAP_FILTERS.STATE}
+            onClick={() => setMapOption(MAP_FILTERS.STATE)}
           >
-            {props.projections.stateName}
-          </MapMenuItem>
+            {stateName}
+          </Styles.TabItem>
         )}
-      </MapMenuMobileWrapper>
-      <MapContentInner>
-        <MapWrapper visible={props.mapOption === MAP_FILTERS.NATIONAL}>
+        <Styles.TabItem
+          selected={mapOption === MAP_FILTERS.NATIONAL}
+          onClick={() => setMapOption(MAP_FILTERS.NATIONAL)}
+        >
+          USA
+        </Styles.TabItem>
+      </Styles.Tabs>
+      <Styles.MapContainer>
+        {/* US Map */}
+        {mapOption === MAP_FILTERS.NATIONAL && (
           <Map
             hideLegend={true}
-            setMapOption={props.setMapOption}
-            setMobileMenuOpen={props.setMobileMenuOpen}
+            setMapOption={setMapOption}
+            setMobileMenuOpen={setMobileMenuOpen}
           />
-        </MapWrapper>
-
-        {props.stateId !== MAP_FILTERS.DC && (
-          <CountyMapAltWrapper visible={props.mapOption === MAP_FILTERS.STATE}>
-            <CountyMap
-              selectedCounty={props.selectedCounty}
-              setSelectedCounty={(fullFips: string) => {
-                const county = _.find(
-                  // @ts-ignore: US_STATE_DATASET is .js, but this is valid
-                  US_STATE_DATASET.state_county_map_dataset[props.stateId]
-                    .county_dataset,
-                  ['full_fips_code', fullFips],
-                );
-
-                goTo(
-                  `/us/${props.stateId.toLowerCase()}/county/${
-                    county.county_url_name
-                  }`,
-                );
-                props.setMobileMenuOpen(false);
-                props.setSelectedCounty(county);
-              }}
-            />
-          </CountyMapAltWrapper>
         )}
-      </MapContentInner>
-    </MapContentWrapper>
+        {/* State Map */}
+        {mapOption === MAP_FILTERS.STATE && (
+          <Styles.StateMapContainer>
+            <CountyMap
+              selectedCounty={selectedCounty}
+              setSelectedCounty={onSelectCounty}
+            />
+          </Styles.StateMapContainer>
+        )}
+      </Styles.MapContainer>
+    </Styles.Container>
   );
 };
 

--- a/src/components/MiniMap/index.ts
+++ b/src/components/MiniMap/index.ts
@@ -1,0 +1,3 @@
+import MiniMap from './MiniMap';
+
+export default MiniMap;

--- a/src/screens/LocationPage/LocationPage.js
+++ b/src/screens/LocationPage/LocationPage.js
@@ -5,7 +5,7 @@ import US_STATE_DATASET from 'components/MapSelectors/datasets/us_states_dataset
 import { MAP_FILTERS } from './Enums/MapFilterEnums';
 import SearchHeader from 'components/Header/SearchHeader';
 import AppMetaTags from 'components/AppMetaTags/AppMetaTags';
-import MiniMap from 'components/MiniMap/MiniMap';
+import MiniMap from 'components/MiniMap';
 import EnsureSharingIdInUrl from 'components/EnsureSharingIdInUrl';
 import ChartsHolder from 'components/LocationPage/ChartsHolder';
 import { LoadingScreen } from './LocationPage.style';


### PR DESCRIPTION
Updates the MiniMap component to accommodate the prevalence metric. See the designs in [Figma](https://www.figma.com/file/kQGQ5qsDh7ir4MhjMM20Tl/5th-metric?node-id=48%3A2025)

![image](https://user-images.githubusercontent.com/114084/85831499-3fd77c80-b743-11ea-9297-fd060ee330fa.png)


I updated the layout to match the designs and added a sized container for the state maps, we need this to adjust the map projection parameters later (center, rotation, scale) so they use the entire available area for the map. I will implement that in a follow-up PR.

Can @goldblatt and @chasulin review? Thanks!