### PR TITLE
explore: v1 fixes

### DIFF
--- a/src/components/Charts/BarChart.tsx
+++ b/src/components/Charts/BarChart.tsx
@@ -25,7 +25,7 @@ const BarChart = <T extends unknown>({
         return (
           <Bar
             key={`bar-${i}`}
-            x={x0}
+            x={x0 - barWidth / 2}
             y={y0}
             width={barWidth}
             height={yMax - y0}

--- a/src/components/Explore/EmptyChart.tsx
+++ b/src/components/Explore/EmptyChart.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { EmptyChart as EmtpyChartStyle } from './Explore.style';
+
+const EmptyChart: React.FC<{
+  height: number;
+}> = ({ height, children }) => (
+  <EmtpyChartStyle style={{ height }}>{children}</EmtpyChartStyle>
+);
+
+export default EmptyChart;

--- a/src/components/Explore/Explore.style.ts
+++ b/src/components/Explore/Explore.style.ts
@@ -99,12 +99,15 @@ export const LegendItemLabel = styled.span`
   line-height: 16px;
 `;
 
+// CHARTS
+
 export const ChartContainer = styled.div`
   margin-top: ${theme.spacing(4)}px;
 `;
 
 export const PositionRelative = styled.div`
   position: relative;
+  margin: 0;
 `;
 
 export const MainSeriesLine = styled.g`
@@ -139,6 +142,15 @@ export const GridLines = styled.g`
     stroke-width: 1px;
     stroke-dasharray: 5, 5;
   }
+`;
+
+export const EmptyChart = styled(ChartContainer)`
+  /* Super centered: https://web.dev/one-line-layouts */
+  display: grid;
+  place-items: center;
+  background-color: ${colorPalette.lightGray};
+  padding: ${theme.spacing(3)}px;
+  text-align: center;
 `;
 
 export const TodayLabel = styled.g`

--- a/src/components/Explore/Explore.tsx
+++ b/src/components/Explore/Explore.tsx
@@ -1,4 +1,5 @@
 import React, { useState, FunctionComponent } from 'react';
+import { some } from 'lodash';
 import Grid from '@material-ui/core/Grid';
 import useMediaQuery from '@material-ui/core/useMediaQuery';
 import { useTheme } from '@material-ui/core/styles';
@@ -9,6 +10,7 @@ import ExploreTabs from './ExploreTabs';
 import ExploreChart from './ExploreChart';
 import Legend from './Legend';
 import { ExploreMetric } from './interfaces';
+import EmptyChart from './EmptyChart';
 
 import {
   getMetricLabels,
@@ -20,6 +22,7 @@ import {
   getSocialQuote,
 } from './utils';
 import * as Styles from './Explore.style';
+import ExternalLink from '../ExternalLink';
 
 const Explore: React.FunctionComponent<{
   projection: Projection;
@@ -38,6 +41,8 @@ const Explore: React.FunctionComponent<{
   const metricLabels = getMetricLabels();
   const series = getSeries(currentMetric, projection);
   const { locationName, fips } = projection;
+
+  const hasData = some(series, ({ data }) => data.length > 0);
 
   return (
     <Styles.Container>
@@ -68,11 +73,11 @@ const Explore: React.FunctionComponent<{
       <Styles.ChartControlsContainer>
         <Legend series={series} />
       </Styles.ChartControlsContainer>
-      <Styles.ChartContainer>
-        {/* The width is set to zero while the parent div is rendering */}
-        <ParentSize>
-          {({ width }) =>
-            width < 10 ? null : (
+      {hasData ? (
+        <Styles.ChartContainer>
+          {/* The width is set to zero while the parent div is rendering */}
+          <ParentSize>
+            {({ width }) => (
               <ExploreChart
                 series={series}
                 isMobile={isMobile}
@@ -80,10 +85,25 @@ const Explore: React.FunctionComponent<{
                 height={400}
                 tooltipSubtext={`in ${locationName}`}
               />
-            )
-          }
-        </ParentSize>
-      </Styles.ChartContainer>
+            )}
+          </ParentSize>
+        </Styles.ChartContainer>
+      ) : (
+        <EmptyChart height={400}>
+          <p>
+            We don't have {metricLabels[currentMetric]} data for {locationName}.
+            Learn more about{' '}
+            <ExternalLink href="https://docs.google.com/document/d/1cd_cEpNiIl1TzUJBvw9sHLbrbUZ2qCxgN32IqVLa3Do/edit">
+              our methodology
+            </ExternalLink>{' '}
+            and our{' '}
+            <ExternalLink href="https://docs.google.com/presentation/d/1XmKCBWYZr9VQKFAdWh_D7pkpGGM_oR9cPjj-UrNdMJQ/edit">
+              our data sources
+            </ExternalLink>
+            .
+          </p>
+        </EmptyChart>
+      )}
     </Styles.Container>
   );
 };

--- a/src/components/Explore/ExploreChart.tsx
+++ b/src/components/Explore/ExploreChart.tsx
@@ -165,7 +165,7 @@ const ExploreChart: React.FC<{
   const axisGridColor = !barOpacity ? `${COLOR_MAP.GRAY_EXPLORE_CHART}` : '';
 
   return (
-    <Styles.PositionRelative>
+    <Styles.PositionRelative style={{ height }}>
       <svg width={width} height={height}>
         <Group key="chart-container" top={marginTop} left={marginLeft}>
           <ChartStyle.LineGrid exploreStroke={axisGridColor}>

--- a/src/components/Explore/ExploreChart.tsx
+++ b/src/components/Explore/ExploreChart.tsx
@@ -51,10 +51,12 @@ const ExploreTooltip: React.FC<{
       title={moment(date).format('MMM D, YYYY')}
     >
       <Styles.TooltipSubtitle>{seriesRaw.tooltipLabel}</Styles.TooltipSubtitle>
-      <Styles.TooltipMetric>{formatInteger(pointRaw.y)}</Styles.TooltipMetric>
-      <Styles.TooltipSubtitle>{`avg ${formatInteger(
-        pointSmooth.y,
-      )}`}</Styles.TooltipSubtitle>
+      <Styles.TooltipMetric>
+        {formatInteger(pointSmooth.y)}
+      </Styles.TooltipMetric>
+      <Styles.TooltipSubtitle>
+        {`${formatInteger(pointRaw.y)} cases`}
+      </Styles.TooltipSubtitle>
       <Styles.TooltipLocation>{subtext}</Styles.TooltipLocation>
     </Tooltip>
   ) : null;

--- a/src/components/Explore/utils.ts
+++ b/src/components/Explore/utils.ts
@@ -79,13 +79,13 @@ export const exploreMetricData: {
     series: [
       {
         label: 'Cases',
-        tooltipLabel: 'Confirmed cases',
+        tooltipLabel: '7-day avg. cases',
         datasetId: 'rawDailyCases',
         type: ChartType.BAR,
       },
       {
         label: '7 Day Average',
-        tooltipLabel: 'Confirmed cases',
+        tooltipLabel: '7-day avg. cases',
         datasetId: 'smoothedDailyCases',
         type: ChartType.LINE,
       },

--- a/src/components/Map/USACountyMap.js
+++ b/src/components/Map/USACountyMap.js
@@ -15,12 +15,9 @@ function getStateCode(stateName) {
 
 const USACountyMap = ({ stateClickHandler, setTooltipContent, condensed }) => {
   const locationSummaries = useSummaries();
-  if (!locationSummaries) {
-    return null;
-  }
 
   const getFillColor = geo => {
-    const summary = locationSummaries[geo.id] || null;
+    const summary = (locationSummaries && locationSummaries[geo.id]) || null;
     return colorFromLocationSummary(summary);
   };
 
@@ -62,7 +59,7 @@ const USACountyMap = ({ stateClickHandler, setTooltipContent, condensed }) => {
           </Geographies>
         </ComposableMap>
       </USStateMapWrapper>
-      <ScreenshotReady />
+      {locationSummaries && <ScreenshotReady />}
     </USMapWrapper>
   );
 };


### PR DESCRIPTION
Addressing feedback from [CAN Explore - Feedback](https://paper.dropbox.com/doc/CAN-Explore--A6wWR1iltDXmI1xe4ZTRyFhrAg-RIlOIJkMWHcX0AmXQA5PW)

- [ ] Add an empty state for when we don't have data
- [ ] Several copy updates to the tooltips
- [ ] Adjust the line to match the bar charts (the last data point didn't exactly match the last bar)
