### PR TITLE
rename the alert email groups for better tracking

### DIFF
--- a/scripts/alert_emails/utils.ts
+++ b/scripts/alert_emails/utils.ts
@@ -1,12 +1,19 @@
 import path from 'path';
 import fs from 'fs-extra';
+import moment from 'moment';
 import * as Handlebars from 'handlebars';
 import { Alert } from './interfaces';
 import { Level } from '../../src/common/level';
 
+export const ALERT_EMAIL_GROUP_PREFIX = 'Alert Email';
+
 const thermometerBaseURL =
   'https://data.covidactnow.org/thermometer_screenshot';
 const unsubscribeURL = 'https://covidactnow.org/alert_unsubscribe';
+
+export function toISO8601(date: Date): string {
+  return moment(date).format('YYYY-MM-DD');
+}
 
 const alertTemplate = Handlebars.compile(
   fs.readFileSync(path.join(__dirname, 'template.html'), 'utf8'),
@@ -83,7 +90,7 @@ export function generateAlertEmailData(
     TrackOpens: true,
     TrackClicks: true,
     InlineCSS: true,
-    Group: 'Alert Email',
+    Group: `${ALERT_EMAIL_GROUP_PREFIX} - ${toISO8601(new Date())}`,
     ConsentToTrack: 'Unchanged',
   };
 }


### PR DESCRIPTION
This PR creates a different group for each email alert send so we can have engagement stats for each send instead of having them grouped together.