### PR TITLE
show current location in ranked position

### DIFF
--- a/src/common/utils/compare.ts
+++ b/src/common/utils/compare.ts
@@ -6,6 +6,9 @@ export interface SummaryForCompare {
   locationInfo: Location;
   metricsInfo: LocationSummary;
 }
+export interface RankedLocationSummary extends SummaryForCompare {
+  rank: number;
+}
 
 const locations: any = getLocationNames();
 

--- a/src/components/Compare/Compare.style.tsx
+++ b/src/components/Compare/Compare.style.tsx
@@ -148,7 +148,7 @@ export const MetricCell = styled.td<{
 
 export const Row = styled(TableRow)<{
   index?: number;
-  isCurrentCounty?: Boolean;
+  isCurrentCounty?: boolean;
 }>`
   background-color: ${({ index }) =>
     !isNumber(index) ? 'white' : index % 2 === 0 ? '#fafafa' : 'white'};

--- a/src/components/Compare/Compare.style.tsx
+++ b/src/components/Compare/Compare.style.tsx
@@ -159,11 +159,6 @@ export const Row = styled(TableRow)<{
     border-bottom: none;
   }
 
-  ${MetricCell} {
-    border-bottom: ${({ isCurrentCounty }) =>
-      isCurrentCounty && '2px solid #CEBFAC'};
-  }
-
   &:hover {
     color: ${COLOR_MAP.BLUE};
   }

--- a/src/components/Compare/CompareTable.tsx
+++ b/src/components/Compare/CompareTable.tsx
@@ -96,9 +96,9 @@ const CompareTable = (props: {
 
   const firstHeaderName = props.isHomepage ? 'State' : 'County';
 
-  const sortedLocations = sortedLocationsArr
-    .slice(0, locationsViewable)
-    .filter(location => location.metricsInfo !== null);
+  const sortedLocations: SummaryForCompare[] = sortedLocationsArr.filter(
+    location => location.metricsInfo !== null,
+  );
 
   return (
     <Wrapper isModal={props.isModal} isHomepage={props.isHomepage}>
@@ -113,6 +113,7 @@ const CompareTable = (props: {
         pinnedLocation={props.county ? currentCounty : null}
         pinnedLocationRank={currentCountyRank}
         sortedLocations={sortedLocations}
+        numLocations={locationsViewable}
       />
       {!props.isModal && (
         <Fragment>

--- a/src/components/Compare/CompareTable.tsx
+++ b/src/components/Compare/CompareTable.tsx
@@ -14,7 +14,7 @@ import {
 import { Metric } from 'common/metric';
 import { COLOR_MAP } from 'common/colors';
 import LocationTable from './LocationTable';
-import { SummaryForCompare } from 'common/utils/compare';
+import { SummaryForCompare, RankedLocationSummary } from 'common/utils/compare';
 
 const CompareTable = (props: {
   stateName?: string;
@@ -96,9 +96,13 @@ const CompareTable = (props: {
 
   const firstHeaderName = props.isHomepage ? 'State' : 'County';
 
-  const sortedLocations: SummaryForCompare[] = sortedLocationsArr.filter(
-    location => location.metricsInfo !== null,
-  );
+  const sortedLocations: RankedLocationSummary[] = sortedLocationsArr
+    .filter(location => location.metricsInfo !== null)
+    .map((summary, i) => ({ rank: i + 1, ...summary }));
+
+  const currentLocation = props.county
+    ? { rank: currentCountyRank + 1, ...currentCounty }
+    : null;
 
   return (
     <Wrapper isModal={props.isModal} isHomepage={props.isHomepage}>
@@ -110,8 +114,7 @@ const CompareTable = (props: {
         metrics={orderedMetrics}
         isModal={props.isModal}
         {...arrowContainerProps}
-        pinnedLocation={props.county ? currentCounty : null}
-        pinnedLocationRank={currentCountyRank}
+        pinnedLocation={currentLocation}
         sortedLocations={sortedLocations}
         numLocations={locationsViewable}
       />

--- a/src/components/Compare/CompareTableRow.tsx
+++ b/src/components/Compare/CompareTableRow.tsx
@@ -3,7 +3,7 @@ import { useHistory } from 'react-router-dom';
 import FiberManualRecordIcon from '@material-ui/icons/FiberManualRecord';
 import { MetricCell, Row } from 'components/Compare/Compare.style';
 import { Metric, formatValue } from 'common/metric';
-import { SummaryForCompare } from 'common/utils/compare';
+import { RankedLocationSummary } from 'common/utils/compare';
 import { Level } from 'common/level';
 
 function cellValue(metric: any, metricType: Metric) {
@@ -14,12 +14,11 @@ function cellValue(metric: any, metricType: Metric) {
 }
 
 const CompareTableRow = (props: {
-  location: SummaryForCompare;
-  index: number;
-  sorter: any;
+  location: RankedLocationSummary;
+  sorter: number;
   isCurrentCounty?: boolean;
 }) => {
-  const { location, index, sorter, isCurrentCounty } = props;
+  const { location, sorter, isCurrentCounty } = props;
 
   //TODO(Chelsi): fix the else?
   function getLevel(metricIndex: Metric): Level {
@@ -60,12 +59,12 @@ const CompareTableRow = (props: {
 
   return (
     <Row
-      index={index}
+      index={location.rank}
       isCurrentCounty={isCurrentCounty}
       onClick={handleLocationClick}
     >
       <MetricCell iconColor={location.metricsInfo.level}>
-        <span>{index + 1}</span>
+        <span>{location.rank}</span>
         <FiberManualRecordIcon />
         {locationName}
       </MetricCell>

--- a/src/components/Compare/LocationTable.style.tsx
+++ b/src/components/Compare/LocationTable.style.tsx
@@ -4,6 +4,7 @@ import { Cell, locationNameCellWidth, metricCellWidth } from './Compare.style';
 import { COLORS } from 'common';
 
 const minTableWidth = locationNameCellWidth + 5 * metricCellWidth;
+const pinnedBorderColor = '#CEBFAC';
 
 export const ModalContainer = styled.div`
   display: flex;
@@ -30,10 +31,18 @@ export const Container = styled.div`
   overflow-x: auto;
 `;
 
-export const Head = styled.div`
+const PinnedTop = `
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.12);
+  z-index: 0;
+  position: relative;
+  border-bottom: 1px solid ${pinnedBorderColor};
+`;
+
+export const Head = styled.div<{ isModal: boolean }>`
   flex: 0 0 auto;
   min-height: 0;
   min-width: ${minTableWidth}px;
+  ${props => (props.isModal ? PinnedTop : '')}
 `;
 
 export const TableContainer = styled.div<{ isModal: boolean }>`

--- a/src/components/Compare/LocationTable.tsx
+++ b/src/components/Compare/LocationTable.tsx
@@ -1,17 +1,11 @@
 import React from 'react';
-import { isNumber } from 'lodash';
 import { Table, TableBody } from '@material-ui/core';
 import { Metric } from 'common/metric';
-import { SummaryForCompare } from 'common/utils/compare';
+import { RankedLocationSummary } from 'common/utils/compare';
 import CompareTableRow from './CompareTableRow';
 import HeaderCell from './HeaderCell';
 import * as Styles from './LocationTable.style';
 import * as CompareStyles from './Compare.style';
-
-interface RankedLocation {
-  rank: number;
-  location: SummaryForCompare;
-}
 
 const LocationTableHead: React.FunctionComponent<{
   setSorter: React.Dispatch<React.SetStateAction<number>>;
@@ -58,35 +52,29 @@ const LocationTableHead: React.FunctionComponent<{
 );
 
 const PinnedRow: React.FunctionComponent<{
-  location: SummaryForCompare;
+  location: RankedLocationSummary;
   sorter: number;
-  locationRank: number;
-}> = ({ location, sorter, locationRank }) => (
+}> = ({ location, sorter }) => (
   <Table key="table-pinned-location">
     <TableBody>
-      <CompareTableRow
-        isCurrentCounty
-        location={location}
-        sorter={sorter}
-        index={locationRank}
-      />
+      <CompareTableRow location={location} sorter={sorter} isCurrentCounty />
     </TableBody>
   </Table>
 );
 
 const LocationTableBody: React.FunctionComponent<{
-  sortedLocations: RankedLocation[];
+  sortedLocations: RankedLocationSummary[];
   sorter: number;
   currentLocationRank?: number;
 }> = ({ sortedLocations, sorter, currentLocationRank }) => (
   <Table>
+    {console.log(sortedLocations, currentLocationRank)}
     <TableBody>
-      {sortedLocations.map(rankedLocation => (
+      {sortedLocations.map(location => (
         <CompareTableRow
           sorter={sorter}
-          location={rankedLocation.location}
-          index={rankedLocation.rank}
-          isCurrentCounty={rankedLocation.rank === currentLocationRank}
+          location={location}
+          isCurrentCounty={location.rank === currentLocationRank}
         />
       ))}
     </TableBody>
@@ -114,9 +102,8 @@ const LocationTable: React.FunctionComponent<{
   firstHeaderName: string;
   metrics: Metric[];
   isModal: boolean;
-  pinnedLocation?: SummaryForCompare;
-  pinnedLocationRank?: number;
-  sortedLocations: SummaryForCompare[];
+  pinnedLocation?: RankedLocationSummary;
+  sortedLocations: RankedLocationSummary[];
   numLocations: number;
 }> = ({
   setSorter,
@@ -129,30 +116,18 @@ const LocationTable: React.FunctionComponent<{
   metrics,
   isModal,
   pinnedLocation,
-  pinnedLocationRank,
   sortedLocations,
   numLocations,
 }) => {
   const Container = isModal ? Styles.ModalContainer : Styles.Container;
 
-  // TODO (pablo): Pass the rank from the component above
-  const rankedLocations: RankedLocation[] = sortedLocations.map(
-    (location, rank) => ({ rank, location }),
-  );
-
-  const showBottom =
-    pinnedLocation && pinnedLocationRank && pinnedLocationRank >= numLocations;
+  const showBottom = pinnedLocation && pinnedLocation.rank >= numLocations;
 
   const numLocationsMain = showBottom ? numLocations - 1 : numLocations;
 
-  const visibleLocations: RankedLocation[] = isModal
-    ? rankedLocations
-    : rankedLocations.slice(0, numLocationsMain);
-
-  const currentLocation =
-    pinnedLocation && pinnedLocationRank
-      ? { rank: pinnedLocationRank, location: pinnedLocation }
-      : null;
+  const visibleLocations = isModal
+    ? sortedLocations
+    : sortedLocations.slice(0, numLocationsMain);
 
   return (
     <Styles.TableContainer isModal={isModal}>
@@ -169,27 +144,23 @@ const LocationTable: React.FunctionComponent<{
             metrics={metrics}
             isModal={isModal}
           />
-          {isModal && pinnedLocation && isNumber(pinnedLocationRank) && (
-            <PinnedRow
-              location={pinnedLocation}
-              locationRank={pinnedLocationRank}
-              sorter={sorter}
-            />
+          {isModal && pinnedLocation && (
+            <PinnedRow location={pinnedLocation} sorter={sorter} />
           )}
         </Styles.Head>
         <Styles.Body>
           <LocationTableBody
             sorter={sorter}
             sortedLocations={visibleLocations}
-            currentLocationRank={pinnedLocationRank}
+            currentLocationRank={pinnedLocation?.rank}
           />
         </Styles.Body>
-        {currentLocation && showBottom && (
+        {pinnedLocation && showBottom && (
           <Styles.Body>
             <LocationTableBody
               sorter={sorter}
-              sortedLocations={[currentLocation]}
-              currentLocationRank={currentLocation.rank}
+              sortedLocations={[pinnedLocation]}
+              currentLocationRank={pinnedLocation?.rank}
             />
           </Styles.Body>
         )}

--- a/src/components/Compare/LocationTable.tsx
+++ b/src/components/Compare/LocationTable.tsx
@@ -68,7 +68,6 @@ const LocationTableBody: React.FunctionComponent<{
   currentLocationRank?: number;
 }> = ({ sortedLocations, sorter, currentLocationRank }) => (
   <Table>
-    {console.log(sortedLocations, currentLocationRank)}
     <TableBody>
       {sortedLocations.map(location => (
         <CompareTableRow
@@ -132,7 +131,7 @@ const LocationTable: React.FunctionComponent<{
   return (
     <Styles.TableContainer isModal={isModal}>
       <Container>
-        <Styles.Head>
+        <Styles.Head isModal={isModal}>
           <LocationTableHead
             setSorter={setSorter}
             setSortDescending={setSortDescending}


### PR DESCRIPTION
This PR updates the compare table to make sure that the row for the current location (for counties) always shows in the inline version of the table in a position relative to its ranking. 

**Top**
The Karnes County is at the top given the current sorting of the table, so it shows at the top.
![image](https://user-images.githubusercontent.com/114084/89818971-84568600-daff-11ea-9e38-d4063c732d3a.png)

**Middle**
Cameron County is in the first 6 locations, so it shows in the corresponding location.
![image](https://user-images.githubusercontent.com/114084/89818942-77399700-daff-11ea-8781-296a98ce1e19.png)

**Bottom**
Jim Wells County should be below the fold, so it shows at the end with its corresponding ranking.
![image](https://user-images.githubusercontent.com/114084/89818914-69841180-daff-11ea-90ca-9a699dce068d.png)
