### PR TITLE
Prevalence - Status text copy

### DIFF
--- a/src/common/metrics/case_density.ts
+++ b/src/common/metrics/case_density.ts
@@ -71,9 +71,9 @@ export const caseDensityStatusText = (projection: Projection) => {
   const statusText2 = levelText(
     level,
     `If these rates continue, we estimate less than 1% of ${locationName}’s population will be infected in the next year.`,
-    `If these rates continue, we estimate less than 1-10% of ${locationName}’s population will be infected in the next year.`,
-    `If these rates continue, we estimate less than 10-50% of ${locationName}’s population will be infected in the next year. Caution is warranted.`,
-    `If these rates continue, we estimate less than >50% of ${locationName}’s population will be infected in the next year. Aggressive action urgently needed.`,
+    `If these rates continue, we estimate that 1-10% of ${locationName}’s population will be infected in the next year.`,
+    `If these rates continue, we estimate that 10-50% of ${locationName}’s population will be infected in the next year. Caution is warranted.`,
+    `If these rates continue, we estimate more than 50% of ${locationName}’s population will be infected in the next year. Aggressive action urgently needed.`,
   );
 
   return `${statusText1} ${statusText2}`;

--- a/src/common/metrics/case_density.ts
+++ b/src/common/metrics/case_density.ts
@@ -54,19 +54,19 @@ rate). Note that this will not match reported cases in many states, as
 testing is only detecting a small number of actual cases.`;
 
 export const caseDensityStatusText = (projection: Projection) => {
-  const { currentCaseDensityByDeaths, locationName } = projection;
+  const { currentCaseDensity, currentDailyDeaths, locationName } = projection;
 
-  if (currentCaseDensityByDeaths === null) {
+  if (currentCaseDensity === null || currentDailyDeaths === null) {
     return `Not enough case data is available to generate ${METRIC_NAME.toLowerCase()}.`;
   }
 
-  const level = getLevel(Metric.CASE_DENSITY, currentCaseDensityByDeaths);
-  const dailyCases = formatDecimal(currentCaseDensityByDeaths, 1);
-  const dailyDeaths = formatDecimal(projection.currentDailyDeaths || 0, 2);
+  const level = getLevel(Metric.CASE_DENSITY, currentCaseDensity);
+  const dailyCases = formatDecimal(currentCaseDensity, 1);
+  const dailyDeaths = formatDecimal(currentDailyDeaths, 2);
 
   const statusText1 = `Over the last week, ${locationName} has reported
-   ${dailyCases} new cases and ${dailyDeaths} new deaths per day
-    for every 100,000 residents.`;
+   ${dailyCases} new cases and ${dailyDeaths} new deaths per day for every
+    100,000 residents.`;
 
   const statusText2 = levelText(
     level,

--- a/src/common/metrics/case_density.ts
+++ b/src/common/metrics/case_density.ts
@@ -62,11 +62,7 @@ export const caseDensityStatusText = (projection: Projection) => {
 
   const level = getLevel(Metric.CASE_DENSITY, currentCaseDensityByDeaths);
   const dailyCases = formatDecimal(currentCaseDensityByDeaths, 1);
-  // TODO(pablo): Move this calculation to Projection.ts
-  const dailyDeaths = formatDecimal(
-    CASE_FATALITY_RATIO * currentCaseDensityByDeaths,
-    2,
-  );
+  const dailyDeaths = formatDecimal(projection.currentDailyDeaths || 0, 2);
 
   const statusText1 = `Over the last week, ${locationName} has reported
    ${dailyCases} new cases and ${dailyDeaths} new deaths per day

--- a/src/common/metrics/case_density.ts
+++ b/src/common/metrics/case_density.ts
@@ -53,7 +53,7 @@ for every reported death (${caseFatalityRatioPercent} infection fatality
 rate). Note that this will not match reported cases in many states, as 
 testing is only detecting a small number of actual cases.`;
 
-export const caseDensityStatusText = (projection: Projection) => {
+export function caseDensityStatusText(projection: Projection) {
   const { currentCaseDensity, currentDailyDeaths, locationName } = projection;
 
   if (currentCaseDensity === null || currentDailyDeaths === null) {
@@ -62,7 +62,7 @@ export const caseDensityStatusText = (projection: Projection) => {
 
   const level = getLevel(Metric.CASE_DENSITY, currentCaseDensity);
   const dailyCases = formatDecimal(currentCaseDensity, 1);
-  const dailyDeaths = formatDecimal(currentDailyDeaths, 2);
+  const dailyDeaths = formatDecimal(currentDailyDeaths, 1);
 
   const statusText1 = `Over the last week, ${locationName} has reported
    ${dailyCases} new cases and ${dailyDeaths} new deaths per day for every
@@ -77,4 +77,4 @@ export const caseDensityStatusText = (projection: Projection) => {
   );
 
   return `${statusText1} ${statusText2}`;
-};
+}

--- a/src/common/models/Projection.ts
+++ b/src/common/models/Projection.ts
@@ -227,9 +227,9 @@ export class Projection {
       this.caseDensityRange.map(range => range && range.caseDensity),
     );
     this.currentDailyDeaths =
-      this.currentCaseDensityByDeaths === null
+      this.currentCaseDensity === null
         ? null
-        : CASE_FATALITY_RATIO * this.currentCaseDensityByDeaths;
+        : CASE_FATALITY_RATIO * this.currentCaseDensity;
 
     this.fixZeros(this.hospitalizations);
     this.fixZeros(this.cumulativeDeaths);

--- a/src/common/models/Projection.ts
+++ b/src/common/models/Projection.ts
@@ -115,6 +115,7 @@ export class Projection {
   readonly currentCaseDensity: number | null;
   readonly currentCaseDensityByCases: number | null;
   readonly currentCaseDensityByDeaths: number | null;
+  readonly currentDailyDeaths: number | null;
 
   private readonly intervention: string;
   private readonly dates: Date[];
@@ -225,6 +226,10 @@ export class Projection {
     this.currentCaseDensity = lastValue(
       this.caseDensityRange.map(range => range && range.caseDensity),
     );
+    this.currentDailyDeaths =
+      this.currentCaseDensityByDeaths === null
+        ? null
+        : CASE_FATALITY_RATIO * this.currentCaseDensityByDeaths;
 
     this.fixZeros(this.hospitalizations);
     this.fixZeros(this.cumulativeDeaths);

--- a/src/common/models/Projection.ts
+++ b/src/common/models/Projection.ts
@@ -226,10 +226,7 @@ export class Projection {
     this.currentCaseDensity = lastValue(
       this.caseDensityRange.map(range => range && range.caseDensity),
     );
-    this.currentDailyDeaths =
-      this.currentCaseDensity === null
-        ? null
-        : CASE_FATALITY_RATIO * this.currentCaseDensity;
+    this.currentDailyDeaths = lastValue(this.smoothedDailyDeaths);
 
     this.fixZeros(this.hospitalizations);
     this.fixZeros(this.cumulativeDeaths);


### PR DESCRIPTION
This PR adds the copy from [CAN Phase 3 Webapp Text](https://docs.google.com/document/d/1Jsj4zOksCJcgjQLUo3rwVAobEUkGLFukD1K71IqVNpo/edit#) for the prevalence metric.

Note: The copy for case density is not complete in the document, adding what we have for now.