### PR TITLE
Website tweaks to enable dynamic screenshot generation.

### DIFF
--- a/src/common/colors.js
+++ b/src/common/colors.js
@@ -45,9 +45,16 @@ export const LEVEL_COLOR = {
   [Level.UNKNOWN]: COLOR_MAP.GRAY.BASE,
 };
 
+export function colorFromLocationSummary(
+  summary,
+  defaultColor = COLOR_MAP.GRAY_LIGHT,
+) {
+  return summary ? LEVEL_COLOR[summary.level] : defaultColor;
+}
+
 export function stateColor(stateCode) {
   const summary = stateSummary(stateCode);
-  return summary ? LEVEL_COLOR[summary.level] : COLOR_MAP.GRAY.LIGHT;
+  return colorFromLocationSummary(summary);
 }
 
 export function countyColor(
@@ -55,7 +62,7 @@ export function countyColor(
   defaultColor = COLOR_MAP.GRAY.LIGHT,
 ) {
   const summary = countySummary(countyFipsCode);
-  return summary ? LEVEL_COLOR[summary.level] : defaultColor;
+  return colorFromLocationSummary(summary, defaultColor);
 }
 
 export const LEVEL_COLOR_CONTACT_TRACING = {

--- a/src/common/location_summaries.ts
+++ b/src/common/location_summaries.ts
@@ -1,9 +1,10 @@
+import { useState, useEffect } from 'react';
 import fetch from 'node-fetch';
 import { Level } from 'common/level';
 import { Metric } from 'common/metric';
 import LocationSummariesJSON from 'assets/data/summaries.json';
 import { findStateFipsCode } from 'common/locations';
-import { currentSnapshot } from './utils/snapshots';
+import { currentSnapshot, getSnapshotOverride } from './utils/snapshots';
 
 export interface MetricSummary {
   value: number | null;
@@ -46,4 +47,27 @@ export async function fetchSummaries(snapshotNumber: number) {
     const json = await response.json();
     return json as SummariesMap;
   }
+}
+
+export function useSummaries(): SummariesMap | null {
+  const [summaries, setSummaries] = useState<SummariesMap | null>(null);
+
+  useEffect(() => {
+    async function fetch() {
+      const snapshot = getSnapshotOverride() || currentSnapshot();
+      let summaries;
+      try {
+        summaries = await fetchSummaries(snapshot);
+      } catch {
+        console.error(
+          `Failed to fetch summaries for snapshot ${snapshot}. Using compiled-in summaries.`,
+        );
+        summaries = LocationSummariesByFIPS;
+      }
+      setSummaries(summaries);
+    }
+    fetch();
+  });
+
+  return summaries;
 }

--- a/src/common/utils/model.ts
+++ b/src/common/utils/model.ts
@@ -10,6 +10,7 @@ import { findCountyByFips } from 'common/locations';
 import moment from 'moment';
 import { RegionSummaryWithTimeseries } from 'api/schema/RegionSummaryWithTimeseries';
 import { assert } from '.';
+import { getSnapshotUrlOverride } from './snapshots';
 
 const cachedProjections: { [key: string]: Promise<Projections> } = {};
 export function fetchProjections(
@@ -17,6 +18,7 @@ export function fetchProjections(
   countyInfo: any = null,
   snapshotUrl: string | null = null,
 ) {
+  snapshotUrl = snapshotUrl || getSnapshotUrlOverride();
   let region: RegionDescriptor;
   if (countyInfo) {
     region = RegionDescriptor.forCounty(countyInfo.full_fips_code);
@@ -43,6 +45,7 @@ export function fetchProjections(
 /** Returns an array of `Projections` instances for all states. */
 const cachedStatesProjections: { [key: string]: Promise<Projections[]> } = {};
 export function fetchAllStateProjections(snapshotUrl: string | null = null) {
+  snapshotUrl = snapshotUrl || getSnapshotUrlOverride();
   async function fetch() {
     const all = await new Api(snapshotUrl).fetchAggregatedSummaryWithTimeseries(
       RegionAggregateDescriptor.STATES,
@@ -66,6 +69,7 @@ export function fetchAllStateProjections(snapshotUrl: string | null = null) {
 /** Returns an array of `Projections` instances for all counties. */
 const cachedCountiesProjections: { [key: string]: Promise<Projections[]> } = {};
 export function fetchAllCountyProjections(snapshotUrl: string | null = null) {
+  snapshotUrl = snapshotUrl || getSnapshotUrlOverride();
   async function fetch() {
     const all = await new Api(snapshotUrl).fetchAggregatedSummaryWithTimeseries(
       RegionAggregateDescriptor.COUNTIES,

--- a/src/common/utils/snapshots.ts
+++ b/src/common/utils/snapshots.ts
@@ -1,3 +1,4 @@
+import * as QueryString from 'query-string';
 import { assert } from 'common/utils';
 import DataUrlJson from 'assets/data/data_url.json';
 
@@ -24,4 +25,27 @@ export function snapshotUrl(snapshotNum: string | number) {
 
 export function currentSnapshot(): number {
   return snapshotFromUrl(SNAPSHOT_URL);
+}
+
+/** Checks for ?snapshot=xyz in the querystring and returns it as a number. */
+export function getSnapshotOverride(): number | null {
+  if (typeof window !== 'undefined') {
+    const search = window?.location?.search;
+    if (search !== undefined) {
+      const params = QueryString.parse(search);
+      if ('snapshot' in params) {
+        const snapshot = Number(params['snapshot']);
+        if (snapshot !== Number.NaN && snapshot !== 0) {
+          return snapshot;
+        }
+      }
+    }
+  }
+  return null;
+}
+
+/** Checks for ?snapshot=xyz in the querystring and returns the corresponding snapshot URL. */
+export function getSnapshotUrlOverride(): string | null {
+  const override = getSnapshotOverride();
+  return override === null ? null : snapshotUrl(override);
 }

--- a/src/common/utils/snapshots.ts
+++ b/src/common/utils/snapshots.ts
@@ -32,12 +32,10 @@ export function getSnapshotOverride(): number | null {
   if (typeof window !== 'undefined') {
     const search = window?.location?.search;
     if (search !== undefined) {
-      const params = QueryString.parse(search);
-      if ('snapshot' in params) {
-        const snapshot = Number(params['snapshot']);
-        if (snapshot !== Number.NaN && snapshot !== 0) {
-          return snapshot;
-        }
+      const params = QueryString.parse(search, { parseNumbers: true });
+      const snapshot = params['snapshot'];
+      if (typeof snapshot === 'number' && snapshot > 0) {
+        return snapshot;
       }
     }
   }

--- a/src/components/Charts/ChartContainer.tsx
+++ b/src/components/Charts/ChartContainer.tsx
@@ -4,6 +4,7 @@ import { Group } from '@vx/group';
 import { useTooltip } from '@vx/tooltip';
 import HoverOverlay from './HoverOverlay';
 import * as Style from './Charts.style';
+import { ScreenshotReady } from 'components/Screenshot';
 
 const ChartContainer = <T extends unknown>({
   width,
@@ -69,6 +70,7 @@ const ChartContainer = <T extends unknown>({
           />
         </Group>
       </svg>
+      {width > 0 && <ScreenshotReady />}
       {tooltipOpen && tooltipData && renderTooltip(tooltipData)}
     </Style.PositionRelative>
   );

--- a/src/components/Explore/ExploreChart.tsx
+++ b/src/components/Explore/ExploreChart.tsx
@@ -16,6 +16,7 @@ import ChartOverlay from './ChartOverlay';
 import { getMaxBy, getTimeAxisTicks, findPointByDate } from './utils';
 import * as Styles from './Explore.style';
 import { COLOR_MAP } from 'common/colors';
+import { ScreenshotReady } from 'components/Screenshot';
 
 const getDate = (d: Column) => new Date(d.x);
 const getY = (d: Column) => d.y;
@@ -234,6 +235,7 @@ const ExploreChart: React.FC<{
           date={tooltipData.date}
         />
       )}
+      {width > 0 && <ScreenshotReady />}
     </Styles.PositionRelative>
   );
 };

--- a/src/components/Map/Map.js
+++ b/src/components/Map/Map.js
@@ -9,6 +9,7 @@ import USACountyMap from './USACountyMap';
 import { MAP_FILTERS } from '../../screens/LocationPage/Enums/MapFilterEnums';
 import ReactTooltip from 'react-tooltip';
 import { MapInstructions, MobileLineBreak } from './Map.style';
+import { ScreenshotReady } from 'components/Screenshot';
 
 // TODO(@pablo): We might want to move this to LOCATION_SUMMARY_LEVELS
 
@@ -88,6 +89,7 @@ function Map({
         </MapInstructions>
       )}
       <ReactTooltip>{content}</ReactTooltip>
+      <ScreenshotReady />
     </div>
   );
 }

--- a/src/components/Map/USACountyMap.js
+++ b/src/components/Map/USACountyMap.js
@@ -1,24 +1,26 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { ComposableMap, Geographies, Geography } from 'react-simple-maps';
-import { countyColor, stateColor } from 'common/colors';
+import { colorFromLocationSummary } from 'common/colors';
 import { geoAlbersUsaTerritories } from 'geo-albers-usa-territories';
 import STATES_JSON from './data/states-10m.json';
 import { USMapWrapper, USStateMapWrapper } from './Map.style';
 import { REVERSED_STATES } from 'common';
+import { useSummaries } from 'common/location_summaries';
 
 function getStateCode(stateName) {
   return REVERSED_STATES[stateName];
 }
 
 const USACountyMap = ({ stateClickHandler, setTooltipContent, condensed }) => {
+  const locationSummaries = useSummaries();
+  if (!locationSummaries) {
+    return null;
+  }
+
   const getFillColor = geo => {
-    if (geo.id.length <= 2) {
-      const stateCode = getStateCode(geo.properties.name);
-      return stateCode && stateColor(stateCode);
-    } else {
-      return countyColor(geo.id);
-    }
+    const summary = locationSummaries[geo.id] || null;
+    return colorFromLocationSummary(summary);
   };
 
   const projection = geoAlbersUsaTerritories()

--- a/src/components/Screenshot/ScreenshotReady.tsx
+++ b/src/components/Screenshot/ScreenshotReady.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+/**
+ * Empty sentinel element used when generating share / export content for
+ * screenshotting purposes to indicate when the content is ready to be captured
+ * (i.e. all asynchronous loading / rendering has completed).
+ */
+const ScreenshotReady = () => (
+  <div className={'screenshot-ready'} style={{ display: 'none' }} />
+);
+
+export default ScreenshotReady;

--- a/src/components/Screenshot/index.ts
+++ b/src/components/Screenshot/index.ts
@@ -1,0 +1,10 @@
+export { default as ScreenshotReady } from './ScreenshotReady';
+
+/**
+ * This class name must be used to mark content that should be included in
+ * screenshotting purposes.
+ *
+ * It should be paired with a <ScreenshotReady /> element, which indicates when
+ * the content is fully-rendered and ready for the screenshot to be taken.
+ */
+export const SCREENSHOT_CLASS = 'screenshot';

--- a/src/screens/internal/ShareImage/ChartExportImage.tsx
+++ b/src/screens/internal/ShareImage/ChartExportImage.tsx
@@ -20,6 +20,7 @@ import { findCountyByFips } from 'common/locations';
 import { useProjections, useModelLastUpdatedDate } from 'common/utils/model';
 import { Projection } from 'common/models/Projection';
 import { formatUtcDate } from 'common/utils';
+import { SCREENSHOT_CLASS } from 'components/Screenshot';
 
 const ExportChartImage = () => {
   let { stateId, countyFipsId, metric: metricString } = useParams();
@@ -49,7 +50,7 @@ const ExportChartImage = () => {
   }
 
   return (
-    <ScreenshotWrapper className={'screenshot'}>
+    <ScreenshotWrapper className={SCREENSHOT_CLASS}>
       <Content>
         <Headers>
           <Location>{projection.locationName}</Location>

--- a/src/screens/internal/ShareImage/ChartShareImage.tsx
+++ b/src/screens/internal/ShareImage/ChartShareImage.tsx
@@ -19,6 +19,7 @@ import { Metric } from 'common/metric';
 import { findCountyByFips } from 'common/locations';
 import { useProjections } from 'common/utils/model';
 import { Projection } from 'common/models/Projection';
+import { SCREENSHOT_CLASS } from 'components/Screenshot';
 
 export default function ChartShareImage() {
   let { stateId, countyFipsId, metric: metricString } = useParams();
@@ -43,7 +44,7 @@ export default function ChartShareImage() {
   const chartHeight = 225;
 
   return (
-    <ScreenshotWrapper className={'screenshot'}>
+    <ScreenshotWrapper className={SCREENSHOT_CLASS}>
       <Wrapper>
         <Headers>
           <Title>{getMetricNameExtended(metric)}</Title>

--- a/src/screens/internal/ShareImage/ExploreChartExportImage.tsx
+++ b/src/screens/internal/ShareImage/ExploreChartExportImage.tsx
@@ -25,6 +25,7 @@ import {
   getTitle,
   getMetricByChartId,
 } from 'components/Explore';
+import { SCREENSHOT_CLASS } from 'components/Screenshot';
 
 const ExploreChartExportImage = () => {
   let { stateId, countyFipsId, chartId } = useParams();
@@ -54,7 +55,7 @@ const ExploreChartExportImage = () => {
   }
 
   return (
-    <ScreenshotWrapper className={'screenshot'}>
+    <ScreenshotWrapper className={SCREENSHOT_CLASS}>
       <Content>
         <Headers>
           <Location>{projection.locationName}</Location>

--- a/src/screens/internal/ShareImage/ExploreChartImage.tsx
+++ b/src/screens/internal/ShareImage/ExploreChartImage.tsx
@@ -25,6 +25,7 @@ import {
   Subtitle,
   Title,
 } from './ChartShareImage.style';
+import { SCREENSHOT_CLASS } from 'components/Screenshot';
 
 const ExploreChartImage = () => {
   const theme = useContext(ThemeContext);
@@ -48,7 +49,7 @@ const ExploreChartImage = () => {
   }
 
   return (
-    <ScreenshotWrapper className={'screenshot'}>
+    <ScreenshotWrapper className={SCREENSHOT_CLASS}>
       <Wrapper>
         <Headers>
           <Title>{getTitle(metric)}</Title>

--- a/src/screens/internal/ShareImage/ShareCardImage.tsx
+++ b/src/screens/internal/ShareImage/ShareCardImage.tsx
@@ -11,6 +11,7 @@ import {
 import { ScreenshotWrapper } from './ShareImage.style';
 import { formatLocalDate } from 'common/utils';
 import { findCountyByFips } from 'common/locations';
+import { ScreenshotReady, SCREENSHOT_CLASS } from 'components/Screenshot';
 
 // TODO(michael): Split this into HomeImage and LocationImage (with some shared code).
 
@@ -22,7 +23,7 @@ const ShareCardImage = () => {
   const { stateId, countyFipsId } = useParams();
   const isHomePage = !stateId && !countyFipsId;
   return (
-    <ScreenshotWrapper className={'screenshot'}>
+    <ScreenshotWrapper className={SCREENSHOT_CLASS}>
       <Header isHomePage={isHomePage} />
       <ShareCardWrapper isHomePage={isHomePage}>
         <ShareCard stateId={stateId} countyFipsId={countyFipsId} />
@@ -70,7 +71,12 @@ const LocationShareCard = ({ stateId, countyFipsId }: ShareCardProps) => {
   }
   const stats = projections.getMetricValues();
 
-  return <SocialLocationPreview projections={projections} stats={stats} />;
+  return (
+    <>
+      <ScreenshotReady />
+      <SocialLocationPreview projections={projections} stats={stats} />
+    </>
+  );
 };
 
 export default ShareCardImage;


### PR DESCRIPTION
* Allow passing ?snapshot=xyz to most pages to choose what snapshot to use for rendering. This lets us generate screenshots for non-current snapshots as necessary.
* Refactor USACountyMap "summaries file" usage so that it can render maps for non-current snapshots.
* Add a <ScreenshotReady/> component that must be used to signal when the screenshot content is fully rendered and ready to be captured (i.e. all async requests are done, etc.).

For an example of what the first two bullets enable, see:
https://covid-projections-git-mikelehen-host-share-images-prework.covidactnow.vercel.app/?snapshot=983
vs
https://covid-projections-git-mikelehen-host-share-images-prework.covidactnow.vercel.app/?snapshot=974