### PR TITLE
remove unused exports from metric files

### DIFF
--- a/src/common/metrics/case_density.tsx
+++ b/src/common/metrics/case_density.tsx
@@ -11,8 +11,6 @@ import {
 import ExternalLink from 'components/ExternalLink';
 import { MetricDefinition } from './interfaces';
 
-export const METRIC_NAME = 'Daily new cases per 100k population';
-
 export const CaseIncidenceMetric: MetricDefinition = {
   renderStatus,
   renderDisclaimer,
@@ -59,9 +57,7 @@ export const CASE_DENSITY_LEVEL_INFO_MAP: LevelInfoMap = {
   },
 };
 
-export const CASE_DENSITY_DISCLAIMER = '';
-
-export function renderStatus(projections: Projections): React.ReactElement {
+function renderStatus(projections: Projections): React.ReactElement {
   const {
     locationName,
     currentCaseDensity,
@@ -76,7 +72,7 @@ export function renderStatus(projections: Projections): React.ReactElement {
     return (
       <Fragment>
         Not enough case data is available to generate{' '}
-        {METRIC_NAME.toLowerCase()}.
+        {CaseIncidenceMetric.extendedMetricName.toLowerCase()}.
       </Fragment>
     );
   }

--- a/src/common/metrics/case_growth.tsx
+++ b/src/common/metrics/case_growth.tsx
@@ -8,7 +8,7 @@ import { Projections } from 'common/models/Projections';
 import { MetricDefinition } from './interfaces';
 import ExternalLink from 'components/ExternalLink';
 
-export const METRIC_NAME = 'Infection rate';
+const METRIC_NAME = 'Infection rate';
 
 export const CaseGrowthMetric: MetricDefinition = {
   renderStatus,
@@ -73,10 +73,7 @@ export const CASE_GROWTH_RATE_LEVEL_INFO_MAP: LevelInfoMap = {
   },
 };
 
-export const CASE_GROWTH_DISCLAIMER =
-  'Each data point is a 14-day weighted average. We present the most recent seven days of data as a dashed line, as data is often revised by states several days after reporting.';
-
-export function renderStatus(projections: Projections): React.ReactElement {
+function renderStatus(projections: Projections): React.ReactElement {
   const { locationName, rt } = projections.primary;
 
   if (rt === null) {

--- a/src/common/metrics/contact_tracing.tsx
+++ b/src/common/metrics/contact_tracing.tsx
@@ -9,7 +9,7 @@ import { TRACERS_NEEDED_PER_CASE } from 'common/models/Projection';
 import { MetricDefinition } from './interfaces';
 import ExternalLink from 'components/ExternalLink';
 
-export const METRIC_NAME = 'Tracers hired';
+const METRIC_NAME = 'Tracers hired';
 
 export const ContactTracingMetric: MetricDefinition = {
   renderStatus,
@@ -76,7 +76,7 @@ export const CONTACT_TRACING_LEVEL_INFO_MAP: LevelInfoMap = {
   },
 };
 
-export function renderStatus(projections: Projections): React.ReactElement {
+function renderStatus(projections: Projections): React.ReactElement {
   const {
     currentContactTracers,
     currentContactTracerMetric,
@@ -160,5 +160,3 @@ function renderDisclaimer(): React.ReactElement {
     </Fragment>
   );
 }
-
-export const CONTACT_TRACING_DISCLAIMER = `that at least 90% of contacts for each new case must be traced within 48 hours in order to contain COVID. Experts estimate that tracing each new case within 48 hours requires an average of ${TRACERS_NEEDED_PER_CASE} contact tracers per new case, as well as fast testing.`;

--- a/src/common/metrics/hospitalizations.tsx
+++ b/src/common/metrics/hospitalizations.tsx
@@ -9,7 +9,7 @@ import { NonCovidPatientsMethod } from 'common/models/ICUHeadroom';
 import { MetricDefinition } from './interfaces';
 import ExternalLink from '../../components/ExternalLink';
 
-export const METRIC_NAME = 'ICU headroom used';
+const METRIC_NAME = 'ICU headroom used';
 
 export const ICUHeadroomMetric: MetricDefinition = {
   renderStatus,
@@ -76,10 +76,7 @@ export const HOSPITAL_USAGE_LEVEL_INFO_MAP: LevelInfoMap = {
   },
 };
 
-export const HOSPITALIZATIONS_DISCLAIMER =
-  ', a pandemic think tank, recommends that hospitals maintain enough ICU capacity to double the number of COVID patients hospitalized.';
-
-export function renderStatus(projections: Projections): React.ReactElement {
+function renderStatus(projections: Projections): React.ReactElement {
   const icu = projections.primary.icuHeadroomInfo;
   const { locationName } = projections.primary;
 

--- a/src/common/metrics/positive_rate.tsx
+++ b/src/common/metrics/positive_rate.tsx
@@ -8,7 +8,7 @@ import { Projections } from 'common/models/Projections';
 import { MetricDefinition } from './interfaces';
 import ExternalLink from 'components/ExternalLink';
 
-export const METRIC_NAME = 'Positive test rate';
+const METRIC_NAME = 'Positive test rate';
 
 export const PositiveTestRateMetric: MetricDefinition = {
   renderStatus,
@@ -74,10 +74,7 @@ export const POSITIVE_TESTS_LEVEL_INFO_MAP: LevelInfoMap = {
   },
 };
 
-export const POSITIVE_RATE_DISCLAIMER =
-  'The World Health Organization recommends a positive test rate of less than 10%. The countries most successful in containing COVID have rates of 3% or less. We calculate the rate as a 7-day trailing average.';
-
-export function renderStatus(projections: Projections) {
+function renderStatus(projections: Projections) {
   const { currentTestPositiveRate, locationName } = projections.primary;
   if (currentTestPositiveRate === null) {
     return <Fragment>No testing data is available.</Fragment>;


### PR DESCRIPTION
Some more metrics cleanup - removing unused variables and exports.