### PR TITLE
charts - minor improvements for mobile and share images

### DIFF
--- a/src/components/Charts/Axis.tsx
+++ b/src/components/Charts/Axis.tsx
@@ -15,7 +15,7 @@ export const AxisBottom = (props: SharedAxisProps<Date>) => {
   const [dateStart, dateStop] = props.scale.domain();
   const [minPx, maxPx] = props.scale.range() as number[];
   const isSmallDevice = maxPx - minPx < 600;
-  const dateFormat = isSmallDevice ? 'MMMM' : 'MMM DD';
+  const dateFormat = isSmallDevice ? 'MMM' : 'MMM DD';
 
   const tickValues = isSmallDevice
     ? timeMonth.range(dateStart, dateStop, 1)

--- a/src/components/Charts/ChartRt.tsx
+++ b/src/components/Charts/ChartRt.tsx
@@ -1,12 +1,11 @@
 import React from 'react';
-import moment from 'moment';
 import { isDate } from 'lodash';
 import { min as d3min, max as d3max } from 'd3-array';
 import { curveNatural } from '@vx/curve';
 import { GridRows } from '@vx/grid';
 import { Group } from '@vx/group';
 import { ParentSize } from '@vx/responsive';
-import { scaleLinear, scaleTime } from '@vx/scale';
+import { scaleLinear } from '@vx/scale';
 import { Area } from '@vx/shape';
 import { Column, RtRange, RT_TRUNCATION_DAYS } from 'common/models/Projection';
 import { CASE_GROWTH_RATE_LEVEL_INFO_MAP as zones } from 'common/metrics/case_growth';
@@ -27,6 +26,7 @@ import {
   getZoneByValue,
   last,
   getAxisLimits,
+  getZonesTimeScale,
 } from './utils';
 
 type PointRt = Omit<Column, 'y'> & {
@@ -68,16 +68,13 @@ const ChartRt = ({
   const dates: Date[] = columnData.map(getDate).filter(isDate);
 
   const minDate = d3min(dates) || new Date('2020-01-01');
-  const maxDate = moment().add(2, 'weeks').toDate();
+  const currDate = new Date();
 
   const yDataMin = 0;
   const yDataMax = d3max(data, getRt) || 1;
   const [yAxisMin, yAxisMax] = getAxisLimits(yDataMin, yDataMax, zones);
 
-  const xScale = scaleTime({
-    domain: [minDate, maxDate],
-    range: [0, chartWidth],
-  });
+  const xScale = getZonesTimeScale(minDate, currDate, 0, chartWidth);
 
   const yScale = scaleLinear({
     domain: [yAxisMin, yAxisMax],
@@ -180,7 +177,7 @@ const ChartRt = ({
               color={region.color}
               name={region.name}
               isActive={truncationZone.name === region.name}
-              x={xScale(maxDate) - 10}
+              x={chartWidth - 10}
               y={yScale(0.5 * (region.valueFrom + region.valueTo))}
             />
           </Group>

--- a/src/components/Charts/ChartZones.tsx
+++ b/src/components/Charts/ChartZones.tsx
@@ -1,12 +1,11 @@
 import React from 'react';
-import moment from 'moment';
 import { isDate } from 'lodash';
 import { min as d3min, max as d3max } from 'd3-array';
 import { curveLinear } from '@vx/curve';
 import { GridRows } from '@vx/grid';
 import { Group } from '@vx/group';
 import { ParentSize } from '@vx/responsive';
-import { scaleLinear, scaleTime } from '@vx/scale';
+import { scaleLinear } from '@vx/scale';
 import { Column } from 'common/models/Projection';
 import { assert, formatUtcDate, formatPercent } from 'common/utils';
 import { LevelInfoMap } from 'common/level';
@@ -25,6 +24,7 @@ import {
   last,
   getAxisLimits,
   getZoneByValue,
+  getZonesTimeScale,
 } from './utils';
 
 type Point = Omit<Column, 'y'> & {
@@ -67,13 +67,10 @@ const ChartZones = ({
   const dates: Date[] = columnData.map(getDate).filter(isDate);
 
   const minDate = d3min(dates);
-  const maxDate = moment().add(2, 'weeks').toDate();
+  const maxDate = new Date();
   assert(minDate !== undefined, 'Data must not be empty');
 
-  const xScale = scaleTime({
-    domain: [minDate, maxDate],
-    range: [0, chartWidth],
-  });
+  const xScale = getZonesTimeScale(minDate, maxDate, 0, chartWidth);
 
   const yDataMin = 0;
   const yDataMax = d3max(data, getY);
@@ -147,7 +144,7 @@ const ChartZones = ({
               color={region.color}
               name={region.name}
               isActive={lastPointZone.name === region.name}
-              x={xScale(maxDate) - 10}
+              x={chartWidth - 10}
               y={yScale(0.5 * (region.valueFrom + region.valueTo))}
             />
           </Group>
@@ -158,8 +155,8 @@ const ChartZones = ({
       </Style.LineGrid>
       <Style.TextAnnotation>
         <BoxedAnnotation
-          x={getXCoord(lastPoint) + 30}
-          y={getYCoord(lastPoint)}
+          x={getXCoord(lastPoint)}
+          y={getYCoord(lastPoint) - 15}
           text={getPointText(lastPointY)}
         />
       </Style.TextAnnotation>

--- a/src/components/Charts/utils.ts
+++ b/src/components/Charts/utils.ts
@@ -1,5 +1,6 @@
 import _ from 'lodash';
 import moment from 'moment';
+import { scaleTime } from '@vx/scale';
 import { LevelInfoMap, Level, LevelInfo } from 'common/level';
 
 export const last = (list: any[]) => list[list.length - 1];
@@ -97,4 +98,25 @@ export const getAxisLimits = (
   const minTickPosition = _.min(tickPositions) || minY;
   const maxTickPosition = _.max(tickPositions) || maxY;
   return roundAxisLimits(minTickPosition, maxTickPosition);
+};
+
+/**
+ * Creates a time scale using the given parameters and adjusts it
+ * to make the labels fit without overlapping the data.
+ */
+export const getZonesTimeScale = (
+  minDate: Date,
+  maxDate: Date,
+  minX: number,
+  maxX: number,
+  zoneLabelsWidth = 80,
+) => {
+  const xScale = scaleTime({
+    domain: [minDate, maxDate],
+    range: [minX, maxX - zoneLabelsWidth],
+  });
+  // Calculates the date that corresponds
+  const endDate = xScale.invert(maxX);
+  xScale.domain([minDate, endDate]).range([0, maxX]);
+  return xScale;
 };


### PR DESCRIPTION
### Changes
- Calculate the end date of the chart to ensure that the threat level labels don't overlap the last point of the time series instead of just adding 2 weeks and hope for the best.
- Changed the format of the x-axis tick labels from full month to 3-letter abbreviations (September → Sep).
- Moved the current point annotation from being on the right of the last point to be on top of the last point, to minimize the chance of overlapping with the zone labels.

#### Mobile

Before → After
![image](https://user-images.githubusercontent.com/114084/87475578-e47a0b00-c5d9-11ea-8806-71317f481a88.png)

#### Share Image

Before
![image](https://user-images.githubusercontent.com/114084/87475043-ec857b00-c5d8-11ea-8814-05a5d77d70f1.png)

After
![image](https://user-images.githubusercontent.com/114084/87475074-f909d380-c5d8-11ea-8ce5-58ebe9c28a1e.png)

### Notes
- There is some discussion around getting rid of the zone labels on mobile, but I'm going to submit a separate PR so we can get feedback on that change.
- The margins can be optimized as well, I will do that on a separate PR too.