### PR TITLE
explore: tab component

### DIFF
--- a/src/components/Explore/Explore.style.ts
+++ b/src/components/Explore/Explore.style.ts
@@ -1,0 +1,40 @@
+import styled from 'styled-components';
+import MuiTab from '@material-ui/core/Tab';
+import MuiTabs from '@material-ui/core/Tabs';
+import theme from 'assets/theme';
+
+// TODO(pablo): Get from theme
+const lightBlue = '#00BFEA';
+
+export const Container = styled.div`
+  /* TODO(pablo): Get from theme */
+  margin-bottom: 20px;
+`;
+
+export const Placeholder = styled.div`
+  margin: 4px;
+  padding: 4px;
+  background-color: #f2f2f2;
+`;
+
+export const Tabs = styled(MuiTabs)`
+  .MuiTabs-indicator {
+    /* TODO(pablo): Get from theme */
+    background-color: ${lightBlue};
+  }
+`;
+
+export const Tab = styled(MuiTab)`
+  /* TODO(pablo): Use Typography */
+  font-family: Roboto;
+  font-weight: normal;
+  font-size: 15px;
+  line-height: 18px;
+  text-transform: none;
+  color: ${theme.palette.text.secondary};
+
+  &.Mui-selected {
+    font-weight: 500;
+    color: ${theme.palette.text.primary};
+  }
+`;

--- a/src/components/Explore/Explore.tsx
+++ b/src/components/Explore/Explore.tsx
@@ -1,0 +1,33 @@
+import React, { useState, FunctionComponent } from 'react';
+import ExploreTabs from './ExploreTabs';
+import * as Styles from './Explore.style';
+
+// TODO(pablo): Create enums and unify with metrics
+const tabLabels = [
+  'Cases',
+  'Deaths',
+  'Hospitalizations',
+  'ICU Hospitalizations',
+];
+
+const Explore: React.FunctionComponent = () => {
+  const [tabIndex, setTabIndex] = useState(0);
+
+  const onChangeTab = (event: React.ChangeEvent<{}>, newTabIndex: number) => {
+    setTabIndex(newTabIndex);
+  };
+
+  return (
+    <Styles.Container>
+      <Styles.Placeholder>header</Styles.Placeholder>
+      <ExploreTabs
+        activeTabIndex={tabIndex}
+        labels={tabLabels}
+        onChangeTab={onChangeTab}
+      />
+      <Styles.Placeholder>{`chart ${tabLabels[tabIndex]}`}</Styles.Placeholder>
+    </Styles.Container>
+  );
+};
+
+export default Explore;

--- a/src/components/Explore/ExploreTabs.tsx
+++ b/src/components/Explore/ExploreTabs.tsx
@@ -1,0 +1,30 @@
+import React, { FunctionComponent } from 'react';
+// import { withStyles } from '@material-ui/core/styles';
+// import Tabs from '@material-ui/core/Tabs';
+// import Tab from '@material-ui/core/Tab';
+import * as Styles from './Explore.style';
+
+const ExploreTabs: FunctionComponent<{
+  activeTabIndex: number;
+  labels: string[];
+  onChangeTab: (event: React.ChangeEvent<{}>, newTabIndex: number) => void;
+}> = ({ activeTabIndex, labels, onChangeTab }) => (
+  <Styles.Tabs
+    value={activeTabIndex}
+    onChange={onChangeTab}
+    aria-label="Metrics Tabs"
+    variant="scrollable"
+  >
+    {labels.map((label, i) => (
+      <Styles.Tab
+        disableRipple
+        disableFocusRipple
+        label={label}
+        id={`tab-id-${i}`}
+        aria-controls={`tab-id-${i}`}
+      />
+    ))}
+  </Styles.Tabs>
+);
+
+export default ExploreTabs;

--- a/src/components/Explore/index.ts
+++ b/src/components/Explore/index.ts
@@ -1,0 +1,2 @@
+import Explore from './Explore';
+export default Explore;

--- a/src/components/LocationPage/ChartsHolder.tsx
+++ b/src/components/LocationPage/ChartsHolder.tsx
@@ -12,6 +12,7 @@ import { Metric } from 'common/metric';
 import CompareMain from 'components/Compare/CompareMain';
 import { getCountiesArr } from 'common/utils/compare';
 import { countySummary } from 'common/location_summaries';
+import Explore from 'components/Explore';
 
 // TODO(michael): figure out where this type declaration should live.
 type County = {
@@ -194,6 +195,9 @@ const ChartsHolder = (props: {
                   stateId={props.stateId}
                 />
               ))}
+            </MainContentInner>
+            <MainContentInner>
+              <Explore />
             </MainContentInner>
           </ChartContentWrapper>
           <div ref={shareBlockRef}>


### PR DESCRIPTION
Implement the Tab component for Explore. I added placeholders for the other components of the Explore block. The component is at the bottom of the location page.

- [Mocks](https://www.figma.com/file/nkoC6P02eXxkB95ukdU6Ms/Explore?node-id=260%3A24)


**Desktop**
<img src="https://user-images.githubusercontent.com/114084/90048734-c232e600-dc88-11ea-8809-df28fe8b06b7.png" width="600" />

**Mobile**
<img src="https://user-images.githubusercontent.com/114084/90048781-d1199880-dc88-11ea-82d0-85f641613c62.png"  width="375" />
