### PR TITLE
Sharecard fix (homepage)

### DIFF
--- a/src/screens/internal/ShareImage/ShareCardImage.style.ts
+++ b/src/screens/internal/ShareImage/ShareCardImage.style.ts
@@ -4,11 +4,12 @@ import styled from 'styled-components';
  * The "homepage" share card isn't as tall as the location share card, so we
  * have to adapt the css styles.
  */
+
 export const ShareCardWrapper = styled.div<{ isHomePage?: boolean }>`
   margin: 50px auto;
   width: 400px;
   height: 262px;
-  transform: scale(${props => (props.isHomePage ? 2.25 : 1.75)});
+  transform: scale(1.75);
   transform-origin: top center;
 `;
 


### PR DESCRIPTION
- Edits sharecard so map+legend both fit in entirety

Before:

<img width="1200" alt="Screen Shot 2020-07-14 at 1 31 14 PM" src="https://user-images.githubusercontent.com/44076375/87458898-a3cdc200-c5d8-11ea-938d-a29264ebb0dc.png">

After: 

<img width="1200" alt="Screen Shot 2020-07-14 at 1 31 57 PM" src="https://user-images.githubusercontent.com/44076375/87458921-ab8d6680-c5d8-11ea-9fa6-988c626093da.png">
