### PR TITLE
Remove legacy intervention-related code.

### DIFF
--- a/DEV_README.md
+++ b/DEV_README.md
@@ -70,5 +70,5 @@ export GITHUB_TOKEN=<YOUR PERSONAL GITHUB TOKEN>
 Alternatively, if you don't care about regenerating the sharing images (which takes a long time), you can update the snapshot and map colors with:
 
 * Update src/assets/data/data_url.json to point at the new snapshot.
-* Run `yarn update-calculated-interventions`
+* Run `yarn update-location-summaries`
 * Check in the result.

--- a/README.md
+++ b/README.md
@@ -1,18 +1,10 @@
 # Covid Act Now
 
-This is the code repository for https://covidactnow.org/ - a tool providing public leaders and health officials data to help answer the question: "how can the US reopen safely?"
-
-## How to use this tool
-This tool is built to enable political leaders to make decisions in their COVID-19 response informed by best available data and modeling.
-
-### Here are the questions we built this tool to answer:
-* What will the impact be in my region be and when can I expect it?
-* How long until my hospital system is under severe pressure?
-* What are my menu of interventions, and how will they address the spread of COVID-19?
+This is the code repository for https://covidactnow.org/
 
 ## Comments, questions, or want to get involved?
 If you have time to give us feedback, have questions, or otherwise want to get involved, please email us info@covidactnow.org
 
-## Already involved? 
-Check out the frontend 
+## Already involved?
+Check out the frontend
 [onboarding document](https://docs.google.com/document/d/1w5wlqynTOf8fFxWP_Cly3M8o8hrhkC6yQ43XpjzgOJY/edit#) for further information on how to get started

--- a/scripts/update_location_summaries.ts
+++ b/scripts/update_location_summaries.ts
@@ -9,10 +9,6 @@ import { currentSnapshot } from '../src/common/utils/snapshots';
 import { LocationSummary } from '../src/common/location_summaries';
 
 async function main() {
-  // TODO(michael): This fetches all interventions for all regions, even though
-  // we only really need 1 intervention (and it doesn't matter which) to
-  // calculate the summary. But to fix this, we need to rework how
-  // Projections works (so it doesn't require all intervention data, etc.).
   const allStatesProjections = await fetchAllStateProjections();
   const allCountiesProjections = await fetchAllCountyProjections();
 

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -9,7 +9,6 @@ import {
   Actualstimeseries,
 } from './schema/RegionSummaryWithTimeseries';
 import { AggregateRegionSummaryWithTimeseries } from './schema/AggregateRegionSummaryWithTimeseries';
-import { INTERVENTIONS, REVERSED_STATES } from 'common';
 import {
   RegionAggregateDescriptor,
   RegionDescriptor,
@@ -19,31 +18,11 @@ import fetch from 'node-fetch';
 
 export const SNAPSHOT_URL = DataUrlJson.data_url;
 
-/**
- * Maps values from the INTERVENTIONS enum to the API endpoints.
- */
-const ApiInterventions: { [intervention: string]: string } = {
-  [INTERVENTIONS.LIMITED_ACTION]: 'NO_INTERVENTION',
-  [INTERVENTIONS.PROJECTED]: 'OBSERVED_INTERVENTION',
-};
-
-// TODO: We could clean up some code in this file (including this) if
-// INTERVENTIONS was a TypeScript enum or string union, and we should ideally
-// consolidate these different intervention types.
-type InterventionKey = keyof typeof INTERVENTIONS;
+// We always use the "observed" intervention (i.e. projected based on current trends).
+const INTERVENTION = 'OBSERVED_INTERVENTION';
 
 /** Represents the actuals timeseries for any kind of region */
 export type ActualsTimeseries = Actualstimeseries;
-
-/** A mapping of interventions to the corresponding region summary+timeseries data. */
-export type RegionSummaryWithTimeseriesMap = {
-  /**
-   * We use null to represent data we tried to fetch from the API but which was
-   * missing (e.g. the region doesn't exist or doesn't have data for a
-   * particular intervention. E.g. not all counties have inference data.)
-   */
-  [intervention: string]: RegionSummaryWithTimeseries | null;
-};
 
 export interface SnapshotVersion {
   timestamp: string;
@@ -60,70 +39,32 @@ export class Api {
   }
 
   /**
-   * Fetches the summary+timeseries for every intervention for every region in
-   * the specified region aggregate (e.g. all counties or all states).
+   * Fetches the summary+timeseries for every region in the specified region
+   * aggregate (e.g. all counties or all states).
    */
-  async fetchAggregatedSummaryWithTimeseriesMaps(
+  async fetchAggregatedSummaryWithTimeseries(
     regionAggregate: RegionAggregateDescriptor,
-  ): Promise<RegionSummaryWithTimeseriesMap[]> {
-    // We have to fetch each intervention separately and then merge them per region ID.
-    const merged = {} as { [id: string]: RegionSummaryWithTimeseriesMap };
-
-    await Promise.all(
-      Object.keys(ApiInterventions).map(async intervention => {
-        const apiIntervention = ApiInterventions[intervention];
-        let all = await this.fetchApiJson<AggregateRegionSummaryWithTimeseries>(
-          `us/${regionAggregate}.${apiIntervention}.timeseries.json`,
-        );
-        assert(all != null, 'Failed to load timeseries');
-
-        for (const summaryTimeseries of all) {
-          let id;
-          if (summaryTimeseries.countyName != null) {
-            id = summaryTimeseries.fips;
-          } else {
-            id = REVERSED_STATES[summaryTimeseries.stateName];
-          }
-          merged[id] = merged[id] || {};
-          merged[id][intervention] = summaryTimeseries;
-        }
-      }),
+  ): Promise<RegionSummaryWithTimeseries[]> {
+    const all = await this.fetchApiJson<AggregateRegionSummaryWithTimeseries>(
+      `us/${regionAggregate}.${INTERVENTION}.timeseries.json`,
     );
-    return Object.values(merged);
+    assert(all != null, 'Failed to load timeseries');
+    return all;
   }
 
   /**
-   * Fetches the summary+timeseries for a region for each available intervention
-   * and returns them as a map.
+   * Fetches the summary+timeseries for a region. Returns null if not found.
    */
-  async fetchSummaryWithTimeseriesMap(
-    region: RegionDescriptor,
-  ): Promise<RegionSummaryWithTimeseriesMap> {
-    const result = {} as RegionSummaryWithTimeseriesMap;
-    await Promise.all(
-      Object.keys(ApiInterventions).map(async intervention => {
-        result[intervention] = await this.fetchSummaryWithTimeseries(
-          region,
-          intervention as InterventionKey,
-        );
-      }),
-    );
-    return result;
-  }
-
-  /** Fetches the summary+timeseries for a region and a single intervention. */
   async fetchSummaryWithTimeseries(
     region: RegionDescriptor,
-    intervention: InterventionKey,
   ): Promise<RegionSummaryWithTimeseries | null> {
-    const apiIntervention = ApiInterventions[intervention];
     if (region.isState()) {
       return await this.fetchApiJson<RegionSummaryWithTimeseries>(
-        `us/states/${region.stateId}.${apiIntervention}.timeseries.json`,
+        `us/states/${region.stateId}.${INTERVENTION}.timeseries.json`,
       );
     } else if (region.isCounty()) {
       return await this.fetchApiJson<RegionSummaryWithTimeseries>(
-        `us/counties/${region.countyFipsId}.${apiIntervention}.timeseries.json`,
+        `us/counties/${region.countyFipsId}.${INTERVENTION}.timeseries.json`,
       );
     } else {
       fail('Unknown region type: ' + region);

--- a/src/common/colors.js
+++ b/src/common/colors.js
@@ -1,4 +1,3 @@
-import { INTERVENTIONS } from 'common/interventions';
 import { Level } from 'common/level';
 
 import { stateSummary, countySummary } from './location_summaries';
@@ -43,14 +42,6 @@ export const LEVEL_COLOR = {
   [Level.HIGH]: COLOR_MAP.ORANGE_DARK.BASE,
   [Level.CRITICAL]: COLOR_MAP.RED.BASE,
   [Level.UNKNOWN]: COLOR_MAP.GRAY.BASE,
-};
-
-export const INTERVENTION_COLOR_MAP = {
-  [INTERVENTIONS.LIMITED_ACTION]: COLOR_MAP.RED.BASE,
-  [INTERVENTIONS.SOCIAL_DISTANCING]: COLOR_MAP.ORANGE.BASE,
-  [INTERVENTIONS.SHELTER_IN_PLACE]: COLOR_MAP.GREEN.BASE,
-  [INTERVENTIONS.SHELTER_IN_PLACE_WORST_CASE]: COLOR_MAP.GREEN.DARK,
-  [INTERVENTIONS.PROJECTED]: COLOR_MAP.BLUE,
 };
 
 export function stateColor(stateCode) {

--- a/src/common/index.js
+++ b/src/common/index.js
@@ -2,8 +2,7 @@ import { invert } from 'lodash';
 import STATES from './us_states';
 import TEAM from './team';
 import COLORS from './colors';
-import { INTERVENTIONS } from './interventions';
 
 const REVERSED_STATES = invert(STATES);
 
-export { COLORS, STATES, REVERSED_STATES, TEAM, INTERVENTIONS };
+export { COLORS, STATES, REVERSED_STATES, TEAM };

--- a/src/common/interventions.js
+++ b/src/common/interventions.js
@@ -1,7 +1,0 @@
-export const LIMITED_ACTION = 'Limited action';
-export const PROJECTED = 'Projected based on current trends';
-
-export const INTERVENTIONS = {
-  LIMITED_ACTION,
-  PROJECTED,
-};

--- a/src/common/models/Projection.ts
+++ b/src/common/models/Projection.ts
@@ -41,7 +41,6 @@ const CONTACT_TRACER_STATE_OVERRIDES: { [key: string]: number } = {};
 
 /** Parameters that can be provided when constructing a Projection. */
 export interface ProjectionParameters {
-  intervention: string;
   isCounty: boolean;
 }
 
@@ -119,7 +118,6 @@ export class Projection {
 
   private readonly cumulativeActualDeaths: Array<number | null>;
 
-  private readonly intervention: string;
   private readonly dates: Date[];
   private readonly isCounty: boolean;
 
@@ -166,7 +164,6 @@ export class Projection {
     const lastUpdated = new Date(summaryWithTimeseries.lastUpdatedDate);
     this.locationName = this.getLocationName(summaryWithTimeseries);
     this.stateName = summaryWithTimeseries.stateName;
-    this.intervention = parameters.intervention;
     this.isCounty = parameters.isCounty;
     this.totalPopulation = actuals.population;
     this.fips = summaryWithTimeseries.fips;
@@ -281,10 +278,6 @@ export class Projection {
   // the same day, to make sure it matches the graph.
   get currentDailyAverageCases() {
     return lastValue(this.smoothedDailyCases);
-  }
-
-  get label() {
-    return this.intervention;
   }
 
   get finalCumulativeInfected() {

--- a/src/common/models/Projections.ts
+++ b/src/common/models/Projections.ts
@@ -3,7 +3,7 @@ import { STATES } from '..';
 import { Metric, getLevel, ALL_METRICS } from 'common/metric';
 import { Level } from 'common/level';
 import { LEVEL_COLOR } from 'common/colors';
-import { fail, assert } from 'common/utils';
+import { fail } from 'common/utils';
 import { LocationSummary, MetricSummary } from 'common/location_summaries';
 import { RegionSummaryWithTimeseries } from 'api/schema/RegionSummaryWithTimeseries';
 

--- a/src/common/utils/makeChartShareQuote.js
+++ b/src/common/utils/makeChartShareQuote.js
@@ -1,5 +1,5 @@
 import { STATES } from 'common';
-import { formatUtcDate, formatDecimal, formatPercent } from 'common/utils';
+import { fail, formatDecimal, formatPercent } from 'common/utils';
 
 //TODO(chelsi): move this copy into individual metric files. remove need for hardcoded identifying numers
 export default function makeChartShareQuote(
@@ -32,12 +32,7 @@ export default function makeChartShareQuote(
       0,
     )} of COVID cases, according to @CovidActNow. See the chart: `;
   } else if (chartIdentifier === 4) {
-    if (projections && projections.baseline.dateOverwhelmed) {
-      return `If all restrictions were completely lifted today, ${displayName}'s hospitals would overload on ${formatUtcDate(
-        projections.baseline.dateOverwhelmed,
-      )}, according to @CovidActNow. See the chart: `;
-    }
-    return `Assuming current trends and interventions continue, ${displayName}'s hospitals are unlikely to become overloaded in the next 3 months, according to @CovidActNow. See the chart: `;
+    fail('Future projections chart was deprecated.');
   } else if (chartIdentifier === 5) {
     return `${displayName} is seeing ${formatDecimal(
       stats[5],

--- a/src/components/Charts/MetricChart.tsx
+++ b/src/components/Charts/MetricChart.tsx
@@ -20,10 +20,10 @@ export default function MetricChart({
   projections: Projections;
   height?: number;
 }) {
-  const projection = projections.primary;
-  if (projection === null || !projections.hasMetric(metric)) {
+  if (!projections.hasMetric(metric)) {
     return null;
   }
+  const projection = projections.primary;
   return (
     <>
       {metric === Metric.CASE_GROWTH_RATE && (

--- a/src/components/LocationPage/ChartsHolder.tsx
+++ b/src/components/LocationPage/ChartsHolder.tsx
@@ -43,7 +43,7 @@ const ChartsHolder = (props: {
   chartId: string;
   countyId: string;
 }) => {
-  const projection: Projection | null = props.projections.primary;
+  const projection = props.projections.primary;
 
   const {
     rtRangeData,

--- a/src/screens/Embed/Embed.js
+++ b/src/screens/Embed/Embed.js
@@ -61,11 +61,6 @@ function LocationEmbed() {
     return null;
   }
 
-  const primary = projections.primary;
-  if (!primary) {
-    return <span>'No data available for county.'</span>;
-  }
-
   const stats = projections.getMetricValues();
   const alarmLevel = projections.getAlarmLevel();
   const levelInfo = LOCATION_SUMMARY_LEVELS[alarmLevel];


### PR DESCRIPTION
NOTE: This is low-pri.  No rush. 

With the removal of future projections and the outcomes table, we no longer
need any intervention-related code.

We now only load the OBSERVED_INTERVENTION api endpoint, not NO_INTERVENTION.
This makes the location page, compare tool, update-location-summaries, etc. faster.