### PR TITLE
compare: minor styling fixes

### DIFF
--- a/src/components/Compare/Compare.style.tsx
+++ b/src/components/Compare/Compare.style.tsx
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import { isNumber } from 'lodash';
 import { TableHead, TableCell, TableRow, Table } from '@material-ui/core';
 import { COLOR_MAP, LEVEL_COLOR } from 'common/colors';
 import { COLORS } from 'common';
@@ -132,7 +133,7 @@ export const Row = styled(TableRow)<{
   isCurrentCounty?: Boolean;
 }>`
   background-color: ${({ index }) =>
-    !index ? 'white' : index && index % 2 ? 'white' : '#fafafa'};
+    !isNumber(index) ? 'white' : index % 2 === 0 ? 'white' : '#fafafa'};
   background-color: ${({ isCurrentCounty }) => isCurrentCounty && '#FFEFD6'};
   border-bottom: none;
 

--- a/src/components/Compare/LocationTable.style.tsx
+++ b/src/components/Compare/LocationTable.style.tsx
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 import { TableHead } from '@material-ui/core';
 import { Cell } from './Compare.style';
+import { COLORS } from 'common';
 
 export const ModalContainer = styled.div`
   display: flex;
@@ -24,6 +25,10 @@ export const ScrollContainer = styled.div`
   overflow: scroll;
 `;
 
+export const TableContainer = styled.div<{ isModal: boolean }>`
+  border: ${({ isModal }) => !isModal && `1px solid ${COLORS.LIGHTGRAY}`};
+`;
+
 export const TableHeadContainer = styled(TableHead)<{ isModal: boolean }>`
   ${Cell} {
     vertical-align: bottom;
@@ -31,10 +36,12 @@ export const TableHeadContainer = styled(TableHead)<{ isModal: boolean }>`
     padding: 1rem 1rem 0.8rem;
     background-color: ${({ isModal }) => isModal && 'black'};
     color: ${({ isModal }) => isModal && 'white'};
-    border-bottom: ${({ isModal }) => !isModal && '2px solid #f2f2f2'};
+    border-bottom: ${({ isModal }) =>
+      !isModal && `2px solid ${COLORS.LIGHTGRAY}`};
 
     &:nth-child(2) {
-      border-left: ${({ isModal }) => !isModal && '2px solid #f2f2f2'};
+      border-left: ${({ isModal }) =>
+        !isModal && `2px solid ${COLORS.LIGHTGRAY}`};
     }
   }
 `;

--- a/src/components/Compare/LocationTable.style.tsx
+++ b/src/components/Compare/LocationTable.style.tsx
@@ -2,19 +2,23 @@ import styled from 'styled-components';
 import { TableHead } from '@material-ui/core';
 import { Cell } from './Compare.style';
 
-export const Container = styled.div`
+export const ModalContainer = styled.div`
   display: flex;
   flex-direction: column;
   height: 400px;
 `;
 
-export const Header = styled.div`
+export const ModalBody = styled.div`
+  flex: 1 0 auto;
+`;
+
+export const Container = styled.div``;
+
+export const Head = styled.div`
   flex: 0 0 auto;
 `;
 
-export const Body = styled.div`
-  flex: 1 0 auto;
-`;
+export const Body = styled.div``;
 
 export const ScrollContainer = styled.div`
   overflow: scroll;

--- a/src/components/Compare/LocationTable.tsx
+++ b/src/components/Compare/LocationTable.tsx
@@ -136,31 +136,33 @@ const LocationTable: React.FunctionComponent<{
   const BodyTable = isModal ? LocationTableBodyScroll : LocationTableBody;
 
   return (
-    <Container>
-      <Styles.Head>
-        <LocationTableHead
-          setSorter={setSorter}
-          setSortDescending={setSortDescending}
-          sortDescending={sortDescending}
-          sorter={sorter}
-          arrowColorSelected={arrowColorSelected}
-          arrowColorNotSelected={arrowColorNotSelected}
-          firstHeaderName={firstHeaderName}
-          metrics={metrics}
-          isModal={isModal}
-        />
-        {pinnedLocation && isNumber(pinnedLocationRank) && (
-          <PinnedRow
-            location={pinnedLocation}
-            locationRank={pinnedLocationRank}
+    <Styles.TableContainer isModal={isModal}>
+      <Container>
+        <Styles.Head>
+          <LocationTableHead
+            setSorter={setSorter}
+            setSortDescending={setSortDescending}
+            sortDescending={sortDescending}
             sorter={sorter}
+            arrowColorSelected={arrowColorSelected}
+            arrowColorNotSelected={arrowColorNotSelected}
+            firstHeaderName={firstHeaderName}
+            metrics={metrics}
+            isModal={isModal}
           />
-        )}
-      </Styles.Head>
-      <Body>
-        <BodyTable sorter={sorter} sortedLocations={sortedLocations} />
-      </Body>
-    </Container>
+          {pinnedLocation && isNumber(pinnedLocationRank) && (
+            <PinnedRow
+              location={pinnedLocation}
+              locationRank={pinnedLocationRank}
+              sorter={sorter}
+            />
+          )}
+        </Styles.Head>
+        <Body>
+          <BodyTable sorter={sorter} sortedLocations={sortedLocations} />
+        </Body>
+      </Container>
+    </Styles.TableContainer>
   );
 };
 

--- a/src/components/Compare/LocationTable.tsx
+++ b/src/components/Compare/LocationTable.tsx
@@ -71,25 +71,39 @@ const LocationTableBody: React.FunctionComponent<{
   sortedLocations: any[];
   sorter: any;
 }> = ({ sortedLocations, sorter }) => (
+  <Table>
+    <TableBody>
+      {sortedLocations.map((location, rank) => (
+        <CompareTableRow sorter={sorter} location={location} index={rank} />
+      ))}
+    </TableBody>
+  </Table>
+);
+
+const LocationTableBodyScroll: React.FunctionComponent<{
+  sortedLocations: any[];
+  sorter: any;
+}> = ({ sortedLocations, sorter }) => (
   <ParentSize>
     {({ height }) => (
       <Styles.ScrollContainer style={{ height }}>
-        <Table>
-          <TableBody>
-            {sortedLocations.map((location, rank) => (
-              <CompareTableRow
-                sorter={sorter}
-                location={location}
-                index={rank}
-              />
-            ))}
-          </TableBody>
-        </Table>
+        <LocationTableBody sortedLocations={sortedLocations} sorter={sorter} />
       </Styles.ScrollContainer>
     )}
   </ParentSize>
 );
 
+/**
+ * NOTE (pablo): Material UI tables have some limitations regarding some
+ * behaviours we need. In particular, we can't have more than one element
+ * pinned to the top, which is what we need to pin the current location
+ * in the top row.
+ *
+ * This implementation is a hack and uses 3 tables. This can create some
+ * accessibility issues (screen readers might have trouble reading the
+ * table as a single unit). We might want to explore some other solutions
+ * (maybe other libraries) at some point.
+ */
 const LocationTable: React.FunctionComponent<{
   setSorter: any;
   setSortDescending: any;
@@ -116,32 +130,38 @@ const LocationTable: React.FunctionComponent<{
   pinnedLocation,
   pinnedLocationRank,
   sortedLocations,
-}) => (
-  <Styles.Container>
-    <Styles.Header>
-      <LocationTableHead
-        setSorter={setSorter}
-        setSortDescending={setSortDescending}
-        sortDescending={sortDescending}
-        sorter={sorter}
-        arrowColorSelected={arrowColorSelected}
-        arrowColorNotSelected={arrowColorNotSelected}
-        firstHeaderName={firstHeaderName}
-        metrics={metrics}
-        isModal={isModal}
-      />
-      {pinnedLocation && isNumber(pinnedLocationRank) && (
-        <PinnedRow
-          location={pinnedLocation}
-          locationRank={pinnedLocationRank}
+}) => {
+  const Container = isModal ? Styles.ModalContainer : Styles.Container;
+  const Body = isModal ? Styles.ModalBody : Styles.Body;
+  const BodyTable = isModal ? LocationTableBodyScroll : LocationTableBody;
+
+  return (
+    <Container>
+      <Styles.Head>
+        <LocationTableHead
+          setSorter={setSorter}
+          setSortDescending={setSortDescending}
+          sortDescending={sortDescending}
           sorter={sorter}
+          arrowColorSelected={arrowColorSelected}
+          arrowColorNotSelected={arrowColorNotSelected}
+          firstHeaderName={firstHeaderName}
+          metrics={metrics}
+          isModal={isModal}
         />
-      )}
-    </Styles.Header>
-    <Styles.Body>
-      <LocationTableBody sorter={sorter} sortedLocations={sortedLocations} />
-    </Styles.Body>
-  </Styles.Container>
-);
+        {pinnedLocation && isNumber(pinnedLocationRank) && (
+          <PinnedRow
+            location={pinnedLocation}
+            locationRank={pinnedLocationRank}
+            sorter={sorter}
+          />
+        )}
+      </Styles.Head>
+      <Body>
+        <BodyTable sorter={sorter} sortedLocations={sortedLocations} />
+      </Body>
+    </Container>
+  );
+};
 
 export default LocationTable;


### PR DESCRIPTION
- [x] fixes the layout on the inline mode (no scrolling, shows all the locations passed)
- [x] Table border in inline mode
- [x] fixes a bug that was causing the first two rows to have white background instead of alternating