### PR TITLE
prevalence: calculate case density by cases only

### DIFF
--- a/src/common/models/Projection.ts
+++ b/src/common/models/Projection.ts
@@ -450,27 +450,11 @@ export class Projection {
   }
 
   private calcCaseDensityRange(): Array<CaseDensityRange | null> {
-    return this.caseDensityByDeaths.map((caseDensityByDeaths, i) => {
-      // TODO: We were intending to calculate a low/high range for
-      // caseDensityByDeath, based on a range of CFRs, but this doesn't work when
-      // we merge with caseDensityByCases which has no range. So for now,
-      // we are punting.
-      // const caseDensityByDeathsLow = (CASE_FATALITY_RATIO / CASE_FATALITY_RATIO_UPPER) * caseDensityByDeaths;
-      // const caseDensityByDeathsHigh = (CASE_FATALITY_RATIO / CASE_FATALITY_RATIO_LOWER) * caseDensityByDeaths;
-
-      const caseDensityByCases = this.caseDensityByCases[i];
-      const caseDensity = _.max(
-        [caseDensityByDeaths, caseDensityByCases].filter(cd => cd !== null),
-      );
-
-      return caseDensity == null
+    return this.caseDensityByCases.map(caseDensity =>
+      caseDensity === null
         ? null
-        : {
-            caseDensity,
-            low: caseDensity,
-            high: caseDensity,
-          };
-    });
+        : { caseDensity, low: caseDensity, high: caseDensity },
+    );
   }
 
   private calcRtRange(


### PR DESCRIPTION
Updates how the case density metric is calculated to use only cases. See the [discussion on Slack](https://covidactnow.slack.com/archives/C0177KERT89/p1594945641003000)

Note: I left the function just in case we need to put deaths back in the mix, I will remove the ranges and unused properties and functions once we confirm the calculation.