### PR TITLE
Refactor: Use smoothWithRollingAverage() instead of getWeeklyAverageForDay().

### DIFF
--- a/src/common/metrics/contact_tracing.ts
+++ b/src/common/metrics/contact_tracing.ts
@@ -65,9 +65,7 @@ export const CONTACT_TRACING_LEVEL_INFO_MAP: LevelInfoMap = {
 
 export function contactTracingStatusText(projection: Projection) {
   const currentContactTracers = projection.currentContactTracers;
-  const weeklyAverageResult = projection.getWeeklyAverageForDay(
-    projection.dailyPositiveTests,
-  );
+  const weeklyAverageResult = projection.currentDailyAverageCases;
   const currentWeeklyAverage =
     weeklyAverageResult && Math.round(weeklyAverageResult);
   const currentContactTracingMetric = projection.currentContactTracerMetric;


### PR DESCRIPTION
This is a purely optional refactor that we could punt for now, but I started down this path while I was trying to track down an issue I was seeing.  If you're not a fan or are busy, we could hold off on this.