### PR TITLE
compare: small typing fixes

### DIFF
--- a/src/common/utils/compare.ts
+++ b/src/common/utils/compare.ts
@@ -9,7 +9,7 @@ export interface SummaryForCompare {
 
 const locations: any = getLocationNames();
 
-export function getStatesArr() {
+export function getStatesArr(): SummaryForCompare[] {
   return locations
     .filter((location: Location) => !location.county)
     .map((stateInfo: Location) => {
@@ -20,7 +20,7 @@ export function getStatesArr() {
     });
 }
 
-export function getCountiesArr(stateId: string) {
+export function getCountiesArr(stateId: string): SummaryForCompare[] {
   return locations
     .filter(
       (location: Location) =>

--- a/src/components/Compare/LocationTable.tsx
+++ b/src/components/Compare/LocationTable.tsx
@@ -1,20 +1,22 @@
 import React from 'react';
 import { isNumber } from 'lodash';
 import { Table, TableBody } from '@material-ui/core';
-import * as Styles from './LocationTable.style';
+import { Metric } from 'common/metric';
+import { SummaryForCompare } from 'common/utils/compare';
+import CompareTableRow from './CompareTableRow';
 import HeaderCell from './HeaderCell';
+import * as Styles from './LocationTable.style';
 import * as CompareStyles from './Compare.style';
-import CompareTableRow from 'components/Compare/CompareTableRow';
 
 const LocationTableHead: React.FunctionComponent<{
-  setSorter: any;
-  setSortDescending: any;
-  sortDescending: any;
-  sorter: any;
+  setSorter: React.Dispatch<React.SetStateAction<number>>;
+  setSortDescending: React.Dispatch<React.SetStateAction<boolean>>;
+  sortDescending: boolean;
+  sorter: number;
   arrowColorSelected: string;
   arrowColorNotSelected: string;
   firstHeaderName: string;
-  metrics: any[];
+  metrics: Metric[];
   isModal: boolean;
 }> = ({
   setSorter,
@@ -51,8 +53,8 @@ const LocationTableHead: React.FunctionComponent<{
 );
 
 const PinnedRow: React.FunctionComponent<{
-  location: any;
-  sorter: any;
+  location: SummaryForCompare;
+  sorter: number;
   locationRank: number;
 }> = ({ location, sorter, locationRank }) => (
   <Table key="table-pinned-location">
@@ -69,7 +71,7 @@ const PinnedRow: React.FunctionComponent<{
 
 const LocationTableBody: React.FunctionComponent<{
   sortedLocations: any[];
-  sorter: any;
+  sorter: number;
 }> = ({ sortedLocations, sorter }) => (
   <Table>
     <TableBody>
@@ -92,18 +94,18 @@ const LocationTableBody: React.FunctionComponent<{
  * (maybe other libraries) at some point.
  */
 const LocationTable: React.FunctionComponent<{
-  setSorter: any;
-  setSortDescending: any;
-  sortDescending: any;
-  sorter: any;
+  setSorter: React.Dispatch<React.SetStateAction<number>>;
+  setSortDescending: React.Dispatch<React.SetStateAction<boolean>>;
+  sortDescending: boolean;
+  sorter: number;
   arrowColorSelected: string;
   arrowColorNotSelected: string;
   firstHeaderName: string;
-  metrics: any[];
+  metrics: Metric[];
   isModal: boolean;
-  pinnedLocation?: any;
+  pinnedLocation?: SummaryForCompare;
   pinnedLocationRank?: number;
-  sortedLocations: any[];
+  sortedLocations: SummaryForCompare[];
 }> = ({
   setSorter,
   setSortDescending,

--- a/src/components/LocationPage/ChartsHolder.tsx
+++ b/src/components/LocationPage/ChartsHolder.tsx
@@ -150,7 +150,7 @@ const ChartsHolder = (props: {
     : [];
 
   const locationsForCompare = getCountiesArr(props.stateId);
-  const currentCountyForCompare: any = props.county && {
+  const currentCountyForCompare = props.county && {
     locationInfo: props.county,
     metricsInfo: countySummary(props.county.full_fips_code),
   };


### PR DESCRIPTION
This PR fixes a couple of `any` I left when fixing the scroll behavior and pinned location on the compare table. It doesn't fix everything, but it's a bit better than before.