### PR TITLE
explore: use the real datasets

### DIFF
--- a/src/common/models/Projection.ts
+++ b/src/common/models/Projection.ts
@@ -65,7 +65,15 @@ export type DatasetId =
   | 'contractTracers'
   | 'caseDensityByCases'
   | 'caseDensityByDeaths'
-  | 'caseDensityRange';
+  | 'caseDensityRange'
+  | 'smoothedDailyCases'
+  | 'smoothedDailyDeaths'
+  | 'rawDailyCases'
+  | 'rawDailyDeaths'
+  | 'rawHospitalizations'
+  | 'smoothedHospitalizations'
+  | 'rawICUHospitalizations'
+  | 'smoothedICUHospitalizations';
 
 export interface RtRange {
   /** The actual Rt value. */
@@ -144,6 +152,13 @@ export class Projection {
   private readonly caseDensityRange: Array<CaseDensityRange | null>;
   private readonly smoothedDailyDeaths: Array<number | null>;
 
+  private readonly rawDailyCases: Array<number | null>;
+  private readonly rawDailyDeaths: Array<number | null>;
+  private readonly rawHospitalizations: Array<number | null>;
+  private readonly smoothedHospitalizations: Array<number | null>;
+  private readonly rawICUHospitalizations: Array<number | null>;
+  private readonly smoothedICUHospitalizations: Array<number | null>;
+
   constructor(
     summaryWithTimeseries: RegionSummaryWithTimeseries,
     parameters: ProjectionParameters,
@@ -201,20 +216,37 @@ export class Projection {
       /*includeTrailingZeros=*/ false,
     );
 
-    const cumulativeConfirmedCases = this.smoothCumulatives(
+    this.rawDailyCases = this.deltasFromCumulatives(
       this.fillLeadingNullsWithZeros(
         actualTimeseries.map(row => row && row.cumulativeConfirmedCases),
       ),
     );
-    this.smoothedDailyCases = this.smoothWithRollingAverage(
-      this.deltasFromCumulatives(cumulativeConfirmedCases),
+    this.smoothedDailyCases = this.smoothWithRollingAverage(this.rawDailyCases);
+
+    this.rawDailyDeaths = this.deltasFromCumulatives(
+      this.fillLeadingNullsWithZeros(
+        actualTimeseries.map(row => row && row.cumulativeDeaths),
+      ),
+    );
+    this.smoothedDailyDeaths = this.smoothWithRollingAverage(
+      this.rawDailyDeaths,
+    );
+
+    this.rawHospitalizations = actualTimeseries.map(
+      row => row && row?.hospitalBeds?.currentUsageCovid,
+    );
+    this.smoothedHospitalizations = this.smoothWithRollingAverage(
+      this.rawHospitalizations,
+    );
+    this.rawICUHospitalizations = actualTimeseries.map(
+      row => row && row?.ICUBeds?.currentUsageCovid,
+    );
+    this.smoothedICUHospitalizations = this.smoothWithRollingAverage(
+      this.rawICUHospitalizations,
     );
 
     this.cumulativeActualDeaths = this.smoothCumulatives(
       actualTimeseries.map(row => row && row.cumulativeDeaths),
-    );
-    this.smoothedDailyDeaths = this.smoothWithRollingAverage(
-      this.deltasFromCumulatives(this.cumulativeActualDeaths),
     );
 
     const disableRt = false;

--- a/src/common/models/Projection.ts
+++ b/src/common/models/Projection.ts
@@ -233,13 +233,13 @@ export class Projection {
     );
 
     this.rawHospitalizations = actualTimeseries.map(
-      row => row && row?.hospitalBeds?.currentUsageCovid,
+      row => row && row.hospitalBeds.currentUsageCovid,
     );
     this.smoothedHospitalizations = this.smoothWithRollingAverage(
       this.rawHospitalizations,
     );
     this.rawICUHospitalizations = actualTimeseries.map(
-      row => row && row?.ICUBeds?.currentUsageCovid,
+      row => row && row.ICUBeds.currentUsageCovid,
     );
     this.smoothedICUHospitalizations = this.smoothWithRollingAverage(
       this.rawICUHospitalizations,

--- a/src/components/Explore/Explore.tsx
+++ b/src/components/Explore/Explore.tsx
@@ -5,34 +5,20 @@ import ExploreTabs from './ExploreTabs';
 import ExploreChart from './ExploreChart';
 import * as Styles from './Explore.style';
 import { ParentSize } from '@vx/responsive';
-import { ChartType, Series } from './interfaces';
-
-// TODO(pablo): Create enums and unify with metrics
-const tabLabels = [
-  'Cases',
-  'Deaths',
-  'Hospitalizations',
-  'ICU Hospitalizations',
-];
+import { ExploreMetric } from './interfaces';
+import { getMetricLabels, getSeries } from './utils';
 
 const Explore: React.FunctionComponent<{ projection: Projection }> = ({
   projection,
 }) => {
-  const [tabIndex, setTabIndex] = useState(1);
+  const [currentMetric, setCurrentMetric] = useState(ExploreMetric.CASES);
 
-  const onChangeTab = (event: React.ChangeEvent<{}>, newTabIndex: number) => {
-    setTabIndex(newTabIndex);
+  const onChangeTab = (event: React.ChangeEvent<{}>, newMetric: number) => {
+    setCurrentMetric(newMetric);
   };
 
-  const rawData: Series = {
-    data: projection.getDataset('cumulativeDeaths'),
-    type: ChartType.LINE,
-  };
-
-  const smoothedData: Series = {
-    data: projection.getDataset('cumulativeDeaths'),
-    type: ChartType.BAR,
-  };
+  const metricLabels = getMetricLabels();
+  const series = getSeries(currentMetric, projection);
 
   return (
     <Styles.Container>
@@ -45,18 +31,14 @@ const Explore: React.FunctionComponent<{ projection: Projection }> = ({
         </Styles.Subtitle>
       </Styles.Header>
       <ExploreTabs
-        activeTabIndex={tabIndex}
-        labels={tabLabels}
+        activeTabIndex={currentMetric}
+        labels={metricLabels}
         onChangeTab={onChangeTab}
       />
       <Styles.ChartContainer>
         <ParentSize>
           {({ width }) => (
-            <ExploreChart
-              series={[rawData, smoothedData]}
-              width={width}
-              height={400}
-            />
+            <ExploreChart series={series} width={width} height={400} />
           )}
         </ParentSize>
       </Styles.ChartContainer>

--- a/src/components/Explore/ExploreChart.tsx
+++ b/src/components/Explore/ExploreChart.tsx
@@ -1,5 +1,6 @@
 import React, { FunctionComponent } from 'react';
-import { scaleTime, scaleLinear, scaleBand } from '@vx/scale';
+import moment from 'moment';
+import { scaleTime, scaleLinear } from '@vx/scale';
 import { Grid } from '@vx/grid';
 import { Group } from '@vx/group';
 import { AxisLeft } from '@vx/axis';
@@ -7,7 +8,7 @@ import { Column } from 'common/models/Projection';
 import { AxisBottom } from 'components/Charts/Axis';
 import * as ChartStyle from 'components/Charts/Charts.style';
 import RectClipGroup from 'components/Charts/RectClipGroup';
-import { Series, ChartType } from './interfaces';
+import { Series } from './interfaces';
 import SeriesChart from './SeriesChart';
 import { getMaxBy } from './utils';
 import * as Styles from './Explore.style';
@@ -34,6 +35,7 @@ const ExploreChart: FunctionComponent<{
 }) => {
   const minX = new Date('2020-03-01');
   const maxX = new Date();
+  const numDays = moment(maxX).diff(minX, 'days');
   const maxY = getMaxBy<number>(series, getY, 1);
 
   const innerWidth = width - marginLeft - marginRight;
@@ -49,32 +51,23 @@ const ExploreChart: FunctionComponent<{
     range: [innerHeight, 0],
   });
 
-  const barScale = scaleBand({
-    range: [0, innerWidth],
-    domain: series[0].data.map(getDate),
-    padding: 0.4,
-  });
-
-  const barWidth = barScale.bandwidth();
+  const barWidth = 0.7 * (innerWidth / numDays);
 
   return (
     <svg width={width} height={height}>
       <Group key="main-chart" top={marginTop} left={marginLeft}>
         <RectClipGroup width={innerWidth} height={innerHeight}>
-          {series.map((serie, i) => {
-            const xScale = serie.type === ChartType.BAR ? barScale : timeScale;
-            return (
-              <SeriesChart
-                key={`series-chart-${i}`}
-                data={serie.data}
-                x={d => xScale(getDate(d)) || 0}
-                y={d => yScale(getY(d))}
-                type={serie.type}
-                yMax={innerHeight}
-                barWidth={barWidth}
-              />
-            );
-          })}
+          {series.map((serie, i) => (
+            <SeriesChart
+              key={`series-chart-${i}`}
+              data={serie.data}
+              x={d => timeScale(getDate(d)) || 0}
+              y={d => yScale(getY(d))}
+              type={serie.type}
+              yMax={innerHeight}
+              barWidth={barWidth}
+            />
+          ))}
         </RectClipGroup>
       </Group>
       <Group key="axes" top={marginTop} left={marginLeft}>

--- a/src/components/Explore/ExploreChart.tsx
+++ b/src/components/Explore/ExploreChart.tsx
@@ -9,7 +9,7 @@ import * as ChartStyle from 'components/Charts/Charts.style';
 import RectClipGroup from 'components/Charts/RectClipGroup';
 import { Series, ChartType } from './interfaces';
 import SeriesChart from './SeriesChart';
-import { getMinBy, getMaxBy } from './utils';
+import { getMaxBy } from './utils';
 import * as Styles from './Explore.style';
 
 const getDate = (d: Column) => new Date(d.x);
@@ -32,8 +32,8 @@ const ExploreChart: FunctionComponent<{
   marginLeft = 50,
   marginRight = 10,
 }) => {
-  const minX = getMinBy<Date>(series, getDate, new Date('2020-03-01'));
-  const maxX = getMaxBy<Date>(series, getDate, new Date());
+  const minX = new Date('2020-03-01');
+  const maxX = new Date();
   const maxY = getMaxBy<number>(series, getY, 1);
 
   const innerWidth = width - marginLeft - marginRight;

--- a/src/components/Explore/SeriesChart.tsx
+++ b/src/components/Explore/SeriesChart.tsx
@@ -1,4 +1,5 @@
 import React, { FunctionComponent } from 'react';
+import { curveCardinalOpen } from '@vx/curve';
 import { LinePath } from '@vx/shape';
 import * as Style from './Explore.style';
 import { ChartType } from './interfaces';
@@ -17,7 +18,7 @@ const SeriesChart: FunctionComponent<{
     case ChartType.LINE:
       return (
         <Style.MainSeriesLine>
-          <LinePath data={data} x={x} y={y} />
+          <LinePath data={data} x={x} y={y} curve={curveCardinalOpen} />
         </Style.MainSeriesLine>
       );
     case ChartType.BAR:

--- a/src/components/Explore/interfaces.ts
+++ b/src/components/Explore/interfaces.ts
@@ -9,3 +9,10 @@ export interface Series {
   data: Column[];
   type: ChartType;
 }
+
+export enum ExploreMetric {
+  CASES,
+  DEATHS,
+  HOSPITALIZATIONS,
+  ICU_HOSPITALIZATIONS,
+}

--- a/src/components/Explore/utils.ts
+++ b/src/components/Explore/utils.ts
@@ -1,15 +1,8 @@
-import { min as _min, max as _max } from 'lodash';
+import { max as _max } from 'lodash';
 import { Column } from 'common/models/Projection';
 import { Series } from './interfaces';
-
-export function getMinBy<T>(
-  series: Series[],
-  getValue: (d: Column) => T,
-  defaultValue: T,
-): T {
-  const minValue = _min(series.map(serie => _min(serie.data.map(getValue))));
-  return minValue || defaultValue;
-}
+import { Projection, DatasetId } from 'common/models/Projection';
+import { ChartType } from './interfaces';
 
 export function getMaxBy<T>(
   series: Series[],
@@ -18,4 +11,106 @@ export function getMaxBy<T>(
 ): T {
   const maxValue = _max(series.map(serie => _max(serie.data.map(getValue))));
   return maxValue || defaultValue;
+}
+
+export enum ExploreMetric {
+  CASES,
+  DEATHS,
+  HOSPITALIZATIONS,
+  ICU_HOSPITALIZATIONS,
+}
+
+const sortedExploreMetrics = [
+  ExploreMetric.CASES,
+  ExploreMetric.DEATHS,
+  ExploreMetric.HOSPITALIZATIONS,
+  ExploreMetric.ICU_HOSPITALIZATIONS,
+];
+
+interface SerieDescription {
+  label: string;
+  datasetId: DatasetId;
+  type: ChartType;
+}
+
+interface ExploreMetricDescription {
+  title: string;
+  series: SerieDescription[];
+}
+
+export const exploreMetricData: {
+  [metric in ExploreMetric]: ExploreMetricDescription;
+} = {
+  [ExploreMetric.CASES]: {
+    title: 'Cases',
+    series: [
+      {
+        label: 'smoothed',
+        datasetId: 'smoothedDailyCases',
+        type: ChartType.LINE,
+      },
+      {
+        label: 'raw',
+        datasetId: 'rawDailyCases',
+        type: ChartType.BAR,
+      },
+    ],
+  },
+  [ExploreMetric.DEATHS]: {
+    title: 'Deaths',
+    series: [
+      {
+        label: 'smoothed',
+        datasetId: 'smoothedDailyDeaths',
+        type: ChartType.LINE,
+      },
+      {
+        label: 'raw',
+        datasetId: 'rawDailyDeaths',
+        type: ChartType.BAR,
+      },
+    ],
+  },
+  [ExploreMetric.HOSPITALIZATIONS]: {
+    title: 'Hospitalizations',
+    series: [
+      {
+        label: 'smoothed',
+        datasetId: 'smoothedHospitalizations',
+        type: ChartType.LINE,
+      },
+      {
+        label: 'raw',
+        datasetId: 'rawHospitalizations',
+        type: ChartType.BAR,
+      },
+    ],
+  },
+  [ExploreMetric.ICU_HOSPITALIZATIONS]: {
+    title: 'ICU Hospitalizations',
+    series: [
+      {
+        label: 'smoothed',
+        datasetId: 'smoothedICUHospitalizations',
+        type: ChartType.LINE,
+      },
+      {
+        label: 'raw',
+        datasetId: 'rawICUHospitalizations',
+        type: ChartType.BAR,
+      },
+    ],
+  },
+};
+
+export function getSeries(metric: ExploreMetric, projection: Projection) {
+  const metricDefinition = exploreMetricData[metric];
+  return metricDefinition.series.map(item => ({
+    data: projection.getDataset(item.datasetId),
+    type: item.type,
+  }));
+}
+
+export function getMetricLabels() {
+  return sortedExploreMetrics.map(metric => exploreMetricData[metric].title);
 }


### PR DESCRIPTION
It looks like our rolling average function "translates" the data forward by a week, the effect is more noticeable with hospitalization data.

![image](https://user-images.githubusercontent.com/114084/90169296-405bbf00-dd53-11ea-89d0-6c434ad0de24.png)

![image](https://user-images.githubusercontent.com/114084/90169423-68e3b900-dd53-11ea-8065-e55f44056bed.png)

@mikelehen @chasulin can you double-check that I'm using the correct metrics in each case? I need to adjust the smoothed line to not go to zero before and after having data, but I will do that on a separate PR