### PR TITLE
Prevalence - Update the critical threshold for contact tracing

### DIFF
--- a/src/common/metrics/contact_tracing.ts
+++ b/src/common/metrics/contact_tracing.ts
@@ -14,11 +14,6 @@ const SHORT_DESCRIPTION_MEDIUM_HIGH =
 const SHORT_DESCRIPTION_HIGH = 'Enough tracing to help contain COVID';
 const SHORT_DESCRIPTION_UNKNOWN = 'Insufficient data to assess';
 
-const LIMIT_LOW = 0.07;
-const LIMIT_MEDIUM = 0.2;
-const LIMIT_MEDIUM_HIGH = 0.9;
-const LIMIT_HIGH = Infinity;
-
 const LOW_NAME = 'Critical';
 const MEDIUM_NAME = 'Low';
 const MEDIUM_HIGH_NAME = 'Medium';
@@ -30,28 +25,28 @@ export const REVERSE_ORDER = true;
 export const CONTACT_TRACING_LEVEL_INFO_MAP: LevelInfoMap = {
   [Level.LOW]: {
     level: Level.LOW,
-    upperLimit: LIMIT_LOW,
+    upperLimit: 0,
     name: LOW_NAME,
     color: COLOR_MAP.RED.BASE,
     detail: () => SHORT_DESCRIPTION_LOW,
   },
   [Level.MEDIUM]: {
     level: Level.MEDIUM,
-    upperLimit: LIMIT_MEDIUM,
+    upperLimit: 0.1,
     name: MEDIUM_NAME,
     color: COLOR_MAP.ORANGE_DARK.BASE,
     detail: () => SHORT_DESCRIPTION_MEDIUM,
   },
   [Level.HIGH]: {
     level: Level.HIGH,
-    upperLimit: LIMIT_MEDIUM_HIGH,
+    upperLimit: 0.9,
     name: MEDIUM_HIGH_NAME,
     color: COLOR_MAP.ORANGE.BASE,
     detail: () => SHORT_DESCRIPTION_MEDIUM_HIGH,
   },
   [Level.CRITICAL]: {
     level: Level.CRITICAL,
-    upperLimit: LIMIT_HIGH,
+    upperLimit: Infinity,
     name: HIGH_NAME,
     color: COLOR_MAP.GREEN.BASE,
     detail: () => SHORT_DESCRIPTION_HIGH,

--- a/src/common/metrics/contact_tracing.ts
+++ b/src/common/metrics/contact_tracing.ts
@@ -25,6 +25,9 @@ export const REVERSE_ORDER = true;
 export const CONTACT_TRACING_LEVEL_INFO_MAP: LevelInfoMap = {
   [Level.LOW]: {
     level: Level.LOW,
+    // NOTE: Setting the upperLimit to 0 means we will not grade anybody as
+    // Level.LOW ("Critical" on the website). The lowest grade you can get is
+    // Level.MEDIUM.
     upperLimit: 0,
     name: LOW_NAME,
     color: COLOR_MAP.RED.BASE,
@@ -83,7 +86,7 @@ export function contactTracingStatusText(projection: Projection) {
   const numNeededTracers = formatInteger(
     currentWeeklyAverage * TRACERS_NEEDED_PER_CASE,
   );
-  const overview = `Per best available data, ${location} has ${numTracers} contact tracers. With an average of ${weeklyAverage} new daily cases, 
+  const overview = `Per best available data, ${location} has ${numTracers} contact tracers. With an average of ${weeklyAverage} new daily cases,
     we estimate ${location} needs ${numNeededTracers} contact tracing staff to trace all new cases in 48 hours, before too many other people are infected.`;
 
   const contactTracingRate = levelText(

--- a/src/components/Charts/utils.ts
+++ b/src/components/Charts/utils.ts
@@ -22,36 +22,43 @@ export interface Region {
   color: string;
 }
 
+const isNotEmpty = (region: Region) =>
+  Math.abs(region.valueFrom - region.valueTo) > 1e-3;
+
 export const getChartRegions = (
   minY: number,
   maxY: number,
   zones: LevelInfoMap,
-): Region[] => [
-  {
-    valueFrom: minY,
-    valueTo: zones[Level.LOW].upperLimit,
-    name: zones[Level.LOW].name,
-    color: zones[Level.LOW].color,
-  },
-  {
-    valueFrom: zones[Level.LOW].upperLimit,
-    valueTo: zones[Level.MEDIUM].upperLimit,
-    name: zones[Level.MEDIUM].name,
-    color: zones[Level.MEDIUM].color,
-  },
-  {
-    valueFrom: zones[Level.MEDIUM].upperLimit,
-    valueTo: zones[Level.HIGH].upperLimit,
-    name: zones[Level.HIGH].name,
-    color: zones[Level.HIGH].color,
-  },
-  {
-    valueFrom: zones[Level.HIGH].upperLimit,
-    valueTo: maxY,
-    name: zones[Level.CRITICAL].name,
-    color: zones[Level.CRITICAL].color,
-  },
-];
+): Region[] => {
+  const regions = [
+    {
+      valueFrom: minY,
+      valueTo: zones[Level.LOW].upperLimit,
+      name: zones[Level.LOW].name,
+      color: zones[Level.LOW].color,
+    },
+    {
+      valueFrom: zones[Level.LOW].upperLimit,
+      valueTo: zones[Level.MEDIUM].upperLimit,
+      name: zones[Level.MEDIUM].name,
+      color: zones[Level.MEDIUM].color,
+    },
+    {
+      valueFrom: zones[Level.MEDIUM].upperLimit,
+      valueTo: zones[Level.HIGH].upperLimit,
+      name: zones[Level.HIGH].name,
+      color: zones[Level.HIGH].color,
+    },
+    {
+      valueFrom: zones[Level.HIGH].upperLimit,
+      valueTo: maxY,
+      name: zones[Level.CRITICAL].name,
+      color: zones[Level.CRITICAL].color,
+    },
+  ];
+
+  return regions.filter(isNotEmpty);
+};
 
 const isBetween = (zoneLow: LevelInfo, zoneHigh: LevelInfo, value: number) =>
   zoneLow.upperLimit <= value && value < zoneHigh.upperLimit;


### PR DESCRIPTION
Removes the `CRITICAL` level for the contact tracing chart and moves the upper limit of the orange level from 7% to 10%.

This is done by changing the upper limit of the `CRITICAL` threshold to `0` and updating the upper level of `HIGH` from 7% to 10%. I updated how regions (the equivalent of levels, but with upper and lower limits) to filter out regions such that their lower and upper limit are too close (< 1e3).

Can you review @mikelehen ?