### PR TITLE
improve the spacing of case incidence level annotations

### DIFF
--- a/src/components/Charts/ChartCaseDensity.tsx
+++ b/src/components/Charts/ChartCaseDensity.tsx
@@ -76,7 +76,7 @@ const ChartCaseDensity: FunctionComponent<{
   // Adjusts the min y-axis to make the Low label fit only if
   // the current level is Low
   const isLow = activeZone.level === Level.LOW;
-  const yAxisMin = isLow ? -9 : 0;
+  const yAxisMin = isLow ? -6 : 0;
   const yAxisMax = Math.min(yAxisLimits[1], capY);
 
   const yScale = scaleLinear({


### PR DESCRIPTION
From [Slack](https://covidactnow.slack.com/archives/C0177KERT89/p1595453168127300)

The "Low" level for case incidence goes from `0` to `1`, which is too narrow to show the label in the chart. We added some padding before to make room for it, but as a consequence, the chart ends up being a bit misleading, as the spacing between the x-axis and 1 is the same as the space between 1 and 10.

This fix hides the "Low" label and sets the min y-axis to 0 if the current level is not Low, and makes room and adds the "Low" label if the current Level for the location is "Low".

### Example: Level = Medium
![image](https://user-images.githubusercontent.com/114084/88240369-c0eb3c00-cc3b-11ea-9934-d32404fea6ae.png)

### Example: Level = Low
![image](https://user-images.githubusercontent.com/114084/88240404-d8c2c000-cc3b-11ea-85f0-30b5dcbb462e.png)
