### PR TITLE
update copy for covid response simulator section

### DIFF
--- a/src/screens/Resources/Resources.tsx
+++ b/src/screens/Resources/Resources.tsx
@@ -57,6 +57,13 @@ const Resources = ({ children }: { children: React.ReactNode }) => {
             COVID Response Simulator
           </SectionHeader>
           <Typography variant="body1" component="p">
+            Try it{' '}
+            <ExternalLink href="https://docs.google.com/spreadsheets/u/3/d/1PTBTp8z49IXexkV02wacWLoyv1A2GtlVFYVqI4APPR8/copy#gid=1190280212">
+              here
+            </ExternalLink>
+            .
+          </Typography>
+          <Typography variant="body1" component="p">
             The COVID Response Simulator is a localized, spreadsheet version of
             the public Covid Act Now (CAN) model. With it, you can take a
             powerful{' '}


### PR DESCRIPTION
Debbie surfaced that the actual link to the COVID Response Simulator is buried under a lot of content, this PR adds a direct link under the title to make it more obvious.