### PR TITLE
explore: add the smoothed series to the tooltip

### DIFF
--- a/src/components/Explore/Explore.style.ts
+++ b/src/components/Explore/Explore.style.ts
@@ -195,14 +195,15 @@ export const TooltipMetric = styled.div`
   font-weight: bold;
   font-size: 15px;
   line-height: 19px;
-  color: #ffffff;
+  color: ${colorPalette.white};
 `;
 
 export const TooltipLocation = styled.div`
+  margin-top: ${theme.spacing(1) / 2}px;
   font-family: Roboto;
   font-style: normal;
   font-weight: 500;
   font-size: 11px;
   line-height: 13px;
-  color: #ffffff;
+  color: ${colorPalette.white};
 `;

--- a/src/components/Explore/ExploreChart.tsx
+++ b/src/components/Explore/ExploreChart.tsx
@@ -41,12 +41,16 @@ const ExploreTooltip: React.FC<{
 
   return pointSmooth && pointRaw ? (
     <Tooltip
+      width={'150px'}
       top={top(pointSmooth)}
       left={left(pointSmooth)}
       title={moment(date).format('MMM D, YYYY')}
     >
       <Styles.TooltipSubtitle>{seriesRaw.tooltipLabel}</Styles.TooltipSubtitle>
       <Styles.TooltipMetric>{formatInteger(pointRaw.y)}</Styles.TooltipMetric>
+      <Styles.TooltipSubtitle>{`avg ${formatInteger(
+        pointSmooth.y,
+      )}`}</Styles.TooltipSubtitle>
       <Styles.TooltipLocation>{subtext}</Styles.TooltipLocation>
     </Tooltip>
   ) : null;


### PR DESCRIPTION
This PR updates the tooltip to include both the smoothed value and the raw value for the series. I also adjusted the width of the tooltip to make it narrower.

<img src="https://user-images.githubusercontent.com/114084/91672600-5653d880-eae4-11ea-8fb9-7f236a20f46e.png" width="400" />


