### PR TITLE
prevalence: add the update copy on the location page header

### DIFF
--- a/src/common/colors.js
+++ b/src/common/colors.js
@@ -33,6 +33,7 @@ export const COLOR_MAP = {
     DARK: '#0A3D31',
   },
   BLUE: '#3BBCE6',
+  GRAY_BODY_COPY: '#4f4f4f',
   GRAY: {
     BASE: '#CCCCCC',
     LIGHT: '#E3E3E3',

--- a/src/common/models/Projections.ts
+++ b/src/common/models/Projections.ts
@@ -205,6 +205,48 @@ export class Projections {
     }
   }
 
+  // TODO(pablo): Remove this method once the prevalence metric is no longer
+  // an 'update'. This is only used to show the level before and after the
+  // introduction of the prevalence metric for locations where the overall
+  // level changed.
+  getAlarmLevelWithoutCaseDensity() {
+    const {
+      rt_level,
+      hospitalizations_level,
+      test_rate_level,
+      contact_tracing_level,
+    } = this.getLevels();
+
+    const levelList = [rt_level, hospitalizations_level, test_rate_level];
+
+    // contact tracing levels are reversed (i.e low is bad, high is good)
+    const reverseList = [contact_tracing_level];
+
+    if (
+      levelList.some(level => level === Level.CRITICAL) ||
+      reverseList.some(level => level === Level.LOW)
+    ) {
+      return Level.CRITICAL;
+    } else if (
+      levelList.some(level => level === Level.HIGH) ||
+      reverseList.some(level => level === Level.MEDIUM)
+    ) {
+      return Level.HIGH;
+    } else if (
+      levelList.some(level => level === Level.MEDIUM) ||
+      reverseList.some(level => level === Level.HIGH)
+    ) {
+      return Level.MEDIUM;
+    } else if (
+      levelList.some(level => level === Level.UNKNOWN) ||
+      reverseList.some(level => level === Level.UNKNOWN)
+    ) {
+      return Level.UNKNOWN;
+    } else {
+      return Level.LOW;
+    }
+  }
+
   getAlarmLevelColor() {
     const level = this.getAlarmLevel();
     return LEVEL_COLOR[level];

--- a/src/components/Header/HomePageHeader.style.tsx
+++ b/src/components/Header/HomePageHeader.style.tsx
@@ -24,9 +24,10 @@ export const HeaderTitle = styled(Typography)<{ component?: string }>`
   line-height: 2.3rem;
   color: black;
   max-width: 300px;
-  margin: 0 auto 1rem;
+  margin: 1.2rem auto 1.5rem;
 
   @media (min-width: 600px) {
+    margin: 1rem auto 1rem;
     font-size: 3rem;
     line-height: 1.2;
     max-width: unset;
@@ -36,8 +37,7 @@ export const HeaderTitle = styled(Typography)<{ component?: string }>`
 export const HeaderSubCopy = styled(Typography)<{ component?: string }>`
   font-size: 1rem;
   line-height: 1.6rem;
-  margin: 0 auto 1rem;
-  color: rgba(0, 0, 0, 0.7);
+  margin: 0 auto 0.5rem;
   max-width: 300px;
 
   a {
@@ -56,19 +56,14 @@ export const ClickableCopy = styled.span`
   cursor: pointer;
 `;
 
-export const HeaderSubCopyItem = styled.span<{ hideOnMobile?: boolean }>`
-  display: ${props => (props.hideOnMobile ? 'none' : 'unset')};
+export const HeaderSubCopyItem = styled.span`
   font-family: Roboto;
-  color: #4f4f4f;
+  color: ${COLOR_MAP.GRAY_BODY_COPY};
 
   @media (min-width: 600px) {
     display: unset;
     font-size: 19px;
     line-height: 140%;
-  }
-
-  strong {
-    color: black;
   }
 `;
 

--- a/src/components/LocationPage/LocationPageHeader.style.tsx
+++ b/src/components/LocationPage/LocationPageHeader.style.tsx
@@ -7,14 +7,14 @@ import { COLOR_MAP } from 'common/colors';
 import { Level } from 'common/level';
 import { LEVEL_COLOR } from 'common/colors';
 
-export const ColoredHeaderBanner = styled(Box)<{ hasStats?: Boolean }>`
+export const ColoredHeaderBanner = styled(Box)`
   display: flex;
   flex-direction: column;
   height: 400px;
   background-color: ${props => props.bgcolor || COLORS.LIGHTGRAY};
 
   @media (min-width: 600px) {
-    height: ${({ hasStats }) => (!hasStats ? '318px' : '380px')};
+    height: 250px;
   }
 `;
 
@@ -35,7 +35,6 @@ export const Wrapper = styled(Box)<{
     justify-content: space-around;
     background-color: unset;
     box-shadow: none;
-    // max-width: 1040px;
     max-width: 1000px;
     flex-direction: column;
     cursor: pointer;
@@ -51,7 +50,6 @@ export const Wrapper = styled(Box)<{
       margin: ${props.headerTopMargin}px auto ${props.headerBottomMargin}px;
     }
     @media (min-width: 1350px) {
-      // margin: ${props.headerTopMargin}px 330px ${props.headerBottomMargin}px auto;
       margin: ${props.headerTopMargin}px 350px ${props.headerBottomMargin}px auto;
     }
 
@@ -119,7 +117,7 @@ export const HeaderTitle = styled(Typography)<{
 export const HeaderSubtitle = styled(Typography)`
   font-size: 15px;
   line-height: 1.4;
-  color: #4f4f4f;
+  color: ${COLOR_MAP.GRAY_BODY_COPY};
   margin-top: 1.2rem;
 
   @media (min-width: 600px) {
@@ -128,14 +126,12 @@ export const HeaderSubtitle = styled(Typography)`
   }
 `;
 
-export const FooterContainer = styled(Box)<{
-  isVerifiedState?: Boolean;
-}>`
-  margin: ${({ isVerifiedState }) =>
-    isVerifiedState ? '.4rem .2rem 1rem .2rem;' : '1rem .2rem 1rem .2rem'};
+export const FooterContainer = styled(Box)`
+  margin: 0.8rem 0.3rem 0.8rem;
 
   p {
     padding: 0;
+    max-width: 600px;
   }
 
   svg {
@@ -144,11 +140,11 @@ export const FooterContainer = styled(Box)<{
   }
 
   @media (min-width: 600px) {
-    max-width: 600px;
     width: 100%;
-    margin: ${({ isVerifiedState }) =>
-      isVerifiedState ? '.4rem 0 0 .2rem' : '.4rem 0 0 .2rem'};
+    margin: 1.5rem 0 0.5rem 0.2rem;
     cursor: auto;
+    max-width: 900px;
+    align-self: center;
 
     a {
       cursor: pointer;
@@ -158,10 +154,18 @@ export const FooterContainer = styled(Box)<{
       transform: translateY(0.35rem);
     }
   }
+
+  @media (min-width: 1350px) {
+    align-self: flex-start;
+  }
+
+  @media (min-width: 1750px) {
+    align-self: center;
+  }
 `;
 
 export const HeaderSubCopy = styled(Typography)`
-  color: #828282;
+  color: ${COLOR_MAP.GRAY_BODY_COPY};
   font-size: 13px;
   line-height: 1.4;
   padding: 1.5rem 0 0.2rem;
@@ -209,15 +213,30 @@ export const HeaderButton = styled(Box)`
 
   &:first-child {
     color: ${COLOR_MAP.BLUE};
-    margin-right: 1.25rem;
+    margin-right: 0.5rem;
+
+    &:hover {
+      border: 1px solid ${COLOR_MAP.BLUE};
+    }
   }
 
   &:last-child {
     color: ${COLOR_MAP.RED.BASE};
+
+    &:hover {
+      border: 1px solid ${COLOR_MAP.RED.BASE};
+    }
   }
 
   svg {
     margin-right: 6px;
+  }
+
+  // iphone 6/7/8/x and up:
+  @media (min-width: 375px) {
+    &:first-child {
+      margin-right: 1.2rem;
+    }
   }
 
   @media (min-width: 600px) {
@@ -286,7 +305,7 @@ export const ColumnTitle = styled(Typography)<{ isUpdateCopy?: Boolean }>`
   font-family: Roboto;
   font-size: ${({ isUpdateCopy }) => (isUpdateCopy ? '13px' : '12px')};
   text-transform: uppercase;
-  color: #828282;
+  color: ${COLOR_MAP.GRAY_BODY_COPY};
   letter-spacing: 0.02rem;
   margin-bottom: 0.5rem;
 
@@ -300,7 +319,7 @@ export const Copy = styled(Typography)<{ isUpdateCopy?: Boolean }>`
   font-family: Source Code Pro;
   font-size: ${({ isUpdateCopy }) => (isUpdateCopy ? '13px' : '12px')};
   line-height: 140%;
-  color: #4f4f4f;
+  color: ${COLOR_MAP.GRAY_BODY_COPY};
 
   strong {
     color: black;
@@ -308,6 +327,7 @@ export const Copy = styled(Typography)<{ isUpdateCopy?: Boolean }>`
 
   @media (min-width: 600px) {
     font-size: 13px;
+    max-width: 440px;
   }
 `;
 

--- a/src/components/LocationPage/LocationPageHeader.tsx
+++ b/src/components/LocationPage/LocationPageHeader.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React, { Fragment, FunctionComponent } from 'react';
 import CheckIcon from '@material-ui/icons/Check';
 import {
   ColoredHeaderBanner,
@@ -34,14 +34,27 @@ import ShareOutlinedIcon from '@material-ui/icons/ShareOutlined';
 import LocationHeaderStats from 'components/SummaryStats/LocationHeaderStats';
 import InfoOutlinedIcon from '@material-ui/icons/InfoOutlined';
 import { LEVEL_COLOR } from 'common/colors';
+import { METRIC_NAME as CASE_DENSITY_METRIC_NAME } from 'common/metrics/case_density';
 
-const NewIndicatorCopy = () => {
+const UpdateCaseDensity: FunctionComponent<{ projections: Projections }> = ({
+  projections,
+}) => {
+  const levelName = (level: Level) => LOCATION_SUMMARY_LEVELS[level].name;
+  const previousLevel = projections.getAlarmLevelWithoutCaseDensity();
+  const currentLevel = projections.getAlarmLevel();
+
+  const changedLevelCopy =
+    previousLevel === currentLevel
+      ? ''
+      : `That changed your threat level from ${levelName(
+          previousLevel,
+        )} to ${levelName(currentLevel)}.`;
   return (
     <Copy isUpdateCopy>
       <strong>New key indicator added</strong>
       <br />
-      We added NEW CASES PER DAY. That changed your threat level from yellow to
-      orange. <a href="/">Learn more</a>
+      {`We added ${CASE_DENSITY_METRIC_NAME}. ${changedLevelCopy}`}{' '}
+      <a href="/">Learn more</a>.
     </Copy>
   );
 };
@@ -87,8 +100,9 @@ const LocationPageHeader = (props: {
     (val: number | null) => !isNull(val),
   ).length;
 
-  const headerTopMargin = !hasStats ? -270 : -330;
-  const headerBottomMargin = !hasStats ? 100 : 0;
+  //TODO (chelsi): get rid of this use of 'magic' numbers
+  const headerTopMargin = !hasStats ? -202 : -218;
+  const headerBottomMargin = !hasStats ? 0 : 0;
 
   const locationName =
     props.projections.countyName || props.projections.stateName;
@@ -135,7 +149,7 @@ const LocationPageHeader = (props: {
 
   return (
     <Fragment>
-      <ColoredHeaderBanner bgcolor={fillColor} hasStats={hasStats} />
+      <ColoredHeaderBanner bgcolor={fillColor} />
       <Wrapper
         condensed={props.condensed}
         headerTopMargin={headerTopMargin}
@@ -183,7 +197,7 @@ const LocationPageHeader = (props: {
               <InfoOutlinedIcon />
               <SectionColumn isUpdateCopy>
                 <ColumnTitle isUpdateCopy>Updates</ColumnTitle>
-                <NewIndicatorCopy />
+                <UpdateCaseDensity projections={props.projections} />
               </SectionColumn>
             </SectionHalf>
           </HeaderSection>
@@ -197,7 +211,7 @@ const LocationPageHeader = (props: {
             isHeader={true}
           />
         </TopContainer>
-        <FooterContainer isVerifiedState={isVerifiedState}>
+        <FooterContainer>
           {props.projections.isCounty && !isEmbed && (
             <HeaderSubCopy>
               <span>Updated {lastUpdatedDateString} · </span>

--- a/src/components/LocationPage/LocationPageHeader.tsx
+++ b/src/components/LocationPage/LocationPageHeader.tsx
@@ -48,13 +48,13 @@ const UpdateCaseDensity: FunctionComponent<{ projections: Projections }> = ({
       ? ''
       : `That changed your threat level from ${levelName(
           previousLevel,
-        )} to ${levelName(currentLevel)}.`;
+        )} to ${levelName(currentLevel)}. `;
   return (
     <Copy isUpdateCopy>
       <strong>New key indicator added</strong>
       <br />
-      {`We added ${CASE_DENSITY_METRIC_NAME}. ${changedLevelCopy}`}{' '}
-      <a href="/">Learn more</a>.
+      {`We added ${CASE_DENSITY_METRIC_NAME}. ${changedLevelCopy}`}
+      <a href="/">Learn more</a>
     </Copy>
   );
 };

--- a/src/components/Map/Map.js
+++ b/src/components/Map/Map.js
@@ -19,6 +19,7 @@ function Map({
   setMobileMenuOpen,
   setMapOption,
   onClick = null,
+  isMiniMap = false,
 }) {
   const history = useHistory();
   const [content, setContent] = useState('');
@@ -81,7 +82,7 @@ function Map({
         />
       </div>
       {!hideInstructions && (
-        <MapInstructions>
+        <MapInstructions isMiniMap={isMiniMap}>
           <strong>Click a state</strong> to view risk details{' '}
           <MobileLineBreak /> and county info.
         </MapInstructions>

--- a/src/components/Map/Map.style.js
+++ b/src/components/Map/Map.style.js
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 import Typography from '@material-ui/core/Typography';
+import { COLOR_MAP } from 'common/colors';
 
 export const USMapWrapper = styled.div`
   position: relative;
@@ -35,8 +36,10 @@ export const USStateMapWrapper = styled.div`
 
 export const MapInstructions = styled(Typography)`
   text-align: center;
-  margin: 1rem 1rem 2.5rem;
+  margin: ${props =>
+    props.isMiniMap ? '-1rem 1rem 1rem 1rem' : '1rem 1rem 2.5rem'};
   font-size: 0.875rem;
+  color: ${COLOR_MAP.GRAY_BODY_COPY};
 `;
 
 export const MobileLineBreak = styled.br`

--- a/src/components/MiniMap/MiniMap.style.tsx
+++ b/src/components/MiniMap/MiniMap.style.tsx
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 import palette from 'assets/theme/palette';
+import { COLOR_MAP } from 'common/colors';
 
 const mapWidth = 300;
 const mapHeight = 280;
@@ -58,7 +59,8 @@ export const TabItem = styled.div<{ selected?: boolean }>`
       ? `solid ${selectedTabBorder}px ${selectedTabColor}`
       : 'none'};
   cursor: pointer;
-  color: ${props => (props.selected ? palette.black : '#828282')};
+  color: ${props =>
+    props.selected ? palette.black : `${COLOR_MAP.GRAY_BODY_COPY}`};
 `;
 
 export const MapContainer = styled.div`

--- a/src/components/MiniMap/MiniMap.tsx
+++ b/src/components/MiniMap/MiniMap.tsx
@@ -81,6 +81,7 @@ const MiniMap: FunctionComponent<MiniMapProperties> = ({
             hideLegend={true}
             setMapOption={setMapOption}
             setMobileMenuOpen={setMobileMenuOpen}
+            isMiniMap={true}
           />
         )}
         {/* State Map */}

--- a/src/components/SummaryStats/LocationHeaderStats.tsx
+++ b/src/components/SummaryStats/LocationHeaderStats.tsx
@@ -132,7 +132,7 @@ const SummaryStat = ({
         >
           {getMetricName(chartType)}{' '}
         </StatNameText>
-        {!condensed && !isMobile && !statusUnknown && (
+        {!condensed && !isMobile && (
           <StatValue
             value={statValue}
             iconColor={levelInfo.color}
@@ -152,7 +152,7 @@ const SummaryStat = ({
           />
         )}
       </StatTextWrapper>
-      {!condensed && isMobile && !statusUnknown && (
+      {!condensed && isMobile && (
         <StatValueWrapper condensed={condensed}>
           <StatValue
             value={statValue}

--- a/src/components/SummaryStats/SummaryStats.style.tsx
+++ b/src/components/SummaryStats/SummaryStats.style.tsx
@@ -68,7 +68,7 @@ export const SummaryStatWrapper = styled(Box)<{
     border-bottom: ${!props.isHeader && `1px solid ${palette.lightGray}`};
 
     @media (min-width: 600px) {
-      border-bottom: 1px solid ${palette.lightGray};
+      border-bottom: ${!props.isHeader && `1px solid ${palette.lightGray}`};
       margin: 0;
       flex-direction: column;
       align-items: center;
@@ -198,11 +198,17 @@ export const StatValueText = styled(Typography)<{
 
     @media (min-width: 600px) {
       text-align: left;
-      font-size: ${props.statusUnknown ? '1rem' : '1.875rem'};
+      font-size: ${
+        !props.isHeader ? '1.875rem' : props.statusUnknown ? '.9rem' : '1.55rem'
+      };
       line-height: ${props.isHeader ? '1.4' : '3.5rem'};
       margin-bottom: ${props.isHeader ? '0' : '0.5rem'};
       display: flex;
       flex-direction: column;
+    }
+
+    @media (min-width: 932px) {
+      font-size: ${props.statusUnknown ? '1rem' : '1.875rem'};
     }
   `}
 `;
@@ -224,7 +230,8 @@ export const BetaTag = styled.span<{ isHeader?: Boolean }>`
   background-color: ${({ isHeader }) =>
     isHeader ? 'none' : `${palette.info.main}`};
   border: ${({ isHeader }) => isHeader && `1px solid ${COLOR_MAP.GRAY.LIGHT}`};
-  color: ${({ isHeader }) => (isHeader ? '#4f4f4f' : 'white')};
+  color: ${({ isHeader }) =>
+    isHeader ? `${COLOR_MAP.GRAY_BODY_COPY}` : 'white'};
   transform: ${({ isHeader }) => (isHeader ? 'none' : 'translateY(-0.15rem)')};
   margin-top: ${({ isHeader }) => (isHeader ? '.5rem' : 'none')};
 
@@ -257,8 +264,12 @@ export const ValueWrapper = styled(Box)<{ iconColor: string }>`
     color: ${({ iconColor }) => iconColor};
 
     @media (min-width: 600px) {
-      margin-right: 0.75rem;
+      margin-right: 0.55rem;
       font-size: 1.15rem;
+    }
+
+    @media (min-width: 932px) {
+      margin-right: 0.75rem;
     }
   }
 `;
@@ -266,7 +277,7 @@ export const ValueWrapper = styled(Box)<{ iconColor: string }>`
 export const PrevalenceMeasure = styled(Typography)`
   font-family: Roboto;
   font-size: 12px;
-  color: #828282;
+  color: ${COLOR_MAP.GRAY_BODY_COPY};
   line-height: 1.1;
   margin-left: 0.5rem;
   margin-top: 0.25rem;

--- a/src/screens/HomePage/Announcements/Announcements.style.tsx
+++ b/src/screens/HomePage/Announcements/Announcements.style.tsx
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import { Typography, Box } from '@material-ui/core';
 import { COLOR_MAP } from 'common/colors';
 
@@ -16,69 +16,74 @@ export const AnnouncementsSectionHeader = styled(Typography)`
   font-size: 14px;
   letter-spacing: 0.01em;
   text-transform: uppercase;
-  color: #828282;
+  color: ${COLOR_MAP.GRAY_BODY_COPY};
   margin-bottom: 0.75rem;
-
-  @media (min-width: 600px) {
-    font-size: 15px;
-  }
 `;
 
 export const AnnouncementIntro = styled(Typography)`
   font-family: Roboto;
   font-weight: 900;
   font-size: 24px;
-  line-height: 140%;
+  line-height: 120%;
   margin-bottom: 1rem;
 
   @media (min-width: 600px) {
-    font-size: 32px;
-    line-height: 140%;
+    font-size: 28px;
   }
 `;
 
 export const Date = styled(Typography)`
-  font-family: Roboto;
+  font-family: Source Code Pro;
   font-size: 13px;
   line-height: 16px;
   letter-spacing: 0.01em;
   text-transform: uppercase;
-  color: #828282;
-  margin-bottom: 1.25rem;
+  color: ${COLOR_MAP.GRAY_BODY_COPY};
+  margin-bottom: 1rem;
 `;
 
 export const AnnouncementBodyCopy = styled(Typography)`
   font-family: Roboto;
   font-size: 14px;
-  line-height: 16px;
+  line-height: 160%;
   letter-spacing: 0.01em;
-  margin-bottom: 2.5rem;
-  color: #4f4f4f;
-  line-height: 140%;
+  margin-bottom: 1.5rem;
+  color: ${COLOR_MAP.GRAY_BODY_COPY};
 `;
 
 export const ButtonsContainer = styled(Box)`
   display: flex;
   flex-direction: column;
-  align-items: center;
+  align-items: flex-start;
 
   @media (min-width: 600px) {
     flex-direction: row;
+    align-items: center;
   }
 `;
 
-export const ReadMoreButton = styled.a`
-  border-radius: 4px;
-  background-color: #e0e0e0;
-  color: white;
+const SharedButtonStyles = css`
   font-family: Roboto;
-  font-weight: bold;
-  font-size: 16px;
-  text-align: center;
-  padding: 1rem 2rem;
+  font-size: 14px;
+  line-height: 1.4;
+  color: ${COLOR_MAP.BLUE};
+  display: flex;
+`;
+
+export const ReadMoreButton = styled.a`
+  ${SharedButtonStyles}
+  border-radius: 4px;
+  border: 1px solid #e0e0e0;
+  font-weight: 500;
+  justify-content: center;
+  padding: 0.75rem 0;
   width: 160px;
   margin-bottom: 1.5rem;
   text-decoration: none;
+
+  &:hover {
+    border: 1px solid ${COLOR_MAP.BLUE};
+  }
 
   @media (min-width: 600px) {
     margin-bottom: 0;
@@ -86,13 +91,9 @@ export const ReadMoreButton = styled.a`
 `;
 
 export const ViewAllLink = styled.a`
-  font-family: Roboto;
-  font-size: 15px;
-  color: ${COLOR_MAP.BLUE};
-  display: flex;
-  align-self: center;
+  ${SharedButtonStyles}
 
   @media (min-width: 600px) {
-    margin-left: 1.75rem;
+    margin-left: 2rem;
   }
 `;

--- a/src/screens/HomePage/Announcements/Announcements.tsx
+++ b/src/screens/HomePage/Announcements/Announcements.tsx
@@ -36,7 +36,7 @@ const Announcements = () => {
           target="_blank"
           rel="noopener"
         >
-          Read more
+          Continue reading
         </ReadMoreButton>
         <ViewAllLink
           href="https://blog.covidactnow.org/"

--- a/src/screens/HomePage/CriteriaExplanation/CriteriaExplanation.style.tsx
+++ b/src/screens/HomePage/CriteriaExplanation/CriteriaExplanation.style.tsx
@@ -2,6 +2,7 @@ import styled from 'styled-components';
 import { Typography, Box } from '@material-ui/core';
 import palette from 'assets/theme/palette';
 import { BetaTag } from 'components/LocationPage/ChartsHolder.style';
+import { COLOR_MAP } from 'common/colors';
 
 export const CriteriaList = styled.div`
   display: flex;
@@ -101,7 +102,7 @@ export const CriterionDescription = styled(Typography)`
   font-family: Roboto;
   font-size: 14px;
   line-height: 140%;
-  color: #4f4f4f;
+  color: ${COLOR_MAP.GRAY_BODY_COPY};
   margin-bottom: 0.25rem;
 
   @media (min-width: 600px) {
@@ -116,13 +117,8 @@ export const ListHeader = styled(Typography)`
   text-align: center;
   letter-spacing: 0.01em;
   text-transform: uppercase;
-  color: #828282;
+  color: ${COLOR_MAP.GRAY_BODY_COPY};
   margin-bottom: 0.5rem;
-
-  @media (min-width: 600px) {
-    font-size: 15px;
-    line-height: 18px;
-  }
 `;
 
 export const ListSubheader = styled(Typography)`

--- a/src/screens/HomePage/HomePage.style.js
+++ b/src/screens/HomePage/HomePage.style.js
@@ -1,13 +1,14 @@
 import styled from 'styled-components';
 import { Typography, Box } from '@material-ui/core';
 import palette from 'assets/theme/palette';
+import { COLOR_MAP } from 'common/colors';
 
 export const SearchBarThermometerWrapper = styled(Box)`
   display: flex;
   justify-content: center;
 
   @media (min-width: 600px) {
-    margin-bottom: -2.5rem;
+    margin: 0 1rem -3.5rem;
   }
 `;
 
@@ -21,27 +22,28 @@ export const PartnerSection = styled.div`
 `;
 
 export const PartnerHeader = styled(Typography)`
-  font-size: 1rem;
   padding-top: 2.5rem;
   margin-top: 2.5rem;
-  color: rgba(0, 0, 0, 0.7);
-  letter-spacing: 0.08em;
   border-top: 1px solid ${palette.lightGray};
-  font-weight: 500;
   text-align: center;
-  text-transform: uppercase;
   margin-bottom: 1rem;
+  font-family: Roboto;
+  font-size: 14px;
+  letter-spacing: 0.01em;
+  text-transform: uppercase;
+  color: ${COLOR_MAP.GRAY_BODY_COPY};
 `;
 
 export const FeaturedHeader = styled(Typography)`
   font-size: 1rem;
   margin-top: 4rem;
-  color: rgba(0, 0, 0, 0.7);
-  letter-spacing: 0.08em;
-  font-weight: 500;
   text-align: center;
-  text-transform: uppercase;
   margin-bottom: 1rem;
+  font-family: Roboto;
+  font-size: 14px;
+  letter-spacing: 0.01em;
+  text-transform: uppercase;
+  color: ${COLOR_MAP.GRAY_BODY_COPY};
 `;
 
 export const SectionWrapper = styled(Box)`

--- a/src/screens/HomePage/HomePageThermometer.style.tsx
+++ b/src/screens/HomePage/HomePageThermometer.style.tsx
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 import { Typography, Box } from '@material-ui/core';
 import { Level } from 'common/level';
+import { COLOR_MAP } from 'common/colors';
 
 export const Content = styled(Box)`
   display: flex;
@@ -53,7 +54,7 @@ export const RowCopy = styled(Typography)`
   font-weight: normal;
   font-size: 15px;
   line-height: 140%;
-  color: #828282;
+  color: ${COLOR_MAP.GRAY_BODY_COPY};
   line-height: 1.8rem;
   margin-left: 1rem;
 `;

--- a/src/screens/internal/ShareImage/ShareCardImage.style.ts
+++ b/src/screens/internal/ShareImage/ShareCardImage.style.ts
@@ -5,15 +5,15 @@ import styled from 'styled-components';
  * have to adapt the css styles.
  */
 export const ShareCardWrapper = styled.div<{ isHomePage?: boolean }>`
-  margin: 50px auto;
+  margin: ${props => (props.isHomePage ? '50px auto' : '35px auto')};
   width: 400px;
   height: 262px;
   transform: scale(${props => (props.isHomePage ? 2.25 : 1.75)});
   transform-origin: top center;
 `;
 
-export const TitleWrapper = styled.div`
-  margin-top: 68px;
+export const TitleWrapper = styled.div<{ isHomePage?: Boolean }>`
+  margin-top: ${props => (props.isHomePage ? '68px' : '35px')};
   height: 48px;
   line-height: 48px;
   font-size: 48px;

--- a/src/screens/internal/ShareImage/ShareCardImage.tsx
+++ b/src/screens/internal/ShareImage/ShareCardImage.tsx
@@ -23,7 +23,7 @@ const ShareCardImage = () => {
   const isHomePage = !stateId && !countyFipsId;
   return (
     <ScreenshotWrapper className={'screenshot'}>
-      <Header />
+      <Header isHomePage={isHomePage} />
       <ShareCardWrapper isHomePage={isHomePage}>
         <ShareCard stateId={stateId} countyFipsId={countyFipsId} />
       </ShareCardWrapper>
@@ -36,10 +36,12 @@ interface ShareCardProps {
   countyFipsId?: string;
 }
 
-const Header = () => {
+const Header = (props: { isHomePage?: Boolean }) => {
   return (
     <>
-      <TitleWrapper>Real-time COVID metrics</TitleWrapper>
+      <TitleWrapper isHomePage={props.isHomePage}>
+        Real-time COVID metrics
+      </TitleWrapper>
       <LastUpdatedWrapper>
         Updated {formatLocalDate(new Date())}
       </LastUpdatedWrapper>


### PR DESCRIPTION
This PR adds the copy for the Updates section on the Location page header.

![image](https://user-images.githubusercontent.com/114084/87734702-41b3bf00-c788-11ea-8925-5b90ac2d10c8.png)

For testing:
- New York changed
- Washington State didn't change

The copy is still preliminary, but since we will probably need the change in levels due to the introduction of prevalence it's better to have the levels ready.

Note that the function `getAlarmLevelWithoutCaseDensity` is only useful while the update is relevant (a few weeks after the release of prevalence), so we can remove this function once it's no longer necessary.