### PR TITLE
Fix displaying contains zipcode if no matched zips in list

### DIFF
--- a/src/components/MapSelectors/GlobalSelector.js
+++ b/src/components/MapSelectors/GlobalSelector.js
@@ -58,6 +58,8 @@ const CountyItem = ({ dataset }) => {
     stateColor(dataset.state_code),
   );
 
+  const hasZipcodeMatch =
+    dataset.matchedZipCodes !== undefined && dataset.matchedZipCodes.length > 0;
   return (
     <StyledResultsMenuOption hasData={dataset.hasData}>
       <div style={{ marginLeft: '0', marginRight: '.75rem' }}>
@@ -72,7 +74,7 @@ const CountyItem = ({ dataset }) => {
       <div>
         <div>
           {dataset.county}, {dataset.state_code}{' '}
-          {dataset.matchedZipCodes !== undefined ? (
+          {hasZipcodeMatch ? (
             <StyledZipcodeInCounty>
               contains zipcode {dataset.matchedZipCodes[0]}
             </StyledZipcodeInCounty>


### PR DESCRIPTION
Was showing 'contains zipcode' even if there was no zipcode match.

Before
![image](https://user-images.githubusercontent.com/1422280/90689291-d5702380-e23d-11ea-80dc-8830bc80eda7.png)

After
![image](https://user-images.githubusercontent.com/1422280/90689310-def98b80-e23d-11ea-966c-a2cd7d990417.png)
