### PR TITLE
Sharecard fix (location page)

### DIFF
--- a/src/screens/internal/ShareImage/ShareCardImage.style.ts
+++ b/src/screens/internal/ShareImage/ShareCardImage.style.ts
@@ -8,7 +8,7 @@ export const ShareCardWrapper = styled.div<{ isHomePage?: boolean }>`
   margin: 50px auto;
   width: 400px;
   height: 262px;
-  transform: scale(${props => (props.isHomePage ? 2.25 : 1.75)});
+  transform: scale(${props => (props.isHomePage ? 2.25 : 1.55)});
   transform-origin: top center;
 `;
 


### PR DESCRIPTION
- edits location page sharecard to make all 5 metrics visible

Before:

<img width="1199" alt="Screen Shot 2020-07-14 at 1 31 01 PM" src="https://user-images.githubusercontent.com/44076375/87457908-2bb2cc80-c5d7-11ea-9930-209aec237b31.png">

After:

<img width="1199" alt="Screen Shot 2020-07-14 at 1 33 06 PM" src="https://user-images.githubusercontent.com/44076375/87457941-353c3480-c5d7-11ea-9e79-9ac717a6c53e.png">
