### PR TITLE
case incidence: clicking on the case incidence stat scrolls to the correct chart

### DIFF
--- a/src/components/LocationPage/ChartsHolder.tsx
+++ b/src/components/LocationPage/ChartsHolder.tsx
@@ -160,6 +160,7 @@ const ChartsHolder = (props: {
             <LocationPageHeader
               projections={props.projections}
               stats={props.projections.getMetricValues()}
+              onCaseDensityClick={() => scrollTo(caseDensityRef.current)}
               onRtRangeClick={() => scrollTo(rtRangeRef.current)}
               onTestPositiveClick={() => scrollTo(testPositiveRef.current)}
               onIcuUtilizationClick={() => scrollTo(icuUtilizationRef.current)}

--- a/src/components/LocationPage/LocationPageHeader.tsx
+++ b/src/components/LocationPage/LocationPageHeader.tsx
@@ -94,6 +94,7 @@ const LocationPageHeader = (props: {
   onContactTracingClick?: () => void;
   onHeaderShareClick: () => void;
   onHeaderSignupClick: () => void;
+  onCaseDensityClick: () => void;
   isMobile?: Boolean;
 }) => {
   const hasStats = !!Object.values(props.stats).filter(
@@ -203,6 +204,7 @@ const LocationPageHeader = (props: {
           </HeaderSection>
           <LocationHeaderStats
             stats={props.stats}
+            onCaseDensityClick={props.onCaseDensityClick}
             onRtRangeClick={props.onRtRangeClick}
             onTestPositiveClick={props.onTestPositiveClick}
             onIcuUtilizationClick={props.onIcuUtilizationClick}

--- a/src/components/SummaryStats/LocationHeaderStats.tsx
+++ b/src/components/SummaryStats/LocationHeaderStats.tsx
@@ -180,6 +180,7 @@ const LocationHeaderStats = (props: {
   stats: { [key: string]: number | null };
   condensed?: Boolean;
   isEmbed?: Boolean;
+  onCaseDensityClick?: () => void;
   onRtRangeClick?: () => void;
   onTestPositiveClick?: () => void;
   onIcuUtilizationClick?: () => void;
@@ -208,7 +209,7 @@ const LocationHeaderStats = (props: {
           condensed={props.condensed}
         >
           <SummaryStat
-            onClick={props.onRtRangeClick || noop}
+            onClick={props.onCaseDensityClick || noop}
             chartType={Metric.CASE_DENSITY}
             value={props.stats[Metric.CASE_DENSITY] as number}
             {...sharedStatProps}


### PR DESCRIPTION
Fixes [Trello 317](https://trello.com/c/kz9wMPgk/317-clicking-the-case-incidence-metric-scrolls-to-the-rt-chart) - Clicking on the case incidence stat scrolls to the Rt chart.

I missed this when implementing the chart, fixed now :)