### PR TITLE
Prevalence-share/export image header update

### DIFF
--- a/src/common/metric.ts
+++ b/src/common/metric.ts
@@ -41,6 +41,14 @@ export function getMetricName(metric: Metric) {
   return METRIC_TO_NAME[metric];
 }
 
+export function getMetricNameExtended(metric: Metric) {
+  if (metric === Metric.CASE_DENSITY) {
+    return `${METRIC_TO_NAME[metric]} per 100k population`;
+  } else {
+    return METRIC_TO_NAME[metric];
+  }
+}
+
 const ALL_METRICS_LEVEL_INFO_MAP = {
   [Metric.CASE_GROWTH_RATE]: CaseGrowth.CASE_GROWTH_RATE_LEVEL_INFO_MAP,
   [Metric.POSITIVE_TESTS]: TestRates.POSITIVE_TESTS_LEVEL_INFO_MAP,

--- a/src/components/LocationPage/ChartBlock.tsx
+++ b/src/components/LocationPage/ChartBlock.tsx
@@ -11,7 +11,11 @@ import { Projection } from 'common/models/Projection';
 import Disclaimer from 'components/Disclaimer/Disclaimer';
 import Outcomes from 'components/Outcomes/Outcomes';
 import ShareButtons from 'components/LocationPage/ShareButtons';
-import { Metric, getMetricName, getMetricStatusText } from 'common/metric';
+import {
+  Metric,
+  getMetricNameExtended,
+  getMetricStatusText,
+} from 'common/metric';
 import { formatUtcDate } from 'common/utils';
 import { generateChartDescription } from 'common/metrics/future_projection';
 import MetricChart from 'components/Charts/MetricChart';
@@ -55,18 +59,13 @@ function ChartBlock(props: {
     !futureProjectionsDisabled &&
     props.projections.hasMetric(Metric.FUTURE_PROJECTIONS);
 
-  const chartHeader =
-    props.metric === Metric.CASE_DENSITY
-      ? `${getMetricName(props.metric)} per 100k population`
-      : `${getMetricName(props.metric)}`;
-
   return (
     <Fragment>
       {props.metric !== Metric.FUTURE_PROJECTIONS && (
         <Fragment>
           <ChartHeaderWrapper>
             <ChartHeader ref={props.chartRef}>
-              {chartHeader}
+              {getMetricNameExtended(props.metric)}
               {showBetaTag && <BetaTag>Beta</BetaTag>}
             </ChartHeader>
             {!props.isMobile && props.data && (

--- a/src/screens/internal/ShareImage/ChartExportImage.tsx
+++ b/src/screens/internal/ShareImage/ChartExportImage.tsx
@@ -14,7 +14,7 @@ import {
 import LogoUrlLight from 'assets/images/logoUrlLight';
 import { Projections } from 'common/models/Projections';
 import { MetricChart } from '../../../components/Charts';
-import { getMetricName, ALL_METRICS } from 'common/metric';
+import { ALL_METRICS, getMetricNameExtended } from 'common/metric';
 import { Metric } from 'common/metric';
 import { findCountyByFips } from 'common/locations';
 import { useProjections, useModelLastUpdatedDate } from 'common/utils/model';
@@ -53,7 +53,7 @@ const ExportChartImage = () => {
       <Content>
         <Headers>
           <Location>{projection.locationName}</Location>
-          <MetricName>{getMetricName(metric)}</MetricName>
+          <MetricName>{getMetricNameExtended(metric)}</MetricName>
           <LastUpdated>Last updated {formatUtcDate(lastUpdated)} </LastUpdated>
         </Headers>
         <LogoHolder>

--- a/src/screens/internal/ShareImage/ChartShareImage.tsx
+++ b/src/screens/internal/ShareImage/ChartShareImage.tsx
@@ -14,7 +14,7 @@ import LogoDark from 'assets/images/logoDark';
 import { chartDarkMode } from 'assets/theme/palette';
 import { Projections } from 'common/models/Projections';
 import { MetricChart } from '../../../components/Charts';
-import { getMetricName, ALL_METRICS } from 'common/metric';
+import { ALL_METRICS, getMetricNameExtended } from 'common/metric';
 import { Metric } from 'common/metric';
 import { findCountyByFips } from 'common/locations';
 import { useProjections } from 'common/utils/model';
@@ -46,7 +46,7 @@ export default function ChartShareImage() {
     <ScreenshotWrapper className={'screenshot'}>
       <Wrapper>
         <Headers>
-          <Title>{getMetricName(metric)}</Title>
+          <Title>{getMetricNameExtended(metric)}</Title>
           <Subtitle>{projection.locationName}</Subtitle>
           <LogoHolder>
             <LogoDark height={35} />


### PR DESCRIPTION
Our share and download images for case density do not currently include the words "per 100k population" anywhere. This PR adds "per 100k population" to the images' headers.