### PR TITLE
Compare: open in new tab

### DIFF
--- a/src/components/Compare/Compare.style.tsx
+++ b/src/components/Compare/Compare.style.tsx
@@ -69,6 +69,12 @@ export const Wrapper = styled.div<{ isModal?: Boolean; isHomepage?: boolean }>`
         min-width: ${metricCellWidth}px;
       }
     }
+
+    a {
+      display: table;
+      color: black;
+      width: 100%;
+    }
   }
 
   ${ChartLocationName} {

--- a/src/components/Compare/CompareTableRow.tsx
+++ b/src/components/Compare/CompareTableRow.tsx
@@ -1,5 +1,5 @@
 import React, { Fragment } from 'react';
-import { useHistory } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import FiberManualRecordIcon from '@material-ui/icons/FiberManualRecord';
 import {
   MetricCell,
@@ -51,83 +51,68 @@ const CompareTableRow = (props: {
     return 4;
   }
 
-  const history = useHistory();
-
-  const goToLocationPage = (page: string) => {
-    //clicking current county when in modal wasn't triggering refresh/modal close, so:
-    if (window.location.pathname === page) {
-      window.location.reload();
-    } else {
-      window.scrollTo(0, 0);
-      history.push(page);
-    }
-  };
-
-  const handleLocationClick = () => {
-    return goToLocationPage(
-      `/us/${location.locationInfo.state_code.toLowerCase()}${
-        location.locationInfo.county_url_name
-          ? `/county/${location.locationInfo.county_url_name.toLowerCase()}`
-          : ''
-      }`,
-    );
-  };
+  const locationLink = `/us/${location.locationInfo.state_code.toLowerCase()}${
+    location.locationInfo.county_url_name
+      ? `/county/${location.locationInfo.county_url_name.toLowerCase()}`
+      : ''
+  }`;
 
   const locationName = getColumnLocationName(location.locationInfo);
 
   const populationRoundTo = isHomepage ? 3 : 2;
 
   return (
-    <Row
-      index={location.rank}
-      isCurrentCounty={isCurrentCounty}
-      onClick={handleLocationClick}
-      isModal={isModal}
-    >
-      <MetricCell
-        iconColor={location.metricsInfo.level}
-        sortByPopulation={sortByPopulation}
+    <Link to={locationLink}>
+      <Row
+        index={location.rank}
+        isCurrentCounty={isCurrentCounty}
+        isModal={isModal}
       >
-        <div>
-          <span>{location.rank}</span>
-          <FiberManualRecordIcon />
-        </div>
-        <div>
-          {locationName[0]}{' '}
-          {locationName[1] && <CountySuffix>{locationName[1]}</CountySuffix>}
-          {showStateCode && (
-            <Fragment>{location.locationInfo.state_code}</Fragment>
-          )}
-          <br />
-          <Population>
-            {formatEstimate(
-              location.locationInfo.population,
-              populationRoundTo,
-            )}
-          </Population>
-        </div>
-      </MetricCell>
-      {orderedMetrics.map((metric: Metric) => {
-        const metricForValue = location.metricsInfo.metrics[metric];
-        const valueUnknown =
-          metricForValue && metricForValue.level === Level.UNKNOWN
-            ? true
-            : false;
-        return (
-          <MetricCell
-            sorter={sorter}
-            metric={metric}
-            iconColor={getLevel(metric)}
-            sortByPopulation={sortByPopulation}
-          >
+        <MetricCell
+          iconColor={location.metricsInfo.level}
+          sortByPopulation={sortByPopulation}
+        >
+          <div>
+            <span>{location.rank}</span>
             <FiberManualRecordIcon />
-            <MetricValue valueUnknown={valueUnknown}>
-              {cellValue(metricForValue, metric)}
-            </MetricValue>
-          </MetricCell>
-        );
-      })}
-    </Row>
+          </div>
+          <div>
+            {locationName[0]}{' '}
+            {locationName[1] && <CountySuffix>{locationName[1]}</CountySuffix>}
+            {showStateCode && (
+              <Fragment>{location.locationInfo.state_code}</Fragment>
+            )}
+            <br />
+            <Population>
+              {formatEstimate(
+                location.locationInfo.population,
+                populationRoundTo,
+              )}
+            </Population>
+          </div>
+        </MetricCell>
+        {orderedMetrics.map((metric: Metric) => {
+          const metricForValue = location.metricsInfo.metrics[metric];
+          const valueUnknown =
+            metricForValue && metricForValue.level === Level.UNKNOWN
+              ? true
+              : false;
+          return (
+            <MetricCell
+              sorter={sorter}
+              metric={metric}
+              iconColor={getLevel(metric)}
+              sortByPopulation={sortByPopulation}
+            >
+              <FiberManualRecordIcon />
+              <MetricValue valueUnknown={valueUnknown}>
+                {cellValue(metricForValue, metric)}
+              </MetricValue>
+            </MetricCell>
+          );
+        })}
+      </Row>
+    </Link>
   );
 };
 


### PR DESCRIPTION
- Adds ability to open a row's corresponding location page in a new tab
- Replaces navigation via pushing URL to `history` with navigation via `Link` component