### PR TITLE
Deploy share images for snapshot 637. (#1029)

### DIFF
--- a/src/assets/data/data_url.json
+++ b/src/assets/data/data_url.json
@@ -1,3 +1,3 @@
 {
-  "data_url": "https://data.covidactnow.org/snapshot/637/"
+    "data_url": "https://data.covidactnow.org/snapshot/637/"
 }

--- a/src/assets/data/share_images_url.json
+++ b/src/assets/data/share_images_url.json
@@ -1,3 +1,3 @@
 {
-    "share_image_url": "https://content.covidactnow.org/share/618-90/"
+    "share_image_url": "https://content.covidactnow.org/share/637-95/"
 }


### PR DESCRIPTION
We already bumped to this snapshot, but this updates the share URL as well.

Co-authored-by: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>