### PR TITLE
add a modal to the simulator screenshot

### DIFF
--- a/src/components/ImageModal/ImageModal.style.ts
+++ b/src/components/ImageModal/ImageModal.style.ts
@@ -1,0 +1,10 @@
+import styled from 'styled-components';
+import palette from 'assets/theme/palette';
+
+export const ModalContainer = styled.div`
+  background-color: ${palette.white};
+`;
+
+export const ImageContainer = styled.div`
+  cursor: pointer;
+`;

--- a/src/components/ImageModal/ImageModal.tsx
+++ b/src/components/ImageModal/ImageModal.tsx
@@ -1,0 +1,28 @@
+import React, { Fragment, useState } from 'react';
+import { Modal } from '@material-ui/core';
+import * as Styles from './ImageModal.style';
+
+const ImageModal: React.FunctionComponent = ({ children }) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <Fragment>
+      <Styles.ImageContainer onClick={() => setIsOpen(true)}>
+        {children}
+      </Styles.ImageContainer>
+      <Modal
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+        open={isOpen}
+        onClose={() => setIsOpen(false)}
+      >
+        <Styles.ModalContainer>{children}</Styles.ModalContainer>
+      </Modal>
+    </Fragment>
+  );
+};
+
+export default ImageModal;

--- a/src/components/ImageModal/index.ts
+++ b/src/components/ImageModal/index.ts
@@ -1,0 +1,3 @@
+import ImageModal from './ImageModal';
+
+export default ImageModal;

--- a/src/screens/Resources/Resources.tsx
+++ b/src/screens/Resources/Resources.tsx
@@ -7,6 +7,7 @@ import StapledSidebar, {
   SectionHeader,
 } from 'components/StapledSidebar/StapledSidebar';
 import ExternalLink from 'components/ExternalLink';
+import ImageModal from 'components/ImageModal';
 import { COLOR_MAP } from 'common/colors';
 import imgReponseSimulatorUrl from 'assets/images/response-simulator-screenshot.png';
 
@@ -75,14 +76,16 @@ const Resources = ({ children }: { children: React.ReactNode }) => {
             graphs illustrating COVID forecasts with and without these NPIs,
             including estimated case numbers and hospitalizations.
           </Typography>
-          <ImageContainer>
-            <picture>
-              <img
-                src={imgReponseSimulatorUrl}
-                alt="Two screenshots showing a Google sheet. In the first tab we see where you can input your information, and in the second tab you can see the resulting graph and table that is exported."
-              />
-            </picture>
-          </ImageContainer>
+          <ImageModal>
+            <ImageContainer>
+              <picture>
+                <img
+                  src={imgReponseSimulatorUrl}
+                  alt="Two screenshots showing a Google sheet. In the first tab we see where you can input your information, and in the second tab you can see the resulting graph and table that is exported."
+                />
+              </picture>
+            </ImageContainer>
+          </ImageModal>
 
           <GetStartedBox>
             <Typography variant="h5" component="h3">


### PR DESCRIPTION
Wrapped the COVID Response Simulator screenshot in a modal so users can see a full-size image when they click on it. Can @chasulin review? Thanks!