### PR TITLE
Fix Escape Key Bug

### DIFF
--- a/src/components/MapSelectors/GlobalSelector.js
+++ b/src/components/MapSelectors/GlobalSelector.js
@@ -235,9 +235,11 @@ const GlobalSelector = ({ handleChange, extendRight }) => {
     }
   };
 
+  /*
+   * Downshift uses this state reducer function to close the menu when the escape key is pressed
+   * and executes default behavior for all other events.
+   */
   const escapeKeyStateReducer = (state, changes) => {
-    console.log(changes);
-
     switch (changes.type) {
       case Downshift.stateChangeTypes.keyDownEscape:
         return {

--- a/src/components/MapSelectors/GlobalSelector.js
+++ b/src/components/MapSelectors/GlobalSelector.js
@@ -235,10 +235,24 @@ const GlobalSelector = ({ handleChange, extendRight }) => {
     }
   };
 
+  const escapeKeyStateReducer = (state, changes) => {
+    console.log(changes);
+
+    switch (changes.type) {
+      case Downshift.stateChangeTypes.keyDownEscape:
+        return {
+          isOpen: false,
+        };
+      default:
+        return changes;
+    }
+  };
+
   return (
     <Downshift
       onChange={selection => handleChange(selection)}
       itemToString={item => (item ? item.value : '')}
+      stateReducer={escapeKeyStateReducer}
     >
       {({
         getInputProps,


### PR DESCRIPTION
This PR adds a stateReducer function to the Downshift element that captures the escape key event and overrides the default behavior and closes the menu.  The default behavior is to pass null the onChange callback, which was causing the error. 