### PR TITLE
explore: format x-axis labels and tick positions

### DIFF
--- a/src/components/Explore/ExploreChart.tsx
+++ b/src/components/Explore/ExploreChart.tsx
@@ -1,4 +1,6 @@
 import React, { FunctionComponent } from 'react';
+import useMediaQuery from '@material-ui/core/useMediaQuery';
+import { useTheme } from '@material-ui/core/styles';
 import moment from 'moment';
 import { scaleTime, scaleLinear, scaleBand } from '@vx/scale';
 import { GridRows, GridColumns } from '@vx/grid';
@@ -44,6 +46,10 @@ const ExploreChart: FunctionComponent<{
     range: [0, innerWidth],
   });
   const timeTicks = getTimeAxisTicks(minX, maxX);
+
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('md'));
+  const timeTickFormat = isMobile ? 'MMM' : 'MMMM D';
 
   const yScale = scaleLinear({
     domain: [0, maxY],
@@ -91,7 +97,7 @@ const ExploreChart: FunctionComponent<{
             top={innerHeight}
             scale={timeScale}
             tickValues={timeTicks}
-            tickFormat={(date: Date) => moment(date).format('MMMM D')}
+            tickFormat={(date: Date) => moment(date).format(timeTickFormat)}
           />
         </ChartStyle.Axis>
       </Group>

--- a/src/components/Explore/ExploreChart.tsx
+++ b/src/components/Explore/ExploreChart.tsx
@@ -1,15 +1,15 @@
 import React, { FunctionComponent } from 'react';
+import moment from 'moment';
 import { scaleTime, scaleLinear, scaleBand } from '@vx/scale';
-import { Grid } from '@vx/grid';
+import { GridRows, GridColumns } from '@vx/grid';
 import { Group } from '@vx/group';
-import { AxisLeft } from '@vx/axis';
+import { AxisLeft, AxisBottom } from '@vx/axis';
 import { Column } from 'common/models/Projection';
-import { AxisBottom } from 'components/Charts/Axis';
 import * as ChartStyle from 'components/Charts/Charts.style';
 import RectClipGroup from 'components/Charts/RectClipGroup';
 import { Series, ChartType } from './interfaces';
 import SeriesChart from './SeriesChart';
-import { getMinBy, getMaxBy } from './utils';
+import { getMaxBy, getTimeAxisTicks } from './utils';
 import * as Styles from './Explore.style';
 
 const getDate = (d: Column) => new Date(d.x);
@@ -32,8 +32,8 @@ const ExploreChart: FunctionComponent<{
   marginLeft = 50,
   marginRight = 10,
 }) => {
-  const minX = getMinBy<Date>(series, getDate, new Date('2020-03-01'));
-  const maxX = getMaxBy<Date>(series, getDate, new Date());
+  const minX = new Date('2020-03-01');
+  const maxX = new Date();
   const maxY = getMaxBy<number>(series, getY, 1);
 
   const innerWidth = width - marginLeft - marginRight;
@@ -43,6 +43,7 @@ const ExploreChart: FunctionComponent<{
     domain: [minX, maxX],
     range: [0, innerWidth],
   });
+  const timeTicks = getTimeAxisTicks(minX, maxX);
 
   const yScale = scaleLinear({
     domain: [0, maxY],
@@ -79,17 +80,20 @@ const ExploreChart: FunctionComponent<{
       </Group>
       <Group key="axes" top={marginTop} left={marginLeft}>
         <Styles.GridLines>
-          <Grid
-            xScale={timeScale}
-            yScale={yScale}
-            width={innerWidth}
-            height={innerHeight}
-          />
+          <GridColumns<Date> scale={timeScale} height={innerHeight} />
+          <GridRows<number> scale={yScale} width={innerWidth} />
         </Styles.GridLines>
         <ChartStyle.Axis>
           <AxisLeft scale={yScale} />
         </ChartStyle.Axis>
-        <AxisBottom top={innerHeight} scale={timeScale} />
+        <ChartStyle.Axis>
+          <AxisBottom
+            top={innerHeight}
+            scale={timeScale}
+            tickValues={timeTicks}
+            tickFormat={(date: Date) => moment(date).format('MMMM D')}
+          />
+        </ChartStyle.Axis>
       </Group>
     </svg>
   );

--- a/src/components/Explore/utils.ts
+++ b/src/components/Explore/utils.ts
@@ -1,15 +1,7 @@
-import { min as _min, max as _max } from 'lodash';
+import moment from 'moment';
+import { max as _max, range as _range } from 'lodash';
 import { Column } from 'common/models/Projection';
 import { Series } from './interfaces';
-
-export function getMinBy<T>(
-  series: Series[],
-  getValue: (d: Column) => T,
-  defaultValue: T,
-): T {
-  const minValue = _min(series.map(serie => _min(serie.data.map(getValue))));
-  return minValue || defaultValue;
-}
 
 export function getMaxBy<T>(
   series: Series[],
@@ -18,4 +10,12 @@ export function getMaxBy<T>(
 ): T {
   const maxValue = _max(series.map(serie => _max(serie.data.map(getValue))));
   return maxValue || defaultValue;
+}
+
+export function getTimeAxisTicks(from: Date, to: Date) {
+  const dateFrom = moment(from).startOf('month').toDate();
+  const numMonths = moment(to).diff(dateFrom, 'months');
+  return _range(1, numMonths + 1).map(i =>
+    moment(dateFrom).add(i, 'month').toDate(),
+  );
 }


### PR DESCRIPTION
Small fix to adjust tick positions to what we have in [the mocks](https://www.figma.com/file/nkoC6P02eXxkB95ukdU6Ms/Explore?node-id=260%3A24)

![image](https://user-images.githubusercontent.com/114084/90178253-7e131480-dd60-11ea-8041-121dd608c5df.png)
