### PR TITLE
explore: update the date marker to show relative time in weeks and days

### DIFF
--- a/src/components/Explore/Explore.style.ts
+++ b/src/components/Explore/Explore.style.ts
@@ -157,7 +157,7 @@ export const DateMarker = styled.div`
   transform: translate(-50%, 100%);
   /* TODO(pablo): Use theme */
   background-color: white;
-  width: 140px;
+  width: 180px;
   box-shadow: 0px 1px 6px rgba(0, 0, 0, 0.15);
   border-radius: 20px;
   padding: ${theme.spacing(1) / 2}px ${theme.spacing(2)}px;

--- a/src/components/Explore/ExploreChart.tsx
+++ b/src/components/Explore/ExploreChart.tsx
@@ -13,7 +13,7 @@ import { Tooltip, RectClipGroup } from 'components/Charts';
 import { Series } from './interfaces';
 import SeriesChart, { SeriesMarker } from './SeriesChart';
 import ChartOverlay from './ChartOverlay';
-import { getMaxBy, getTimeAxisTicks, findPointByDate } from './utils';
+import { getMaxBy, getTimeAxisTicks, findPointByDate, weeksAgo } from './utils';
 import * as Styles from './Explore.style';
 import { COLOR_MAP } from 'common/colors';
 
@@ -22,11 +22,14 @@ const getY = (d: Column) => d.y;
 const daysBetween = (dateFrom: Date, dateTo: Date) =>
   moment(dateTo).diff(dateFrom, 'days');
 
-const DateMarker: React.FC<{ left: number; date: Date }> = ({ left, date }) => (
-  <Styles.DateMarker style={{ left }}>
-    {moment(date).fromNow()}
-  </Styles.DateMarker>
-);
+const DateMarker: React.FC<{ left: number; date: Date }> = ({ left, date }) => {
+  // Do not show the date marker for dates in the future
+  return new Date() < date ? null : (
+    <Styles.DateMarker style={{ left }}>
+      {weeksAgo(date, new Date())}
+    </Styles.DateMarker>
+  );
+};
 
 const ExploreTooltip: React.FC<{
   date: Date;

--- a/src/components/Explore/utils.ts
+++ b/src/components/Explore/utils.ts
@@ -227,26 +227,28 @@ export function getSocialQuote(fips: string, metric: ExploreMetric) {
   return '';
 }
 
-function pluralize(num: number, singular: string, plural: string) {
-  return num === 1 ? singular : plural;
-}
+const pluralize = (num: number, singular: string, plural: string) =>
+  num === 1 ? singular : plural;
 
 const pluralizeWeeks = (num: number) => pluralize(num, 'week', 'weeks');
 const pluralizeDays = (num: number) => pluralize(num, 'day', 'days');
 
+/**
+ * Returns the relative time between two dates in days and weeks, for example:
+ * today, 1 day ago, 5 days ago, 3 weeks and 2 days ago, 5 weeks ago, etc.
+ */
 export function weeksAgo(dateFrom: Date, dateTo: Date) {
-  const numDays = moment(dateTo).diff(dateFrom, 'days');
-  const numWeeks = Math.floor(numDays / 7);
-  const reminderDays = numDays % 7;
+  const totalDays = moment(dateTo).diff(dateFrom, 'days');
+  const totalWeeks = Math.floor(totalDays / 7);
+  const numDays = totalDays % 7;
 
-  if (numDays < 7) {
-    return numDays === 0 ? 'today' : `${numDays} ${pluralizeDays(numDays)} ago`;
+  if (totalDays < 7) {
+    return totalDays === 0
+      ? 'today'
+      : `${totalDays} ${pluralizeDays(totalDays)} ago`;
   } else {
-    const weeksAgo = `${numWeeks} ${pluralizeWeeks(numWeeks)}`;
-    const daysAgo =
-      reminderDays > 0
-        ? `, ${reminderDays} ${pluralizeDays(reminderDays)}`
-        : '';
+    const weeksAgo = `${totalWeeks} ${pluralizeWeeks(totalWeeks)}`;
+    const daysAgo = numDays > 0 ? `, ${numDays} ${pluralizeDays(numDays)}` : '';
     return `${weeksAgo} ${daysAgo} ago`;
   }
 }

--- a/src/components/Explore/utils.ts
+++ b/src/components/Explore/utils.ts
@@ -226,3 +226,27 @@ export function getSocialQuote(fips: string, metric: ExploreMetric) {
   }
   return '';
 }
+
+function pluralize(num: number, singular: string, plural: string) {
+  return num === 1 ? singular : plural;
+}
+
+const pluralizeWeeks = (num: number) => pluralize(num, 'week', 'weeks');
+const pluralizeDays = (num: number) => pluralize(num, 'day', 'days');
+
+export function weeksAgo(dateFrom: Date, dateTo: Date) {
+  const numDays = moment(dateTo).diff(dateFrom, 'days');
+  const numWeeks = Math.floor(numDays / 7);
+  const reminderDays = numDays % 7;
+
+  if (numDays < 7) {
+    return numDays === 0 ? 'today' : `${numDays} ${pluralizeDays(numDays)} ago`;
+  } else {
+    const weeksAgo = `${numWeeks} ${pluralizeWeeks(numWeeks)}`;
+    const daysAgo =
+      reminderDays > 0
+        ? `, ${reminderDays} ${pluralizeDays(reminderDays)}`
+        : '';
+    return `${weeksAgo} ${daysAgo} ago`;
+  }
+}


### PR DESCRIPTION
This PR changes the format of the date marker to show weeks and days ago instead of the default from `moment().fromNow()`.

![image](https://user-images.githubusercontent.com/114084/91671889-45549880-eadf-11ea-93eb-9ab6b47538f8.png)

- Changes the format of the date marker to weeks and days ago.
- Do not show the marker for dates in the future.

### Notes
- The last points are missing, I'm going to fix that on a separate PR.