### PR TITLE
Alert Email Fixes

### DIFF
--- a/scripts/alert_emails/template.html
+++ b/scripts/alert_emails/template.html
@@ -902,7 +902,7 @@
                                         normal;font-family: Arial, Helvetica, sans-serif;text-align:center;font-size:
                                         15px">
                                                 <span style="color:#4F4F4F;">
-                                                    <a style="color:#00BFEA;" href="{{unsubscribe_link}}">Add or
+                                                    <a style="color:#00BFEA;" href="{{{unsubscribe_link}}}">Add or
                                                         remove locations</a> for
                                                     alerts
                                                 </span>
@@ -918,7 +918,7 @@
                                                                                                                 15px">
                                                 <span>
                                                     <a style="color:#00BFEA;"
-                                                        href="{{unsubscribe_link}}">Unsubscribe</a> from all
+                                                        href="{{{unsubscribe_link}}}">Unsubscribe</a> from all
                                                     alerts
                                                 </span>
                                             </p>

--- a/scripts/alert_emails/utils.ts
+++ b/scripts/alert_emails/utils.ts
@@ -36,8 +36,7 @@ function generateAlertEmailContent(
   } = locationAlert;
 
   const data: AlertTemplateData = {
-    // TODO(pablo): change it back to risk increased / risk decreased after the case incidence send
-    change: 'new risk score',
+    change: changeText(oldLevel, newLevel),
     location_name: locationName,
     img_alt: `Image depicting that ${locationName} went from level ${Level[oldLevel]} to ${Level[newLevel]}`,
     img_url: `${thermometerBaseURL}/therm-${newLevel}-${oldLevel}.png`,
@@ -50,6 +49,16 @@ function generateAlertEmailContent(
   };
 
   return alertTemplate(data);
+}
+
+function changeText(oldLevel: Level, newLevel: Level) {
+  if (oldLevel === Level.UNKNOWN) {
+    return 'new risk score';
+  } else if (oldLevel < newLevel) {
+    return 'risk increased';
+  } else {
+    return 'risk decreased';
+  }
 }
 
 export function generateAlertEmailData(


### PR DESCRIPTION
* Change alert template to use "risk increased" and "risk decreased" again (but keep "new risk
  score" for unknown=>non-unknown transitions.
* Fix unsubscribe link. I'm not sure how long it's been broken, but Handlebars was html-escaping the
  URL in a way that CreateSend didn't like when it tried to add click-tracking to it.