### PR TITLE
fix handling of invalid emails

### DIFF
--- a/scripts/alert_emails/campaign-monitor.ts
+++ b/scripts/alert_emails/campaign-monitor.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosInstance, AxiosResponse } from 'axios';
+import axios, { AxiosInstance, AxiosResponse, AxiosError } from 'axios';
 import delay from 'delay';
 
 export interface EmailSendData {
@@ -30,7 +30,7 @@ export interface CampaignMonitorMessageSent {
   MessageID: string;
 }
 
-class CampaignMonitorException {
+class CampaignMonitorException implements CampaignMonitorError {
   Code: number;
   Message: string;
   constructor(code: number, message: string) {
@@ -47,7 +47,7 @@ function isRateLimitExceeded(status: number) {
   return status === 429;
 }
 
-export function isInvalidEmailError(error: CampaignMonitorException) {
+export function isInvalidEmailError(error: CampaignMonitorError) {
   return (
     error.Code === 1 &&
     error.Message === 'A valid recipient address is required'

--- a/scripts/alert_emails/campaign-monitor.ts
+++ b/scripts/alert_emails/campaign-monitor.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosInstance, AxiosResponse, AxiosError } from 'axios';
+import axios, { AxiosInstance, AxiosResponse } from 'axios';
 import delay from 'delay';
 
 export interface EmailSendData {

--- a/scripts/alert_emails/send-test-email.ts
+++ b/scripts/alert_emails/send-test-email.ts
@@ -29,6 +29,11 @@ async function main(emailAddress: string) {
     await cm.sendClassicEmail(data);
     console.info(`Email sent to ${emailAddress}.`);
   } catch (err) {
+    if (err.Code === 1) {
+      console.log('invalid email');
+      process.exit(1);
+    }
+
     console.error(err);
     process.exit(1);
   }

--- a/scripts/alert_emails/send-test-email.ts
+++ b/scripts/alert_emails/send-test-email.ts
@@ -9,7 +9,7 @@
  *    $ yarn send-test-email pablo@covidactnow.org
  */
 
-import CampaignMonitor from './campaign-monitor';
+import CampaignMonitor, { isInvalidEmailError } from './campaign-monitor';
 import { Alert } from './interfaces';
 import { generateAlertEmailData } from './utils';
 
@@ -29,12 +29,11 @@ async function main(emailAddress: string) {
     await cm.sendClassicEmail(data);
     console.info(`Email sent to ${emailAddress}.`);
   } catch (err) {
-    if (err.Code === 1) {
-      console.log('invalid email');
-      process.exit(1);
+    if (isInvalidEmailError(err)) {
+      console.log(`Invalid email: "${emailAddress}"`);
+    } else {
+      console.error(`Error sending email to "${emailAddress}"`, err);
     }
-
-    console.error(err);
     process.exit(1);
   }
 }

--- a/scripts/alert_emails/send_emails.ts
+++ b/scripts/alert_emails/send_emails.ts
@@ -1,28 +1,17 @@
-//@ts-ignore createsend has no types and throws an error
 import _ from 'lodash';
 import admin from 'firebase-admin';
 import path from 'path';
 import { getFirestore } from './firestore';
-import CampaignMonitor, { CampaignMonitorError } from './campaign-monitor';
+import CampaignMonitor, { isInvalidEmailError } from './campaign-monitor';
 import { generateAlertEmailData, readAlerts } from './utils';
+
+const BATCH_SIZE = 20;
 
 interface SendEmailResult {
   MessageID: string;
   Recipient: string;
   Status: string;
   headers: { [key: string]: string };
-}
-
-const CM_INVALID_EMAIL_MESSAGE = 'A valid recipient address is required';
-const CM_INVALID_EMAIL_ERROR_CODE = 1;
-
-const BATCH_SIZE = 20;
-
-function isInvalidEmailError(err: CampaignMonitorError) {
-  return (
-    err.Code === CM_INVALID_EMAIL_ERROR_CODE &&
-    err.Message === CM_INVALID_EMAIL_MESSAGE
-  );
 }
 
 async function setLastSnapshotNumber(

--- a/scripts/alert_emails/send_emails.ts
+++ b/scripts/alert_emails/send_emails.ts
@@ -60,7 +60,7 @@ async function setLastSnapshotNumber(
     const currentData = querySnapshot.data();
     if (currentData) {
       await db
-        .collection('invalid-alerts-subscriptions')
+        .collection('invalid-alert-subscriptions')
         .doc(email)
         .set(currentData);
       await db.collection('alerts-subscriptions').doc(email).delete();

--- a/scripts/alert_emails/send_emails.ts
+++ b/scripts/alert_emails/send_emails.ts
@@ -7,13 +7,6 @@ import { generateAlertEmailData, readAlerts } from './utils';
 
 const BATCH_SIZE = 20;
 
-interface SendEmailResult {
-  MessageID: string;
-  Recipient: string;
-  Status: string;
-  headers: { [key: string]: string };
-}
-
 async function setLastSnapshotNumber(
   firestore: FirebaseFirestore.Firestore,
   snapshot: string,
@@ -35,13 +28,7 @@ async function setLastSnapshotNumber(
  * You can run via `yarn send-emails fipsToAlertFilename currentSnapshot [send]`
  */
 (async () => {
-  const {
-    fipsToAlertFilename,
-    currentSnapshot,
-    dryRun,
-    sendAllToEmail,
-  } = await parseArgs();
-
+  const { fipsToAlertFilename, currentSnapshot, dryRun } = await parseArgs();
   const alertPath = path.join(__dirname, fipsToAlertFilename);
   const alertsByLocation = readAlerts(alertPath);
 
@@ -132,13 +119,14 @@ async function setLastSnapshotNumber(
     );
   }
 
-  console.log(
-    `Total Emails to be sent: ${emailSent}.) Total locations with emails: ${
-      Object.keys(locationsWithEmails).length
-    }. Unique Email addresses: ${
-      Object.keys(uniqueEmailAddress).length
-    }. Invalid emails removed: ${invalidEmailCount}`,
+  console.info(`Total emails to be sent: ${emailSent}.`);
+  console.info(
+    `Total locations with emails: ${Object.keys(locationsWithEmails).length}.`,
   );
+  console.info(
+    `Unique Email addresses: ${Object.keys(uniqueEmailAddress).length}.`,
+  );
+  console.info(`Invalid emails removed: ${invalidEmailCount}.`);
 
   if (!dryRun) {
     setLastSnapshotNumber(db, currentSnapshot);
@@ -150,7 +138,7 @@ async function setLastSnapshotNumber(
       process.exit(1);
     }
   }
-  console.log(`Done.`);
+  console.info(`Done.`);
 })();
 
 async function parseArgs(): Promise<{
@@ -160,26 +148,23 @@ async function parseArgs(): Promise<{
   sendAllToEmail?: string;
 }> {
   const args = process.argv.slice(2);
-
-  if (args.length < 2 || args.length > 4) {
+  if (args.length < 2 || args.length > 3) {
     exitWithUsage();
   } else {
     const fipsToAlertFilename = args[0];
     const currentSnapshot = args[1];
     const isSend = (args[2] || 'false') === 'true';
-    const sendAllToEmail = args[3] || undefined;
     return {
       fipsToAlertFilename,
       currentSnapshot,
       dryRun: !isSend,
-      sendAllToEmail,
     };
   }
 }
 
 function exitWithUsage(): never {
   console.log(
-    'Usage: yarn send-emails fipsToAlertFilename currentSnapshot [send] [sendAllToEmail]',
+    'Usage: yarn send-emails fipsToAlertFilename currentSnapshot [send]',
   );
   process.exit(1);
 }


### PR DESCRIPTION
Fixes the handling of invalid emails in the `send_emails` script. It also fixes the name of the collection with invalid emails. 

This is how I tested:

### Testing
**Setup**
- Make sure that you have the `CREATE_SEND_TOKEN` environment variable set.
- Make sure that you have the `scripts/alert_emails/google-service-account.json` with the development credentials.
- Unzip the [alerts.json.zip](https://github.com/covid-projections/covid-projections/files/4973819/alerts.json.zip) on `scripts/alert_emails`
 
**Testing**
1. Run `yarn send-test-email invalid@email.com,` - This will try to send a test email to the address `invalid@email.com,` (note the `,` after the email, that passes the regex, but Campaign Monitor rejects it). It should fail and log the `Invalid email` error in the console.
2. Add the invalid email to Firebase and subscribe it to the location `11`
3. Run `yarn create-lists-to-email alerts.json 497` - this will update the `/snapshots/479/locations/11/emails` collection
4. Run `yarn send-emails alerts.json 479 true` - this will try to send an email to all the emails on `/snapshots/479/locations/11/emails`


