### PR TITLE
 add disclaimer to metric definition

### DIFF
--- a/src/common/metric.tsx
+++ b/src/common/metric.tsx
@@ -93,18 +93,6 @@ export function getLevel(metric: Metric, value: number | null): Level {
   return Level.UNKNOWN;
 }
 
-const METRIC_TO_DISCLAIMER: { [metricName: number]: string } = {
-  [Metric.CASE_GROWTH_RATE]: CaseGrowth.CASE_GROWTH_DISCLAIMER,
-  [Metric.POSITIVE_TESTS]: TestRates.POSITIVE_RATE_DISCLAIMER,
-  [Metric.HOSPITAL_USAGE]: Hospitalizations.HOSPITALIZATIONS_DISCLAIMER,
-  [Metric.CONTACT_TRACING]: ContactTracing.CONTACT_TRACING_DISCLAIMER,
-  [Metric.CASE_DENSITY]: CaseDensity.CASE_DENSITY_DISCLAIMER,
-};
-
-export function getMetricDisclaimer(metric: Metric) {
-  return METRIC_TO_DISCLAIMER[metric];
-}
-
 const metricDefinitions: { [metric in Metric]: MetricDefinition } = {
   [Metric.CASE_GROWTH_RATE]: CaseGrowth.CaseGrowthMetric,
   [Metric.POSITIVE_TESTS]: TestRates.PositiveTestRateMetric,
@@ -114,12 +102,20 @@ const metricDefinitions: { [metric in Metric]: MetricDefinition } = {
   [Metric.CASE_DENSITY]: CaseDensity.CaseIncidenceMetric,
 };
 
-export function getMetricStatusText(metric: Metric, projections: Projections) {
+function getMetricDefinition(metric: Metric) {
   if (!(metric in metricDefinitions)) {
     fail('unknown metric');
   }
+  return metricDefinitions[metric];
+}
 
-  const metricDefinition = metricDefinitions[metric];
+export function getMetricDisclaimer(metric: Metric) {
+  const metricDefinition = getMetricDefinition(metric);
+  return metricDefinition.renderDisclaimer();
+}
+
+export function getMetricStatusText(metric: Metric, projections: Projections) {
+  const metricDefinition = getMetricDefinition(metric);
   return metricDefinition.renderStatus(projections);
 }
 

--- a/src/common/metrics/case_density.tsx
+++ b/src/common/metrics/case_density.tsx
@@ -13,6 +13,7 @@ import { MetricDefinition } from './interfaces';
 
 export const CaseIncidenceMetric: MetricDefinition = {
   renderStatus,
+  renderDisclaimer,
 };
 
 export const METRIC_NAME = 'Daily new cases per 100k population';
@@ -100,6 +101,34 @@ export function renderStatus(projections: Projections): React.ReactElement {
       {formatEstimate(estimatedNewInfectionsPerYear)} infections (
       {formatPercent(estimatedPercentageNewInfectedPerYear, 1)} of the
       population).
+    </Fragment>
+  );
+}
+
+function renderDisclaimer(): React.ReactElement {
+  return (
+    <Fragment>
+      Our risk levels for daily new cases are based on the{' '}
+      <ExternalLink href="https://ethics.harvard.edu/files/center-for-ethics/files/key_metrics_and_indicators_v4.pdf">
+        “Key Metrics for Covid Suppression”
+      </ExternalLink>{' '}
+      by Harvard Global Health Institute and others.
+      <br />
+      When estimating the number of people who will become infected in the
+      course of a year, we rely on the{' '}
+      <ExternalLink href="https://www.globalhealthnow.org/2020-06/us-cases-10x-higher-reported">
+        CDC’s estimate
+      </ExternalLink>{' '}
+      that confirmed cases represent as few as 10% of overall infections. Learn
+      more about{' '}
+      <ExternalLink href="https://docs.google.com/document/d/1cd_cEpNiIl1TzUJBvw9sHLbrbUZ2qCxgN32IqVLa3Do/edit">
+        our methodology
+      </ExternalLink>{' '}
+      and{' '}
+      <ExternalLink href="https://docs.google.com/presentation/d/1XmKCBWYZr9VQKFAdWh_D7pkpGGM_oR9cPjj-UrNdMJQ/edit">
+        our data sources
+      </ExternalLink>
+      .
     </Fragment>
   );
 }

--- a/src/common/metrics/case_growth.tsx
+++ b/src/common/metrics/case_growth.tsx
@@ -6,9 +6,11 @@ import { levelText } from 'common/utils/chart';
 import { formatDecimal } from 'common/utils';
 import { Projections } from 'common/models/Projections';
 import { MetricDefinition } from './interfaces';
+import ExternalLink from 'components/ExternalLink';
 
 export const CaseGrowthMetric: MetricDefinition = {
   renderStatus,
+  renderDisclaimer,
 };
 
 export const METRIC_NAME = 'Infection rate';
@@ -95,6 +97,24 @@ export function renderStatus(projections: Projections): React.ReactElement {
     <Fragment>
       On average, each person in {locationName} with COVID is infecting{' '}
       {formatDecimal(rt)} other people. {epidemiologyReasoning}
+    </Fragment>
+  );
+}
+
+function renderDisclaimer(): React.ReactElement {
+  return (
+    <Fragment>
+      Each data point is a 14-day weighted average. We present the most recent
+      seven days of data as a dashed line, as data is often revised by states
+      several days after reporting. Learn more about{' '}
+      <ExternalLink href="https://docs.google.com/document/d/1cd_cEpNiIl1TzUJBvw9sHLbrbUZ2qCxgN32IqVLa3Do/edit">
+        our methodology
+      </ExternalLink>{' '}
+      and{' '}
+      <ExternalLink href="https://docs.google.com/presentation/d/1XmKCBWYZr9VQKFAdWh_D7pkpGGM_oR9cPjj-UrNdMJQ/edit">
+        our data sources
+      </ExternalLink>
+      .
     </Fragment>
   );
 }

--- a/src/common/metrics/contact_tracing.tsx
+++ b/src/common/metrics/contact_tracing.tsx
@@ -7,9 +7,11 @@ import { formatPercent, formatInteger } from 'common/utils';
 import { Projections } from 'common/models/Projections';
 import { TRACERS_NEEDED_PER_CASE } from 'common/models/Projection';
 import { MetricDefinition } from './interfaces';
+import ExternalLink from 'components/ExternalLink';
 
 export const ContactTracingMetric: MetricDefinition = {
   renderStatus,
+  renderDisclaimer,
 };
 
 export const METRIC_NAME = 'Contacts traced';
@@ -120,6 +122,32 @@ export function renderStatus(projections: Projections): React.ReactElement {
       new cases in 48 hours, before too many other people are infected. This
       means that {locationName} is likely able to trace {contactTracingRate} of
       new COVID infections in 48 hours. {outcomesAtLevel}
+    </Fragment>
+  );
+}
+
+function renderDisclaimer(): React.ReactElement {
+  return (
+    <Fragment>
+      <ExternalLink href="https://covidlocal.org/assets/documents/COVID%20Local%20Metrics%20overview.pdf">
+        Experts recommend
+      </ExternalLink>{' '}
+      that at least 90% of contacts for each new case must be traced within 48
+      hours in order to contain COVID. Experts estimate that tracing each new
+      case within 48 hours requires an average of {TRACERS_NEEDED_PER_CASE}{' '}
+      contact tracers per new case, as well as fast testing. Learn more about{' '}
+      <ExternalLink href="https://docs.google.com/document/d/1cd_cEpNiIl1TzUJBvw9sHLbrbUZ2qCxgN32IqVLa3Do/edit">
+        our methodology
+      </ExternalLink>{' '}
+      and{' '}
+      <ExternalLink href="https://docs.google.com/presentation/d/1XmKCBWYZr9VQKFAdWh_D7pkpGGM_oR9cPjj-UrNdMJQ/edit">
+        our data sources
+      </ExternalLink>{' '}
+      (for contact tracing data, we partner with{' '}
+      <ExternalLink href="https://testandtrace.com/">
+        testandtrace.com
+      </ExternalLink>
+      ).
     </Fragment>
   );
 }

--- a/src/common/metrics/future_projection.tsx
+++ b/src/common/metrics/future_projection.tsx
@@ -6,6 +6,7 @@ import { MetricDefinition } from './interfaces';
 
 export const FutureProjectionsMetric: MetricDefinition = {
   renderStatus,
+  renderDisclaimer,
 };
 
 export const METRIC_NAME = 'Future hospitalization projections';
@@ -46,4 +47,8 @@ export function renderStatus(projections: Projections) {
       </Fragment>
     );
   }
+}
+
+function renderDisclaimer(): React.ReactElement {
+  return <Fragment></Fragment>;
 }

--- a/src/common/metrics/hospitalizations.tsx
+++ b/src/common/metrics/hospitalizations.tsx
@@ -7,9 +7,11 @@ import { formatPercent, formatInteger } from 'common/utils';
 import { Projections } from 'common/models/Projections';
 import { NonCovidPatientsMethod } from 'common/models/ICUHeadroom';
 import { MetricDefinition } from './interfaces';
+import ExternalLink from '../../components/ExternalLink';
 
 export const ICUHeadroomMetric: MetricDefinition = {
   renderStatus,
+  renderDisclaimer,
 };
 
 export const METRIC_NAME = 'ICU headroom used';
@@ -127,6 +129,27 @@ export function renderStatus(projections: Projections): React.ReactElement {
       non-COVID patients. Of the {remainingICUBeds} ICU beds remaining,{' '}
       {textWeEstimate} {covidICUPatients} are needed by COVID cases, or{' '}
       {icuHeadroom} of available beds. {textLevel}.
+    </Fragment>
+  );
+}
+
+function renderDisclaimer(): React.ReactElement {
+  return (
+    <Fragment>
+      <ExternalLink href="https://preventepidemics.org/wp-content/uploads/2020/04/COV020_WhenHowTightenFaucet_v3.pdf">
+        Resolve to Save Lives
+      </ExternalLink>
+      , a pandemic think tank, recommends that hospitals maintain enough ICU
+      capacity to double the number of COVID patients hospitalized. Learn more
+      about{' '}
+      <ExternalLink href="https://docs.google.com/document/d/1cd_cEpNiIl1TzUJBvw9sHLbrbUZ2qCxgN32IqVLa3Do/edit">
+        our methodology
+      </ExternalLink>{' '}
+      and{' '}
+      <ExternalLink href="https://docs.google.com/presentation/d/1XmKCBWYZr9VQKFAdWh_D7pkpGGM_oR9cPjj-UrNdMJQ/edit">
+        our data sources
+      </ExternalLink>
+      .
     </Fragment>
   );
 }

--- a/src/common/metrics/interfaces.ts
+++ b/src/common/metrics/interfaces.ts
@@ -3,4 +3,5 @@ import { Projections } from 'common/models/Projections';
 
 export interface MetricDefinition {
   renderStatus: (projections: Projections) => React.ReactElement;
+  renderDisclaimer: () => React.ReactElement;
 }

--- a/src/common/metrics/positive_rate.tsx
+++ b/src/common/metrics/positive_rate.tsx
@@ -6,9 +6,11 @@ import { getLevel, Metric } from 'common/metric';
 import { formatPercent } from 'common/utils';
 import { Projections } from 'common/models/Projections';
 import { MetricDefinition } from './interfaces';
+import ExternalLink from 'components/ExternalLink';
 
 export const PositiveTestRateMetric: MetricDefinition = {
   renderStatus,
+  renderDisclaimer,
 };
 
 export const METRIC_NAME = 'Positive test rate';
@@ -107,6 +109,24 @@ export function renderStatus(projections: Projections) {
     <Fragment>
       A {lowSizableLarge} percentage ({percentage}) of COVID tests were
       positive, {testingBroadlyText}. {textForecast}.
+    </Fragment>
+  );
+}
+
+function renderDisclaimer(): React.ReactElement {
+  return (
+    <Fragment>
+      The World Health Organization recommends a positive test rate of less than
+      10%. The countries most successful in containing COVID have rates of 3% or
+      less. We calculate the rate as a 7-day trailing average. Learn more about{' '}
+      <ExternalLink href="https://docs.google.com/document/d/1cd_cEpNiIl1TzUJBvw9sHLbrbUZ2qCxgN32IqVLa3Do/edit">
+        our methodology
+      </ExternalLink>{' '}
+      and{' '}
+      <ExternalLink href="https://docs.google.com/presentation/d/1XmKCBWYZr9VQKFAdWh_D7pkpGGM_oR9cPjj-UrNdMJQ/edit">
+        our data sources
+      </ExternalLink>
+      .
     </Fragment>
   );
 }

--- a/src/components/Disclaimer/Disclaimer.tsx
+++ b/src/components/Disclaimer/Disclaimer.tsx
@@ -1,9 +1,7 @@
-import React, { Fragment } from 'react';
-
+import React from 'react';
 import { DisclaimerWrapper, DisclaimerBody } from './Disclaimer.style';
 import LightTooltip from 'components/LightTooltip/LightTooltip';
 import { useModelLastUpdatedDate } from 'common/utils/model';
-import { Metric } from 'common/metric';
 import { getMetricDisclaimer } from 'common/metric';
 
 const Disclaimer = ({ metricName }: { metricName: number }) => {
@@ -19,84 +17,7 @@ const Disclaimer = ({ metricName }: { metricName: number }) => {
         >
           <span>Last updated {lastUpdatedDateString}.</span>
         </LightTooltip>{' '}
-        {metricName === Metric.CASE_DENSITY && (
-          <Fragment>
-            <span>
-              Our risk levels for daily new cases are based on the{' '}
-              <a
-                href="https://ethics.harvard.edu/files/center-for-ethics/files/key_metrics_and_indicators_v4.pdf"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                “Key Metrics for Covid Suppression”
-              </a>{' '}
-              by Harvard Global Health Institute and others.
-              <br />
-              When estimating the number of people who will become infected in
-              the course of a year, we rely on the{' '}
-              <a
-                href="https://www.globalhealthnow.org/2020-06/us-cases-10x-higher-reported"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                CDC’s estimate
-              </a>{' '}
-              that confirmed cases represent as few as 10% of overall
-              infections.
-            </span>
-          </Fragment>
-        )}
-        {metricName === Metric.CONTACT_TRACING && (
-          <Fragment>
-            <a
-              href="https://covidlocal.org/assets/documents/COVID%20Local%20Metrics%20overview.pdf"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Experts recommend
-            </a>{' '}
-          </Fragment>
-        )}
-        {metricName === Metric.HOSPITAL_USAGE && (
-          <a
-            href="https://preventepidemics.org/wp-content/uploads/2020/04/COV020_WhenHowTightenFaucet_v3.pdf"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Resolve to Save Lives
-          </a>
-        )}
-        {getMetricDisclaimer(metricName)} Learn more about{' '}
-        <a
-          href="https://docs.google.com/document/d/1cd_cEpNiIl1TzUJBvw9sHLbrbUZ2qCxgN32IqVLa3Do/edit"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          our methodology
-        </a>{' '}
-        and{' '}
-        <a
-          href="https://docs.google.com/presentation/d/1XmKCBWYZr9VQKFAdWh_D7pkpGGM_oR9cPjj-UrNdMJQ/edit"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          our data sources
-        </a>
-        {metricName === Metric.CONTACT_TRACING && (
-          <Fragment>
-            {' '}
-            (for contact tracing data, we partner with{' '}
-            <a
-              href="https://testandtrace.com/"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              testandtrace.com
-            </a>
-            )
-          </Fragment>
-        )}
-        .
+        {getMetricDisclaimer(metricName)}
       </DisclaimerBody>
     </DisclaimerWrapper>
   );


### PR DESCRIPTION
This PR adds `renderDisclaimer` to the `MetricDefinition` interface, and moves the copy accordingly.