### PR TITLE
explore: implement chart container and bar chart

### DIFF
--- a/src/components/Charts/BarChart.tsx
+++ b/src/components/Charts/BarChart.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { Bar } from '@vx/shape';
+import { Group } from '@vx/group';
+
+interface BarChartProps<T> {
+  data: T[];
+  x: (d: T) => number | undefined;
+  y: (d: T) => number | undefined;
+  yMax: number;
+  barWidth: number;
+}
+
+const BarChart = <T extends unknown>({
+  data,
+  x,
+  y,
+  yMax,
+  barWidth,
+}: BarChartProps<T>) => {
+  return (
+    <Group>
+      {data.map((d, i) => {
+        const x0 = x(d)!;
+        const y0 = y(d)!;
+        return (
+          <Bar
+            key={`bar-${i}`}
+            x={x0}
+            y={y0}
+            width={barWidth}
+            height={yMax - y0}
+          />
+        );
+      })}
+    </Group>
+  );
+};
+
+export default BarChart;

--- a/src/components/Explore/Explore.style.ts
+++ b/src/components/Explore/Explore.style.ts
@@ -3,6 +3,11 @@ import MuiTab from '@material-ui/core/Tab';
 import MuiTabs from '@material-ui/core/Tabs';
 import theme from 'assets/theme';
 
+/** Gets the chart palette based on the current theme. */
+function palette(props: any) {
+  return props.theme.palette.chart;
+}
+
 // TODO(pablo): Get from theme
 const lightBlue = '#00BFEA';
 
@@ -11,10 +16,22 @@ export const Container = styled.div`
   margin-bottom: 20px;
 `;
 
-export const Placeholder = styled.div`
-  margin: 4px;
-  padding: 4px;
-  background-color: #f2f2f2;
+// Header
+export const Header = styled.div`
+  /* TODO(pablo): Use spacing from the theme */
+  margin-bottom: 40px;
+`;
+
+export const Subtitle = styled.div`
+  /* TODO(pablo): Move subtitle to the theme, use typography */
+  font-family: Roboto;
+  font-style: normal;
+  font-weight: 500;
+  font-size: 12px;
+  line-height: 14px;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  color: #828282;
 `;
 
 export const Tabs = styled(MuiTabs)`
@@ -36,5 +53,29 @@ export const Tab = styled(MuiTab)`
   &.Mui-selected {
     font-weight: 500;
     color: ${theme.palette.text.primary};
+  }
+`;
+
+export const ChartContainer = styled.div`
+  /* TODO (pablo): Get from theme */
+  margin-top: 30px;
+`;
+
+// Chart
+export const MainSeriesLine = styled.g`
+  line,
+  path {
+    fill: none;
+    stroke: ${props =>
+      props.stroke ? props.stroke : palette(props).foreground};
+    stroke-linecap: round;
+    stroke-width: 3px;
+  }
+`;
+
+export const BarsSeries = styled.g`
+  rect {
+    fill: ${props => (props.stroke ? props.stroke : palette(props).foreground)};
+    fill-opacity: 0.2;
   }
 `;

--- a/src/components/Explore/Explore.tsx
+++ b/src/components/Explore/Explore.tsx
@@ -1,6 +1,11 @@
 import React, { useState, FunctionComponent } from 'react';
+import Typography from '@material-ui/core/Typography';
+import { Projection } from 'common/models/Projection';
 import ExploreTabs from './ExploreTabs';
+import ExploreChart from './ExploreChart';
 import * as Styles from './Explore.style';
+import { ParentSize } from '@vx/responsive';
+import { ChartType, Series } from './interfaces';
 
 // TODO(pablo): Create enums and unify with metrics
 const tabLabels = [
@@ -10,22 +15,51 @@ const tabLabels = [
   'ICU Hospitalizations',
 ];
 
-const Explore: React.FunctionComponent = () => {
-  const [tabIndex, setTabIndex] = useState(0);
+const Explore: React.FunctionComponent<{ projection: Projection }> = ({
+  projection,
+}) => {
+  const [tabIndex, setTabIndex] = useState(1);
 
   const onChangeTab = (event: React.ChangeEvent<{}>, newTabIndex: number) => {
     setTabIndex(newTabIndex);
   };
 
+  const rawData: Series = {
+    data: projection.getDataset('cumulativeDeaths'),
+    type: ChartType.LINE,
+  };
+
+  const smoothedData: Series = {
+    data: projection.getDataset('cumulativeDeaths'),
+    type: ChartType.BAR,
+  };
+
   return (
     <Styles.Container>
-      <Styles.Placeholder>header</Styles.Placeholder>
+      <Styles.Header>
+        <Typography variant="h4" component="h2">
+          Trends
+        </Typography>
+        <Styles.Subtitle>
+          cases since march 1st in {projection.locationName}
+        </Styles.Subtitle>
+      </Styles.Header>
       <ExploreTabs
         activeTabIndex={tabIndex}
         labels={tabLabels}
         onChangeTab={onChangeTab}
       />
-      <Styles.Placeholder>{`chart ${tabLabels[tabIndex]}`}</Styles.Placeholder>
+      <Styles.ChartContainer>
+        <ParentSize>
+          {({ width }) => (
+            <ExploreChart
+              series={[rawData, smoothedData]}
+              width={width}
+              height={400}
+            />
+          )}
+        </ParentSize>
+      </Styles.ChartContainer>
     </Styles.Container>
   );
 };

--- a/src/components/Explore/ExploreChart.tsx
+++ b/src/components/Explore/ExploreChart.tsx
@@ -1,0 +1,88 @@
+import React, { FunctionComponent } from 'react';
+import { scaleTime, scaleLinear, scaleBand } from '@vx/scale';
+import { Group } from '@vx/group';
+import { AxisLeft } from '@vx/axis';
+import { Column } from 'common/models/Projection';
+import { AxisBottom } from 'components/Charts/Axis';
+import * as ChartStyle from 'components/Charts/Charts.style';
+import RectClipGroup from 'components/Charts/RectClipGroup';
+import { Series, ChartType } from './interfaces';
+import SeriesChart from './SeriesChart';
+import { getMinBy, getMaxBy } from './utils';
+
+const getDate = (d: Column) => new Date(d.x);
+const getY = (d: Column) => d.y;
+
+const ExploreChart: FunctionComponent<{
+  width: number;
+  height: number;
+  series: Series[];
+  marginTop?: number;
+  marginBottom?: number;
+  marginLeft?: number;
+  marginRight?: number;
+}> = ({
+  width,
+  height,
+  series,
+  marginTop = 10,
+  marginBottom = 30,
+  marginLeft = 50,
+  marginRight = 10,
+}) => {
+  const minX = getMinBy<Date>(series, getDate, new Date('2020-03-01'));
+  const maxX = getMaxBy<Date>(series, getDate, new Date());
+  const maxY = getMaxBy<number>(series, getY, 1);
+
+  const innerWidth = width - marginLeft - marginRight;
+  const innerHeight = height - marginTop - marginBottom;
+
+  const timeScale = scaleTime({
+    domain: [minX, maxX],
+    range: [0, innerWidth],
+  });
+
+  const yScale = scaleLinear({
+    domain: [0, maxY],
+    range: [innerHeight, 0],
+  });
+
+  const barScale = scaleBand({
+    range: [0, innerWidth],
+    domain: series[0].data.map(getDate),
+    padding: 0.4,
+  });
+
+  const barWidth = barScale.bandwidth();
+
+  return (
+    <svg width={width} height={height}>
+      <Group key="main-chart" top={marginTop} left={marginLeft}>
+        <RectClipGroup width={innerWidth} height={innerHeight}>
+          {series.map((serie, i) => {
+            const xScale = serie.type === ChartType.BAR ? barScale : timeScale;
+            return (
+              <SeriesChart
+                key={`series-chart-${i}`}
+                data={serie.data}
+                x={d => xScale(getDate(d)) || 0}
+                y={d => yScale(getY(d))}
+                type={serie.type}
+                yMax={innerHeight}
+                barWidth={barWidth}
+              />
+            );
+          })}
+        </RectClipGroup>
+      </Group>
+      <Group key="axes" top={marginTop} left={marginLeft}>
+        <ChartStyle.Axis>
+          <AxisLeft scale={yScale} />
+        </ChartStyle.Axis>
+        <AxisBottom top={innerHeight} scale={timeScale} />
+      </Group>
+    </svg>
+  );
+};
+
+export default ExploreChart;

--- a/src/components/Explore/SeriesChart.tsx
+++ b/src/components/Explore/SeriesChart.tsx
@@ -1,0 +1,32 @@
+import React, { FunctionComponent } from 'react';
+import { LinePath } from '@vx/shape';
+import * as Style from './Explore.style';
+import { ChartType } from './interfaces';
+import { Column } from 'common/models/Projection';
+import BarChart from 'components/Charts/BarChart';
+
+const SeriesChart: FunctionComponent<{
+  type: ChartType;
+  data: Column[];
+  x: (d: Column) => number;
+  y: (d: Column) => number;
+  yMax: number;
+  barWidth: number;
+}> = ({ type, data, x, y, yMax, barWidth }) => {
+  switch (type) {
+    case ChartType.LINE:
+      return (
+        <Style.MainSeriesLine>
+          <LinePath data={data} x={x} y={y} />
+        </Style.MainSeriesLine>
+      );
+    case ChartType.BAR:
+      return (
+        <Style.BarsSeries>
+          <BarChart data={data} x={x} y={y} yMax={yMax} barWidth={barWidth} />
+        </Style.BarsSeries>
+      );
+  }
+};
+
+export default SeriesChart;

--- a/src/components/Explore/interfaces.ts
+++ b/src/components/Explore/interfaces.ts
@@ -1,0 +1,11 @@
+import { Column } from 'common/models/Projection';
+
+export enum ChartType {
+  LINE,
+  BAR,
+}
+
+export interface Series {
+  data: Column[];
+  type: ChartType;
+}

--- a/src/components/Explore/utils.ts
+++ b/src/components/Explore/utils.ts
@@ -1,0 +1,21 @@
+import { min as _min, max as _max } from 'lodash';
+import { Column } from 'common/models/Projection';
+import { Series } from './interfaces';
+
+export function getMinBy<T>(
+  series: Series[],
+  getValue: (d: Column) => T,
+  defaultValue: T,
+): T {
+  const minValue = _min(series.map(serie => _min(serie.data.map(getValue))));
+  return minValue || defaultValue;
+}
+
+export function getMaxBy<T>(
+  series: Series[],
+  getValue: (d: Column) => T,
+  defaultValue: T,
+): T {
+  const maxValue = _max(series.map(serie => _max(serie.data.map(getValue))));
+  return maxValue || defaultValue;
+}

--- a/src/components/LocationPage/ChartsHolder.tsx
+++ b/src/components/LocationPage/ChartsHolder.tsx
@@ -197,7 +197,7 @@ const ChartsHolder = (props: {
               ))}
             </MainContentInner>
             <MainContentInner>
-              <Explore />
+              <Explore projection={props.projections.baseline} />
             </MainContentInner>
           </ChartContentWrapper>
           <div ref={shareBlockRef}>


### PR DESCRIPTION
This PR implements the Explore chart container and the BarChart component. [Design Specs](https://www.figma.com/file/nkoC6P02eXxkB95ukdU6Ms/Explore?node-id=260%3A25)

## Notes
- The demo won't include comparing with other location, but I prepared the API of the `ExploreChart` component so it can receive an array of series. For the MVP, it will only show raw and smoothed data.
- The axes need some tweaking to match the designs, more PRs to come!


