### PR TITLE
explore: change curve type to show the first and last points

### DIFF
--- a/src/components/Explore/SeriesChart.tsx
+++ b/src/components/Explore/SeriesChart.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent } from 'react';
-import { curveCardinalOpen } from '@vx/curve';
+import { curveCardinal } from '@vx/curve';
 import { LinePath } from '@vx/shape';
 import * as Styles from './Explore.style';
 import { ChartType } from './interfaces';
@@ -20,7 +20,7 @@ const SeriesChart: FunctionComponent<{
     case ChartType.LINE:
       return (
         <Styles.MainSeriesLine>
-          <LinePath data={data} x={x} y={y} curve={curveCardinalOpen} />
+          <LinePath data={data} x={x} y={y} curve={curveCardinal} />
         </Styles.MainSeriesLine>
       );
     case ChartType.BAR:


### PR DESCRIPTION
This PR changes the curve type for the smoothed series in the explore chart. The type of curve we were using, `curveCardinalOpen` doesn't show the first and last point, here we are using `curveCardinal` which doesn't have this problem (See https://github.com/d3/d3-shape#curves).