### PR TITLE
Fix: compare modal

### DIFF
--- a/src/components/Compare/LocationTable.tsx
+++ b/src/components/Compare/LocationTable.tsx
@@ -189,7 +189,13 @@ const LocationTable: React.FunctionComponent<{
   const Container = isModal ? Styles.ModalContainer : Styles.Container;
 
   // Seemingly random numbers are the heights of each modal header
-  const modalHeaderOffset = isHomepage ? 159 : pinnedLocation ? 193 : 110;
+  const homepageOffset = viewAllCounties ? 159 : 73;
+  const locationPageOffset = geoScope === GeoScopeFilter.NEARBY ? 107 : 198;
+  const modalHeaderOffset = isHomepage
+    ? homepageOffset
+    : pinnedLocation
+    ? locationPageOffset
+    : 110;
   const finalHeaderOffset = isModal ? modalHeaderOffset : 0;
 
   const showBottom = pinnedLocation && pinnedLocation.rank >= numLocations;


### PR DESCRIPTION
- Fixes (removes) gap at the bottom of compare modal that occurs when metro menu is not displayed (mobile only)

Before:
<img width="365" alt="Screen Shot 2020-08-31 at 1 41 34 PM" src="https://user-images.githubusercontent.com/44076375/91750010-5d382500-eb90-11ea-8c3b-d0d8c4ff3d18.png">


After:
![Screen Shot 2020-08-31 at 1 43 21 PM](https://user-images.githubusercontent.com/44076375/91750021-60cbac00-eb90-11ea-9125-da46efa2fd9e.png)