### PR TITLE
Fix: search bar/minimap 

### DIFF
--- a/src/components/Header/SearchHeader.tsx
+++ b/src/components/Header/SearchHeader.tsx
@@ -56,7 +56,12 @@ const SearchHeader = ({
       <Wrapper>
         <Content>
           <MenuBarWrapper>
-            <SelectorWrapper isNarrowMobile={isNarrowMobile}>
+            <SelectorWrapper
+              onClick={() => {
+                setMobileMenuOpen(false);
+              }}
+              isNarrowMobile={isNarrowMobile}
+            >
               <GlobalSelector
                 extendRight={true}
                 handleChange={handleSelectChange}


### PR DESCRIPTION
Fixes [trello item re: minimap not closing when search bar is open](https://trello.com/c/TWpPenNR/329-map-doesnt-disappear-when-clicking-on-the-search-bar-on-mobile)