### PR TITLE
add a URL for the response simulator

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -74,6 +74,11 @@ export default function App() {
               <Route path="/contact" component={Contact} />
               <Route path="/terms" component={Terms} />
               <Route path="/privacy" component={Privacy} />
+              {/* Custom URL for sharing the COVID Response Simulator */}
+              <Route path="/response-simulator">
+                <Redirect to="resources#covid-response-simulator" />
+              </Route>
+
               {/* Embed routes */}
               <Route
                 exact

--- a/src/App.js
+++ b/src/App.js
@@ -76,7 +76,7 @@ export default function App() {
               <Route path="/privacy" component={Privacy} />
               {/* Custom URL for sharing the COVID Response Simulator */}
               <Route path="/response-simulator">
-                <Redirect to="resources#covid-response-simulator" />
+                <Redirect to="/resources#covid-response-simulator" />
               </Route>
 
               {/* Embed routes */}


### PR DESCRIPTION
We are creating a vanity URL for the response simulator to make it easier to share. The URL is just redirecting to `/resources#covid-response-simulator`

`https://covidactnow.org/response-simulator`