### PR TITLE
Move over to the dynamic image serving.

### DIFF
--- a/.github/workflows/update-snapshot.yml
+++ b/.github/workflows/update-snapshot.yml
@@ -50,7 +50,11 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.CONTENT_AWS_SECRET_ACCESS_KEY }}
           SOURCE_DIR: scripts/generate_share_images/output
           DEST_DIR: share/${{env.RUN_ID}}
-      - run: 'echo "{ \"share_image_url\": \"https://content.covidactnow.org/share/${{env.RUN_ID}}/\" }" | python -mjson.tool > src/assets/data/share_images_url.json'
+
+      # TODO: We have switched to dynamic images served via Firebase Hosting.  Remove all of the
+      # image generation / S3 upload / content.covidactnow.org stuff once we're 100% confident.
+      # - run: 'echo "{ \"share_image_url\": \"https://content.covidactnow.org/share/${{env.RUN_ID}}/\" }" | python -mjson.tool > src/assets/data/share_images_url.json'
+      - run: 'echo "{ \"share_image_url\": \"https://covidactnow-prod.web.app/share/${{env.RUN_ID}}/\" }" | python -mjson.tool > src/assets/data/share_images_url.json'
 
       # Generate Pull Request
       - name: Create Pull Request

--- a/src/assets/data/share_images_url.json
+++ b/src/assets/data/share_images_url.json
@@ -1,3 +1,3 @@
 {
-    "share_image_url": "https://content.covidactnow.org/share/987-199/"
+    "share_image_url": "https://covidactnow-prod.web.app/share/987-199/"
 }


### PR DESCRIPTION
Note: This is a bit hard to validate as-is.  We should probably merge to staging and then load some sharing URLs (e.g. https://staging.covidactnow.org/us/wa/chart/0/?s=987199), look at the meta tags served (should be the new covidactnow-prod.web.app URL), and then verify the image URL serves the expected image.