### PR TITLE
Enhance Daily New Cases Tooltip

### DIFF
--- a/src/common/models/Projection.ts
+++ b/src/common/models/Projection.ts
@@ -77,6 +77,7 @@ export interface RtRange {
 
 export interface CaseDensityRange {
   caseDensity: number;
+  newCases: number | null;
   low: number;
   high: number;
 }
@@ -469,10 +470,15 @@ export class Projection {
   }
 
   private calcCaseDensityRange(): Array<CaseDensityRange | null> {
-    return this.caseDensityByCases.map(caseDensity =>
+    return this.caseDensityByCases.map((caseDensity, indx, arr) =>
       caseDensity === null
         ? null
-        : { caseDensity, low: caseDensity, high: caseDensity },
+        : {
+            caseDensity: caseDensity,
+            newCases: this.smoothedDailyCases[indx],
+            low: caseDensity,
+            high: caseDensity,
+          },
     );
   }
 

--- a/src/components/Charts/ChartCaseDensity.tsx
+++ b/src/components/Charts/ChartCaseDensity.tsx
@@ -33,8 +33,10 @@ type Point = {
 };
 
 const getDate = (d: Point) => new Date(d.x);
-const getY = (d: Point) => d?.y?.caseDensity;
-const hasData = (d: any) => isDate(getDate(d)) && Number.isFinite(getY(d));
+const getYCaseDensity = (d: Point) => d?.y?.caseDensity;
+const getYNewCases = (d: Point) => d?.y?.newCases;
+const hasData = (d: any) =>
+  isDate(getDate(d)) && Number.isFinite(getYCaseDensity(d));
 
 const ChartCaseDensity: FunctionComponent<{
   columnData: Column[];
@@ -63,14 +65,14 @@ const ChartCaseDensity: FunctionComponent<{
   const data: Point[] = columnData.filter(hasData);
 
   const lastPoint = last(data);
-  const activeZone = getZoneByValue(getY(lastPoint), zones);
+  const activeZone = getZoneByValue(getYCaseDensity(lastPoint), zones);
 
   const dates = data.map(getDate);
   const minDate = d3min(dates) || new Date('2020-01-01');
   const currDate = new Date();
   const xScale = getZonesTimeScale(minDate, currDate, 0, chartWidth);
 
-  const yDataMax = d3max(data, getY) || 100;
+  const yDataMax = d3max(data, getYCaseDensity) || 100;
   const yAxisLimits = getAxisLimits(0, yDataMax, zones);
 
   // Adjusts the min y-axis to make the Low label fit only if
@@ -85,7 +87,7 @@ const ChartCaseDensity: FunctionComponent<{
   });
 
   const getXCoord = (p: Point) => xScale(getDate(p));
-  const getYCoord = (p: Point) => yScale(Math.min(getY(p), capY));
+  const getYCoord = (p: Point) => yScale(Math.min(getYCaseDensity(p), capY));
 
   const regions = getChartRegions(yAxisMin, yAxisMax, zones);
   const yTicks = computeTickPositions(yAxisMin, yAxisMax, zones);
@@ -99,8 +101,12 @@ const ChartCaseDensity: FunctionComponent<{
       top={marginTop + getYCoord(p)}
       title={formatUtcDate(getDate(p), 'MMM D, YYYY')}
     >
+      <TooltipStyle.SubText>
+        {`Daily new cases`}
+        <div>{`${formatDecimal(getYNewCases(p), 1)} cases`}</div>
+      </TooltipStyle.SubText>
       <TooltipStyle.Body>
-        {`Daily new cases ${formatDecimal(getY(p), 1)}/100k`}
+        {`${formatDecimal(getYCaseDensity(p), 1)}/100k`}
       </TooltipStyle.Body>
     </Tooltip>
   );
@@ -109,7 +115,7 @@ const ChartCaseDensity: FunctionComponent<{
       cx={getXCoord(p)}
       cy={getYCoord(p)}
       r={6}
-      fill={getZoneByValue(getY(p), zones).color}
+      fill={getZoneByValue(getYCaseDensity(p), zones).color}
     />
   );
 
@@ -144,7 +150,7 @@ const ChartCaseDensity: FunctionComponent<{
           <BoxedAnnotation
             x={getXCoord(lastPoint) + 30}
             y={getYCoord(lastPoint)}
-            text={formatDecimal(getY(lastPoint), 1)}
+            text={formatDecimal(getYCaseDensity(lastPoint), 1)}
           />
         </Style.TextAnnotation>
       </RectClipGroup>

--- a/src/components/Charts/ChartCaseDensity.tsx
+++ b/src/components/Charts/ChartCaseDensity.tsx
@@ -100,13 +100,14 @@ const ChartCaseDensity: FunctionComponent<{
       left={marginLeft + getXCoord(p)}
       top={marginTop + getYCoord(p)}
       title={formatUtcDate(getDate(p), 'MMM D, YYYY')}
+      width={'150px'}
     >
-      <TooltipStyle.SubText>
-        {`Daily new cases`}
+      <TooltipStyle.Title>DAILY NEW CASES</TooltipStyle.Title>
+      <TooltipStyle.BodySmall>
         <div>{`${formatDecimal(getYNewCases(p), 1)} cases`}</div>
-      </TooltipStyle.SubText>
+      </TooltipStyle.BodySmall>
       <TooltipStyle.Body>
-        {`${formatDecimal(getYCaseDensity(p), 1)}/100k`}
+        {`${formatDecimal(getYCaseDensity(p), 1)} per 100k`}
       </TooltipStyle.Body>
     </Tooltip>
   );

--- a/src/components/Charts/Tooltip.style.ts
+++ b/src/components/Charts/Tooltip.style.ts
@@ -61,6 +61,11 @@ export const Body = styled.div`
   color: ${props => palette(props).tooltip.text};
 `;
 
+export const BodySmall = styled(Body)`
+  font-size: 11px;
+  color: ${props => palette(props).tooltip.textMuted};
+`;
+
 export const BodyMuted = styled(Body)`
   font-weight: 500;
   font-size: 11px;

--- a/src/components/Charts/Tooltip.tsx
+++ b/src/components/Charts/Tooltip.tsx
@@ -7,14 +7,16 @@ const Tooltip = ({
   top,
   children,
   subtext,
+  width,
 }: {
   left: number;
   top: number;
   title?: string;
   children?: React.ReactNode;
   subtext?: string;
+  width?: string;
 }) => (
-  <StyleTooltip.TooltipArrowDown style={{ top, left }}>
+  <StyleTooltip.TooltipArrowDown style={{ top, left, width: width }}>
     {title && <StyleTooltip.Title>{title}</StyleTooltip.Title>}
     {children}
     {subtext && <StyleTooltip.SubText>{subtext}</StyleTooltip.SubText>}


### PR DESCRIPTION
This PR enhances the tooltip on the "Daily new cases per 100k population" chart.
The tooltip now includes 7 day average new cases for a given day. 

(Addresses https://trello.com/c/O9nRsq19/358-implement-new-new-cases-tool-tip.)
![Screen Shot 2020-08-19 at 7 01 47 PM](https://user-images.githubusercontent.com/14878849/90698460-bf1e9380-e24e-11ea-88d7-e651d4c138b2.png)
