### PR TITLE
Use cumulativeConfirmedCases instead of cumulativePositiveTests where applicable.

### DIFF
--- a/src/common/models/Projection.ts
+++ b/src/common/models/Projection.ts
@@ -127,10 +127,9 @@ export class Projection {
   private readonly actualTimeseries: Array<ActualsTimeseriesRow | null>;
   private readonly cumulativeDeaths: Array<number | null>;
   private readonly cumulativeInfected: Array<number | null>;
-  private readonly cumulativePositiveTests: Array<number | null>;
-  private readonly cumulativeNegativeTests: Array<number | null>;
   private readonly smoothedDailyNegativeTests: Array<number | null>;
   private readonly smoothedDailyPositiveTests: Array<number | null>;
+  private readonly smoothedDailyCases: Array<number | null>;
   private readonly rtRange: Array<RtRange | null>;
   // ICU Utilization series as values between 0-1 (or > 1 if over capacity).
   private readonly icuUtilization: Array<number | null>;
@@ -179,17 +178,24 @@ export class Projection {
     this.cumulativeInfected = timeseries.map(
       row => row && row.cumulativeInfected,
     );
-    this.cumulativePositiveTests = this.smoothCumulatives(
+    const cumulativePositiveTests = this.smoothCumulatives(
       actualTimeseries.map(row => row && row.cumulativePositiveTests),
     );
-    this.cumulativeNegativeTests = this.smoothCumulatives(
+    const cumulativeNegativeTests = this.smoothCumulatives(
       actualTimeseries.map(row => row && row.cumulativeNegativeTests),
     );
     this.smoothedDailyPositiveTests = this.smoothWithRollingAverage(
-      this.deltasFromCumulatives(this.cumulativePositiveTests),
+      this.deltasFromCumulatives(cumulativePositiveTests),
     );
     this.smoothedDailyNegativeTests = this.smoothWithRollingAverage(
-      this.deltasFromCumulatives(this.cumulativeNegativeTests),
+      this.deltasFromCumulatives(cumulativeNegativeTests),
+    );
+
+    const cumulativeConfirmedCases = this.smoothCumulatives(
+      actualTimeseries.map(row => row && row.cumulativeConfirmedCases),
+    );
+    this.smoothedDailyCases = this.smoothWithRollingAverage(
+      this.deltasFromCumulatives(cumulativeConfirmedCases),
     );
 
     const cumulativeActualDeaths = this.smoothCumulatives(
@@ -260,9 +266,7 @@ export class Projection {
   // currentDailyAverageCases and make sure we're pulling all of the data from
   // the same day, to make sure it matches the graph.
   get currentDailyAverageCases() {
-    // TODO(michael): We conflate "positive tests" and "cases" throughout this
-    // code. Is that okay? Can they diverge?
-    return lastValue(this.smoothedDailyPositiveTests);
+    return lastValue(this.smoothedDailyCases);
   }
 
   get label() {
@@ -414,7 +418,7 @@ export class Projection {
       if (row && row.contactTracers) {
         const contactTracers =
           CONTACT_TRACER_STATE_OVERRIDES[this.stateName] || row.contactTracers;
-        const cases = this.smoothedDailyPositiveTests[i];
+        const cases = this.smoothedDailyCases[i];
         if (cases) {
           return contactTracers / (cases * TRACERS_NEEDED_PER_CASE);
         }
@@ -426,7 +430,7 @@ export class Projection {
 
   private calcCaseDensityByCases(): Array<number | null> {
     const totalPopulation = this.totalPopulation;
-    return this.smoothedDailyPositiveTests.map(cases => {
+    return this.smoothedDailyCases.map(cases => {
       if (totalPopulation === 0 || cases === null) {
         return null;
       } else {

--- a/src/screens/internal/CompareSnapshots/CompareSnapshots.tsx
+++ b/src/screens/internal/CompareSnapshots/CompareSnapshots.tsx
@@ -24,7 +24,7 @@ import {
   ModelComparisonsContainer,
   ModelSelectorContainer,
 } from './CompareSnapshots.style';
-import { Metric, getMetricName } from 'common/metric';
+import { Metric, getMetricName, ALL_METRICS } from 'common/metric';
 import { Projections } from 'common/models/Projections';
 import { ProjectionsSet } from 'common/models/ProjectionsSet';
 import { SortType, ProjectionsPair } from 'common/models/ProjectionsPair';
@@ -235,13 +235,7 @@ function CompareSnapshotsInner({ masterSnapshot }: { masterSnapshot: number }) {
         <FormControl style={{ width: '12rem', marginLeft: '1rem' }}>
           <InputLabel focused={false}>Metric:</InputLabel>
           <Select value={metric} onChange={changeMetric}>
-            {[
-              Metric.CASE_GROWTH_RATE,
-              Metric.POSITIVE_TESTS,
-              Metric.HOSPITAL_USAGE,
-              Metric.CONTACT_TRACING,
-              Metric.FUTURE_PROJECTIONS,
-            ].map(metric => (
+            {ALL_METRICS.map(metric => (
               <MenuItem key={metric} value={metric}>
                 {getMetricName(metric)}
               </MenuItem>


### PR DESCRIPTION
* We were assuming that cumulativeConfirmedCases and cumulativePositiveTests were interchangeable, but they're not. E.g. Marion County, IN has good cumulativeConfirmedCases, but cumulativePositiveTests is garbage.  So we use cumulativeConfirmedCases now for the contact tracing and case density metrics.

Also added new case density metric to compare tool (mostly because it made it easier
for me to sanity-check all the graphs).

Before this change (with deaths disabled):
![image](https://user-images.githubusercontent.com/206364/87756212-5494b680-c7bd-11ea-88d1-e7f130c8338a.png)

After this change (with deaths disabled):
![image](https://user-images.githubusercontent.com/206364/87756249-6aa27700-c7bd-11ea-8b9c-397e7aa44b10.png)

