### PR TITLE
Prevalence - Add cap for case density chart

### DIFF
--- a/src/components/Charts/ChartCaseDensity.tsx
+++ b/src/components/Charts/ChartCaseDensity.tsx
@@ -2,6 +2,7 @@ import React, { FunctionComponent } from 'react';
 import moment from 'moment';
 import { isDate } from 'lodash';
 import { min as d3min, max as d3max } from 'd3-array';
+import { curveMonotoneX } from '@vx/curve';
 import { GridRows } from '@vx/grid';
 import { scaleLinear, scaleTime } from '@vx/scale';
 import { ParentSize } from '@vx/responsive';
@@ -38,6 +39,7 @@ const hasData = (d: any) => isDate(getDate(d)) && Number.isFinite(getY(d));
 const ChartCaseDensity: FunctionComponent<{
   columnData: Column[];
   zones: LevelInfoMap;
+  capY?: number;
   width: number;
   height: number;
   marginTop?: number;
@@ -47,6 +49,7 @@ const ChartCaseDensity: FunctionComponent<{
 }> = ({
   columnData,
   zones,
+  capY = 100,
   width,
   height,
   marginTop = 5,
@@ -70,7 +73,7 @@ const ChartCaseDensity: FunctionComponent<{
 
   const yDataMax = d3max(data, getY) || 100;
   const yAxisLimits = getAxisLimits(0, yDataMax, zones);
-  const [yAxisMin, yAxisMax] = [-9, yAxisLimits[1]];
+  const [yAxisMin, yAxisMax] = [-9, Math.min(yAxisLimits[1], capY)];
 
   const yScale = scaleLinear({
     domain: [yAxisMin, yAxisMax],
@@ -78,7 +81,7 @@ const ChartCaseDensity: FunctionComponent<{
   });
 
   const getXCoord = (p: Point) => xScale(getDate(p));
-  const getYCoord = (p: Point) => yScale(getY(p));
+  const getYCoord = (p: Point) => yScale(Math.min(getY(p), capY));
 
   const regions = getChartRegions(yAxisMin, yAxisMax, zones);
   const lastPoint = last(data);
@@ -120,7 +123,7 @@ const ChartCaseDensity: FunctionComponent<{
       marginLeft={marginLeft}
       marginRight={marginRight}
     >
-      <RectClipGroup width={chartWidth} height={chartHeight} topPadding={0}>
+      <RectClipGroup width={chartWidth} height={chartHeight} topPadding={5}>
         <LinePathRegion
           data={data}
           x={getXCoord}
@@ -128,6 +131,7 @@ const ChartCaseDensity: FunctionComponent<{
           regions={regions}
           width={chartWidth}
           yScale={yScale}
+          curve={curveMonotoneX}
         />
         <Style.LineGrid>
           <GridRows width={chartWidth} scale={yScale} tickValues={yTicks} />


### PR DESCRIPTION
Adding a cap for the case density chart. We need to review the value, set to 100 for now.

### Example

http://localhost:3000/us/tx/county/garza_county?s=665110

![image](https://user-images.githubusercontent.com/114084/87348358-6fd79b80-c509-11ea-9658-c53017ab0792.png)

### Notes
- I changed the curve parameter as an experiment, after realizing that `curveNatural` can produce strange loops depending on how much the value of the curve changes between 2 points. I think we should change all the lines to use [`curveMonotoneX`](https://github.com/d3/d3-shape#curveMonotoneX) instead. From the docs:

> “a smooth curve with continuous first-order derivatives that passes through any given set of data points without spurious oscillations. Local extrema can occur only at grid points where they are given by the data, but not in between two adjacent grid points.”


Compare

#### `curveNatural` (removed the clipping paths and showing the curve outside the SVG)
![image](https://user-images.githubusercontent.com/114084/87348541-c513ad00-c509-11ea-90a6-06c2a318fed4.png)

#### `curveMonotoneX`
![image](https://user-images.githubusercontent.com/114084/87348358-6fd79b80-c509-11ea-9658-c53017ab0792.png)
