### PR TITLE
add links to state and county maps

### DIFF
--- a/src/common/locations.ts
+++ b/src/common/locations.ts
@@ -1,6 +1,6 @@
 /** Helpers for dealing with the State / Counties dataset. */
 import US_STATE_DATASET from 'components/MapSelectors/datasets/us_states_dataset_01_02_2020.json';
-import { each, sortBy, takeRight } from 'lodash';
+import { each, sortBy, takeRight, find as _find } from 'lodash';
 import { assert } from './utils';
 import countyAdjacency from './data/county_adjacency_msa.json';
 
@@ -147,4 +147,12 @@ export function isStateFips(fips: string) {
 export function getAdjacentCounties(fips: string): string[] {
   assert(fips in ADJACENT_COUNTIES, `${fips} not found in adjacency list.`);
   return ADJACENT_COUNTIES[fips].adjacent_counties;
+}
+
+export function getCounty(stateId: string, fullFips: string) {
+  return _find(
+    // @ts-ignore: US_STATE_DATASET is .js, but this is valid
+    US_STATE_DATASET.state_county_map_dataset[stateId].county_dataset,
+    ['full_fips_code', fullFips],
+  );
 }

--- a/src/common/locations.ts
+++ b/src/common/locations.ts
@@ -1,6 +1,6 @@
 /** Helpers for dealing with the State / Counties dataset. */
 import US_STATE_DATASET from 'components/MapSelectors/datasets/us_states_dataset_01_02_2020.json';
-import { each, sortBy, takeRight, find as _find } from 'lodash';
+import { each, sortBy, takeRight } from 'lodash';
 import { assert } from './utils';
 import countyAdjacency from './data/county_adjacency_msa.json';
 
@@ -147,12 +147,4 @@ export function isStateFips(fips: string) {
 export function getAdjacentCounties(fips: string): string[] {
   assert(fips in ADJACENT_COUNTIES, `${fips} not found in adjacency list.`);
   return ADJACENT_COUNTIES[fips].adjacent_counties;
-}
-
-export function getCounty(stateId: string, fullFips: string) {
-  return _find(
-    // @ts-ignore: US_STATE_DATASET is .js, but this is valid
-    US_STATE_DATASET.state_county_map_dataset[stateId].county_dataset,
-    ['full_fips_code', fullFips],
-  );
 }

--- a/src/components/CountyMap/CountyMap.js
+++ b/src/components/CountyMap/CountyMap.js
@@ -9,7 +9,7 @@ import {
 import ReactTooltip from 'react-tooltip';
 import STATE_CENTERS from '../../common/us_state_centers';
 import { countyColor } from 'common/colors';
-import { getCounty } from 'common/locations';
+import { findCountyByFips } from 'common/locations';
 import { CountyMapWrapper, CountyMapLayerWrapper } from './CountyMap.style';
 
 const CountyMap = ({ selectedCounty, setSelectedCounty }) => {
@@ -55,7 +55,7 @@ const CountyMap = ({ selectedCounty, setSelectedCounty }) => {
           const isSelected =
             selectedCounty && selectedCounty.full_fips_code === geoFullFips;
 
-          const county = getCounty(stateId, geoFullFips);
+          const county = findCountyByFips(geoFullFips);
 
           return (
             <Link

--- a/src/components/CountyMap/CountyMap.js
+++ b/src/components/CountyMap/CountyMap.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams, Link } from 'react-router-dom';
 import {
   ComposableMap,
   Geographies,
@@ -9,6 +9,7 @@ import {
 import ReactTooltip from 'react-tooltip';
 import STATE_CENTERS from '../../common/us_state_centers';
 import { countyColor } from 'common/colors';
+import { getCounty } from 'common/locations';
 import { CountyMapWrapper, CountyMapLayerWrapper } from './CountyMap.style';
 
 const CountyMap = ({ selectedCounty, setSelectedCounty }) => {
@@ -17,6 +18,10 @@ const CountyMap = ({ selectedCounty, setSelectedCounty }) => {
   const state = STATE_CENTERS[stateId];
   const counties = require(`./countyTopoJson/${stateId}.json`);
   const [content, setContent] = useState('');
+
+  const onMouseLeave = () => {
+    setContent('');
+  };
 
   return (
     <CountyMapWrapper>
@@ -46,39 +51,47 @@ const CountyMap = ({ selectedCounty, setSelectedCounty }) => {
         state={state}
         counties={counties}
         geographyFactory={geo => {
+          const geoFullFips = geo.properties.GEOID;
           const isSelected =
-            selectedCounty &&
-            selectedCounty.full_fips_code === geo.properties.GEOID;
+            selectedCounty && selectedCounty.full_fips_code === geoFullFips;
+
+          const county = getCounty(stateId, geoFullFips);
+
           return (
-            <Geography
-              key={geo.rsmKey}
-              geography={geo}
-              // The fill is only used for hover
-              fill={'white'}
-              fillOpacity={0}
-              // The stroke is only used for selection.
-              strokeOpacity={isSelected ? 1 : 0}
-              stroke={'black'}
-              strokeWidth={3}
-              onMouseEnter={() => {
-                const { NAME } = geo.properties;
-                setContent(NAME);
-              }}
-              onMouseLeave={() => {
-                setContent('');
-              }}
-              onClick={() => setSelectedCounty(geo.properties.GEOID)}
-              style={{
-                cursor: 'pointer',
-                hover: {
-                  fillOpacity: '0.5',
-                  outline: 'none',
-                },
-                pressed: {
-                  outline: 'none',
-                },
-              }}
-            />
+            <Link
+              key={geoFullFips}
+              to={`/us/${stateId.toLowerCase()}/county/${
+                county.county_url_name
+              }`}
+            >
+              <Geography
+                key={geo.rsmKey}
+                geography={geo}
+                // The fill is only used for hover
+                fill={'white'}
+                fillOpacity={0}
+                // The stroke is only used for selection.
+                strokeOpacity={isSelected ? 1 : 0}
+                stroke={'black'}
+                strokeWidth={3}
+                onMouseEnter={() => {
+                  const { NAME } = geo.properties;
+                  setContent(NAME);
+                }}
+                onMouseLeave={onMouseLeave}
+                onClick={() => setSelectedCounty(geoFullFips)}
+                style={{
+                  cursor: 'pointer',
+                  hover: {
+                    fillOpacity: '0.5',
+                    outline: 'none',
+                  },
+                  pressed: {
+                    outline: 'none',
+                  },
+                }}
+              />
+            </Link>
           );
         }}
       />

--- a/src/components/Map/USACountyMap.js
+++ b/src/components/Map/USACountyMap.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import { ComposableMap, Geographies, Geography } from 'react-simple-maps';
 import { countyColor, stateColor } from 'common/colors';
 import { geoAlbersUsaTerritories } from 'geo-albers-usa-territories';
@@ -6,10 +7,14 @@ import STATES_JSON from './data/states-10m.json';
 import { USMapWrapper, USStateMapWrapper } from './Map.style';
 import { REVERSED_STATES } from 'common';
 
-const USACountyMap = ({ stateClickHandler, setTooltipContent, condensed }) => {
+function getStateCode(stateName) {
+  return REVERSED_STATES[stateName];
+}
+
+const USACountyMap = ({ setTooltipContent, condensed }) => {
   const getFillColor = geo => {
     if (geo.id.length <= 2) {
-      const stateCode = REVERSED_STATES[geo.properties.name];
+      const stateCode = getStateCode(geo.properties.name);
       return stateCode && stateColor(stateCode);
     } else {
       return countyColor(geo.id);
@@ -20,28 +25,33 @@ const USACountyMap = ({ stateClickHandler, setTooltipContent, condensed }) => {
     .scale(1000)
     .translate([400, 300]);
 
+  const onMouseLeave = () => {
+    setTooltipContent('');
+  };
+
   return (
     <USMapWrapper condensed={condensed}>
       {/** Map with shaded background colors for states. */}
       <USStateMapWrapper>
-        <ComposableMap data-tip="" projection={projection} stroke="white">
+        <ComposableMap data-tip="" projection={projection}>
           <Geographies geography={STATES_JSON}>
             {({ geographies }) =>
               geographies.map(geo => {
                 const { name } = geo.properties;
-                return REVERSED_STATES[name] ? (
-                  <Geography
-                    key={geo.rsmKey}
-                    geography={geo}
-                    onClick={() => stateClickHandler(name)}
-                    onMouseEnter={() => {
-                      setTooltipContent(name);
-                    }}
-                    onMouseLeave={() => {
-                      setTooltipContent('');
-                    }}
-                    fill={getFillColor(geo)}
-                  />
+                const stateCode = getStateCode(name);
+                return stateCode ? (
+                  <Link key={stateCode} to={`/us/${stateCode.toLowerCase()}`}>
+                    <Geography
+                      key={geo.rsmKey}
+                      geography={geo}
+                      onMouseEnter={() => {
+                        setTooltipContent(name);
+                      }}
+                      onMouseLeave={onMouseLeave}
+                      fill={getFillColor(geo)}
+                      stroke="white"
+                    />
+                  </Link>
                 ) : null;
               })
             }

--- a/src/components/MiniMap/MiniMap.tsx
+++ b/src/components/MiniMap/MiniMap.tsx
@@ -1,10 +1,7 @@
 import React, { FunctionComponent } from 'react';
-import { useHistory } from 'react-router-dom';
-import { find as _find } from 'lodash';
 import Map from 'components/Map/Map';
 import CountyMap from 'components/CountyMap/CountyMap';
 import { MAP_FILTERS } from 'screens/LocationPage/Enums/MapFilterEnums';
-import US_STATE_DATASET from '../MapSelectors/datasets/us_states_dataset_01_02_2020.json';
 import { Projections } from 'common/models/Projections';
 import * as Styles from './MiniMap.style';
 
@@ -18,13 +15,6 @@ interface MiniMapProperties {
   mapOption: string;
   setMapOption: (input: string) => {};
 }
-
-const getCounty = (stateId: string, fullFips: string) =>
-  _find(
-    // @ts-ignore: US_STATE_DATASET is .js, but this is valid
-    US_STATE_DATASET.state_county_map_dataset[stateId].county_dataset,
-    ['full_fips_code', fullFips],
-  );
 
 /**
  * TODO(sgoldblatt): Don't pass in the setState vars here and use a provider
@@ -40,21 +30,11 @@ const MiniMap: FunctionComponent<MiniMapProperties> = ({
   mapOption,
   setMapOption,
 }) => {
-  const history = useHistory();
-
-  const goTo = (route: string) => {
-    history.push(route);
-  };
-
   const showState = stateId !== MAP_FILTERS.DC;
-
   const { stateName } = projections;
 
   const onSelectCounty = (fullFips: string) => {
-    const county = getCounty(stateId, fullFips);
     setMobileMenuOpen(false);
-    setSelectedCounty(county);
-    goTo(`/us/${stateId.toLowerCase()}/county/${county.county_url_name}`);
   };
 
   return (


### PR DESCRIPTION
This PR changes how we do navigation when clicking on locations on the map. In production, we pushed the new URL to the [`history`](https://reactrouter.com/web/api/history). 

This PR replaces navigation for the maps with the [`Link`](https://reactrouter.com/web/api/Link) component in order to allow opening links on a new tab, using the contextual menu to copy the link address, among others. If we go with this solution, we need to also replace links on:
- Compare table
- Top navigation bar
- Footer

but we can do that on a separate PR.


