### PR TITLE
feedback survey: add banner with tracking links

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@types/d3-array": "^2.0.0",
     "@types/d3-shape": "^1.3.2",
     "@types/d3-time": "^1.0.10",
+    "@types/uuid": "^8.3.0",
     "@vx/axis": "^0.0.196",
     "@vx/clip-path": "^0.0.196",
     "@vx/curve": "^0.0.196",
@@ -47,7 +48,8 @@
     "react-tooltip": "^4.1.2",
     "sharp": "^0.25.2",
     "styled-components": "^5.0.1",
-    "tar": "^6.0.1"
+    "tar": "^6.0.1",
+    "uuid": "^8.3.0"
   },
   "scripts": {
     "start": "cross-env TSC_COMPILE_ON_ERROR=false react-scripts -r @cypress/instrument-cra start",

--- a/src/App.js
+++ b/src/App.js
@@ -25,6 +25,7 @@ import AppBar from 'components/AppBar/AppBar';
 import Footer from 'components/Footer/Footer';
 import ScrollToTop from 'components/ScrollToTop';
 import theme from 'assets/theme';
+import { RedirectToFeedbackSurvey } from 'components/Banner';
 
 export default function App() {
   return (
@@ -106,6 +107,15 @@ export default function App() {
               <Route path="/contact">
                 <Redirect to="/faq" />
               </Route>
+              {/**
+               * This endpoint is to share the feedback survey link in social
+               * media. We redirec them to Typeform with URL parameters to
+               * track users through the survey, as well as their source.
+               */}
+              <Route
+                path="feedback-survery"
+                component={() => <RedirectToFeedbackSurvey source="social" />}
+              />
 
               {/** Internal endpoint that shows all the state charts. */}
               <Route path="/all">

--- a/src/App.js
+++ b/src/App.js
@@ -113,7 +113,7 @@ export default function App() {
                * track users through the survey, as well as their source.
                */}
               <Route
-                path="/feedback-survery"
+                path="/feedback-survey"
                 component={() => <RedirectToFeedbackSurvey source="social" />}
               />
 

--- a/src/App.js
+++ b/src/App.js
@@ -113,7 +113,7 @@ export default function App() {
                * track users through the survey, as well as their source.
                */}
               <Route
-                path="feedback-survery"
+                path="/feedback-survery"
                 component={() => <RedirectToFeedbackSurvey source="social" />}
               />
 

--- a/src/components/Banner/FeedbackSurveyBanner.tsx
+++ b/src/components/Banner/FeedbackSurveyBanner.tsx
@@ -7,7 +7,7 @@ import ExternalLink from 'components/ExternalLink';
 const FEEDBACK_SURVEY_URL = 'https://can386399.typeform.com/to/fCLv9bzl';
 
 export function getFeedbackSurveyUrl(source: string) {
-  return `${FEEDBACK_SURVEY_URL}#source=${source}&${uuidv4()}`;
+  return `${FEEDBACK_SURVEY_URL}#source=${source}&id=${uuidv4()}`;
 }
 
 const renderButton = () => (

--- a/src/components/Banner/FeedbackSurveyBanner.tsx
+++ b/src/components/Banner/FeedbackSurveyBanner.tsx
@@ -1,13 +1,17 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 import Banner from './Banner';
 import { SurveyButton } from './Banner.style';
 import ExternalLink from 'components/ExternalLink';
 
+const FEEDBACK_SURVEY_URL = 'https://can386399.typeform.com/to/fCLv9bzl';
+
+export function getFeedbackSurveyUrl(source: string) {
+  return `${FEEDBACK_SURVEY_URL}#source=${source}&${uuidv4()}`;
+}
+
 const renderButton = () => (
-  <ExternalLink
-    href={`https://can386399.typeform.com/to/fCLv9bzl#source=test&id=${uuidv4()}`}
-  >
+  <ExternalLink href={getFeedbackSurveyUrl('org')}>
     <SurveyButton
       variant="contained"
       color="primary"
@@ -26,5 +30,14 @@ const MESSAGE = `We’re a team of volunteers working to provide you with
 const FeedbackSurveyBanner: React.FC = () => (
   <Banner message={MESSAGE} renderButton={renderButton} />
 );
+
+export const RedirectToFeedbackSurvey: React.FC<{ source: string }> = ({
+  source,
+}) => {
+  useEffect(() => {
+    window.location.href = getFeedbackSurveyUrl(source);
+  }, [source]);
+  return null;
+};
 
 export default FeedbackSurveyBanner;

--- a/src/components/Banner/FeedbackSurveyBanner.tsx
+++ b/src/components/Banner/FeedbackSurveyBanner.tsx
@@ -1,10 +1,13 @@
 import React from 'react';
+import { v4 as uuidv4 } from 'uuid';
 import Banner from './Banner';
 import { SurveyButton } from './Banner.style';
-import ExternalLink from '../ExternalLink';
+import ExternalLink from 'components/ExternalLink';
 
 const renderButton = () => (
-  <ExternalLink href="https://can386399.typeform.com/to/fCLv9bzl#source=org">
+  <ExternalLink
+    href={`https://can386399.typeform.com/to/fCLv9bzl#source=org&id=${uuidv4()}`}
+  >
     <SurveyButton
       variant="contained"
       color="primary"

--- a/src/components/Banner/FeedbackSurveyBanner.tsx
+++ b/src/components/Banner/FeedbackSurveyBanner.tsx
@@ -6,7 +6,7 @@ import ExternalLink from 'components/ExternalLink';
 
 const renderButton = () => (
   <ExternalLink
-    href={`https://can386399.typeform.com/to/fCLv9bzl#source=org&id=${uuidv4()}`}
+    href={`https://can386399.typeform.com/to/fCLv9bzl#source=test&id=${uuidv4()}`}
   >
     <SurveyButton
       variant="contained"

--- a/src/components/Banner/index.ts
+++ b/src/components/Banner/index.ts
@@ -1,5 +1,7 @@
 import Banner from './Banner';
-import FeedbackSurveyBanner from './FeedbackSurveyBanner';
+import FeedbackSurveyBanner, {
+  RedirectToFeedbackSurvey,
+} from './FeedbackSurveyBanner';
 
 export default Banner;
-export { FeedbackSurveyBanner };
+export { FeedbackSurveyBanner, RedirectToFeedbackSurvey };

--- a/src/screens/HomePage/HomePage.js
+++ b/src/screens/HomePage/HomePage.js
@@ -21,9 +21,11 @@ import {
   PartnerHeader,
   SearchBarThermometerWrapper,
   SectionWrapper,
+  BannerContainer,
 } from './HomePage.style';
 import { SelectorWrapper } from 'components/Header/HomePageHeader.style';
 import CompareMain from 'components/Compare/CompareMain';
+import { FeedbackSurveyBanner } from 'components/Banner';
 
 export default function HomePage() {
   const shareBlockRef = useRef(null);
@@ -73,6 +75,9 @@ export default function HomePage() {
         pageTitle={undefined}
         pageDescription="Real-time modeling and metrics to understand where we stand against COVID. 50 states. 3,000+ counties. Click the map to dive in"
       />
+      <BannerContainer>
+        <FeedbackSurveyBanner />
+      </BannerContainer>
       <HomePageHeader
         indicatorsLinkOnClick={() => scrollTo(indicatorsRef.current)}
       />

--- a/yarn.lock
+++ b/yarn.lock
@@ -2608,6 +2608,11 @@
   resolved "https://registry.yarnpkg.com/@types/url-join/-/url-join-4.0.0.tgz#72eff71648a429c7d4acf94e03780e06671369bd"
   integrity sha512-awrJu8yML4E/xTwr2EMatC+HBnHGoDxc2+ImA9QyeUELI1S7dOCIZcyjki1rkwoA8P2D2NVgLAJLjnclkdLtAw==
 
+"@types/uuid@^8.3.0":
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.0.tgz#215c231dff736d5ba92410e6d602050cce7e273f"
+  integrity sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ==
+
 "@types/yargs-parser@*":
   version "15.0.0"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-15.0.0.tgz#cb3f9f741869e20cce330ffbeb9271590483882d"
@@ -15563,7 +15568,7 @@ uuid@^7.0.0, uuid@^7.0.3:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-7.0.3.tgz#c5c9f2c8cf25dc0a372c4df1441c41f5bd0c680b"
   integrity sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==
 
-uuid@^8.0.0:
+uuid@^8.0.0, uuid@^8.3.0:
   version "8.3.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.0.tgz#ab738085ca22dc9a8c92725e459b1d507df5d6ea"
   integrity sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ==


### PR DESCRIPTION
- Adds the feedback survey banner in the homepage
- It attaches a random ID to the Typeform URL, so we can track which responses belong to the same individual (we need this to link the first part of the feedback form to demographics, which are in the 3rd part of the survey)
- Adds a redirect so we can track users coming from social media with a unique ID as well. The link shared in social will be `https://covidactnow.org/feedback-survey`, upon clicking, the user will be redirected to the Typeform URL with `source=social&id={UNIQUE_ID}`