### PR TITLE
add redirect to track clicks to the covid response simulator

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -11,7 +11,9 @@ import LocationPage from 'screens/LocationPage/LocationPage';
 import HomePage from 'screens/HomePage/HomePage';
 import About from 'screens/About/About';
 // import ComingSoon from 'screens/ComingSoon/ComingSoon';
-import Resources from 'screens/Resources/Resources';
+import Resources, {
+  COVID_RESPONSE_SIMULATOR_URL,
+} from 'screens/Resources/Resources';
 import Contact from 'screens/Contact/Contact';
 import Terms from 'screens/Terms/Terms';
 import Privacy from 'screens/Terms/Privacy';
@@ -25,7 +27,8 @@ import AppBar from 'components/AppBar/AppBar';
 import Footer from 'components/Footer/Footer';
 import ScrollToTop from 'components/ScrollToTop';
 import theme from 'assets/theme';
-import { RedirectToFeedbackSurvey } from 'components/Banner';
+import { getFeedbackSurveyUrl } from 'components/Banner';
+import ExternalRedirect from 'components/ExternalRedirect';
 
 export default function App() {
   return (
@@ -114,7 +117,24 @@ export default function App() {
                */}
               <Route
                 path="/feedback-survey"
-                component={() => <RedirectToFeedbackSurvey source="social" />}
+                component={() => (
+                  <ExternalRedirect url={getFeedbackSurveyUrl('social')} />
+                )}
+              />
+
+              {/**
+               * This endpoint is to be able to track clicks to the COVID
+               * Response Simulator on the resources page. The user will be briefly
+               * redirected to COVID_RESPONSE_SIMULATOR_REDIRECT_URL and then
+               * to the spreadsheet. The number of visits to the redirect URL
+               * will correspond to the number of clicks to the COVID Response
+               * Simulator.
+               */}
+              <Route
+                path="/covid-response-simulator-redirect"
+                component={() => (
+                  <ExternalRedirect url={COVID_RESPONSE_SIMULATOR_URL} />
+                )}
               />
 
               {/** Internal endpoint that shows all the state charts. */}

--- a/src/components/Banner/FeedbackSurveyBanner.tsx
+++ b/src/components/Banner/FeedbackSurveyBanner.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { v4 as uuidv4 } from 'uuid';
 import Banner from './Banner';
 import { SurveyButton } from './Banner.style';
@@ -30,14 +30,5 @@ const MESSAGE = `We’re a team of volunteers working to provide you with
 const FeedbackSurveyBanner: React.FC = () => (
   <Banner message={MESSAGE} renderButton={renderButton} />
 );
-
-export const RedirectToFeedbackSurvey: React.FC<{ source: string }> = ({
-  source,
-}) => {
-  useEffect(() => {
-    window.location.href = getFeedbackSurveyUrl(source);
-  }, [source]);
-  return null;
-};
 
 export default FeedbackSurveyBanner;

--- a/src/components/Banner/index.ts
+++ b/src/components/Banner/index.ts
@@ -1,7 +1,7 @@
 import Banner from './Banner';
 import FeedbackSurveyBanner, {
-  RedirectToFeedbackSurvey,
+  getFeedbackSurveyUrl,
 } from './FeedbackSurveyBanner';
 
 export default Banner;
-export { FeedbackSurveyBanner, RedirectToFeedbackSurvey };
+export { FeedbackSurveyBanner, getFeedbackSurveyUrl };

--- a/src/components/ExternalRedirect/ExternalRedirect.tsx
+++ b/src/components/ExternalRedirect/ExternalRedirect.tsx
@@ -1,0 +1,13 @@
+import React, { useEffect } from 'react';
+
+/**
+ * This component redirects the user to the provided external URL.
+ */
+const ExternalRedirect: React.FC<{ url: string }> = ({ url }) => {
+  useEffect(() => {
+    window.location.href = url;
+  }, [url]);
+  return null;
+};
+
+export default ExternalRedirect;

--- a/src/components/ExternalRedirect/index.ts
+++ b/src/components/ExternalRedirect/index.ts
@@ -1,0 +1,3 @@
+import ExternalRedirect from './ExternalRedirect';
+
+export default ExternalRedirect;

--- a/src/screens/Resources/Resources.tsx
+++ b/src/screens/Resources/Resources.tsx
@@ -20,6 +20,9 @@ import {
   ImageContainer,
 } from './Resources.style';
 
+export const COVID_RESPONSE_SIMULATOR_URL =
+  'https://docs.google.com/spreadsheets/u/3/d/1PTBTp8z49IXexkV02wacWLoyv1A2GtlVFYVqI4APPR8/copy#gid=1190280212';
+
 const sidebar = (
   <React.Fragment>
     <SidebarLink href="#covid-response-simulator">
@@ -58,7 +61,7 @@ const Resources = ({ children }: { children: React.ReactNode }) => {
           </SectionHeader>
           <Typography variant="body1" component="p">
             Try it{' '}
-            <ExternalLink href="https://docs.google.com/spreadsheets/u/3/d/1PTBTp8z49IXexkV02wacWLoyv1A2GtlVFYVqI4APPR8/copy#gid=1190280212">
+            <ExternalLink href="/covid-response-simulator-redirect">
               here
             </ExternalLink>
             .
@@ -132,7 +135,7 @@ const Resources = ({ children }: { children: React.ReactNode }) => {
               <li>
                 <Typography variant="body1" component="p">
                   Click on{' '}
-                  <ExternalLink href="https://docs.google.com/spreadsheets/u/3/d/1PTBTp8z49IXexkV02wacWLoyv1A2GtlVFYVqI4APPR8/copy#gid=1190280212">
+                  <ExternalLink href="/covid-response-simulator-redirect">
                     this link
                   </ExternalLink>{' '}
                   to create a copy of the simulator for your use. You’ll be


### PR DESCRIPTION
We want to track clicks to the COVID Response Simulator. Since Google Analytics already tracks page views for all our pages, one way to track clicks is to replace the URL of the CRS with an internal link to `/covid-response-simulator-redirect` and configure the router to redirect visits to  `/covid-response-simulator-redirect` to the actual CRS URL.

The `Redirect` component from `react-router-dom` only redirects to pages within the application, so I implemented a component to hide the implementation details of the external redirect. 