### PR TITLE
changing default share text to not start with @CovidActNow

### DIFF
--- a/src/components/AppBar/AppBar.tsx
+++ b/src/components/AppBar/AppBar.tsx
@@ -133,7 +133,7 @@ const _AppBar = () => {
   const hashtag = 'COVIDActNow';
   const locationShareTitle = `I'm keeping track of ${locationName}'s COVID data and risk level with @CovidActNow. What does your community look like?`;
   const defaultShareTitle =
-    '@CovidActNow has real-time COVID data and risk levels for all communities across the country. What does yours look like?';
+    'I’m keeping track of the latest COVID data and risk levels with @CovidActNow. What does your community look like?';
 
   const shareTitle = locationName ? locationShareTitle : defaultShareTitle;
 

--- a/src/components/LocationPage/SocialButtons.js
+++ b/src/components/LocationPage/SocialButtons.js
@@ -22,7 +22,7 @@ const SocialButtons = props => {
   const url = shareURL || 'https://covidactnow.org/';
   const quote =
     shareQuote ||
-    '@CovidActNow has real-time COVID data and risk levels for all communities across the country. What does yours look like?';
+    'I’m keeping track of the latest COVID data and risk levels with @CovidActNow. What does your community look like?';
   const hashtag = 'COVIDActNow';
 
   const [copyLinkButtonTextA, setCopyLinkButtonTextA] = useState('Copy');

--- a/src/components/ShareBlock/ShareBlock.tsx
+++ b/src/components/ShareBlock/ShareBlock.tsx
@@ -52,7 +52,7 @@ const ShareBlock = ({
   const url = urls.addSharingId(shareURL || 'https://covidactnow.org/');
   const quote =
     shareQuote ||
-    '@CovidActNow has real-time COVID data and risk levels for all communities across the country. What does yours look like?';
+    'I’m keeping track of the latest COVID data and risk levels with @CovidActNow. What does your community look like?';
   const hashtag = 'COVIDActNow';
 
   const trackShare = (target: string) => {


### PR DESCRIPTION
"I’m keeping track of the latest COVID data and risk levels with @CovidActNow. What does your community look like?" is what I used as the new default share text.   More than happy to change this, but wanted to put a proposed change in motion!