### PR TITLE
explore v2: implement location selector

### DIFF
--- a/src/common/locations.ts
+++ b/src/common/locations.ts
@@ -157,3 +157,7 @@ export function getCountyMsaCode(fips: string): string | undefined {
     return ADJACENT_COUNTIES[fips].msa_code;
   }
 }
+
+export function findLocationForFips(fips: string): Location {
+  return isStateFips(fips) ? findStateByFips(fips) : findCountyByFips(fips);
+}

--- a/src/components/AutocompleteLocations/AutocompleteLocations.tsx
+++ b/src/components/AutocompleteLocations/AutocompleteLocations.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import Autocomplete from '@material-ui/lab/Autocomplete';
+import TextField from '@material-ui/core/TextField';
+import { Location } from 'common/locations';
+
+function getLocationLabel(location: Location) {
+  return location.county
+    ? `${location.county}, ${location.state_code}`
+    : location.state;
+}
+
+const getFips = (location: Location) =>
+  location.full_fips_code || location.state_fips_code;
+
+const getOptionSelected = (option: Location, value: Location) =>
+  getFips(option) === getFips(value);
+
+// TODO(Pablo): Use this component for the Newsletter
+const AutocompleteLocations: React.FC<{
+  locations: Location[];
+  selectedLocations: Location[];
+  onChangeLocations: (
+    event: React.ChangeEvent<{}>,
+    newLocations: Location[],
+  ) => void;
+}> = ({ locations, onChangeLocations, selectedLocations }) => (
+  <Autocomplete
+    multiple
+    options={locations}
+    getOptionLabel={getLocationLabel}
+    onChange={onChangeLocations}
+    getOptionSelected={getOptionSelected}
+    value={selectedLocations}
+    renderInput={params => (
+      <TextField
+        variant="outlined"
+        {...params}
+        placeholder="Compare states or counties"
+      />
+    )}
+  />
+);
+
+export default AutocompleteLocations;

--- a/src/components/AutocompleteLocations/index.ts
+++ b/src/components/AutocompleteLocations/index.ts
@@ -1,0 +1,5 @@
+import AutocompleteLocations from './AutocompleteLocations';
+import { isCounty, isState, belongsToState } from './utils';
+
+export default AutocompleteLocations;
+export { isCounty, isState, belongsToState };

--- a/src/components/AutocompleteLocations/utils.ts
+++ b/src/components/AutocompleteLocations/utils.ts
@@ -1,0 +1,8 @@
+import { Location } from 'common/locations';
+
+export const isCounty = (location: Location) => location.county !== undefined;
+
+export const isState = (location: Location) => !isCounty(location);
+
+export const belongsToState = (location: Location, stateFips: string) =>
+  location.state_fips_code === stateFips;

--- a/src/components/Explore/LocationSelector.style.ts
+++ b/src/components/Explore/LocationSelector.style.ts
@@ -1,0 +1,41 @@
+import styled from 'styled-components';
+import { Button } from '@material-ui/core';
+import theme from 'assets/theme';
+import palette from 'assets/theme/palette';
+
+export const ModalContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  background-color: white;
+  width: 90%;
+  margin: 200px auto;
+  border-radius: ${theme.spacing(1)}px;
+  padding: ${theme.spacing(2)}px;
+`;
+
+export const ModalHeader = styled.div`
+  flex: 0 1 auto;
+  margin-bottom: ${theme.spacing(3)}px;
+
+  /* TODO(Pablo): Use the theme */
+  font-family: Roboto;
+  font-style: normal;
+  font-weight: 500;
+  font-size: 12px;
+  line-height: 14px;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+`;
+
+export const ModalTitle = styled.div`
+  padding: ${theme.spacing(1)}px 0;
+`;
+
+export const ModalBody = styled.div`
+  flex: 1 0 auto;
+`;
+
+export const DoneButton = styled(Button)`
+  text-transform: none;
+  color: ${palette.lightBlue};
+`;

--- a/src/components/Explore/LocationSelector.tsx
+++ b/src/components/Explore/LocationSelector.tsx
@@ -1,0 +1,110 @@
+import React, { useState } from 'react';
+import Autocomplete from '@material-ui/lab/Autocomplete';
+import Grid from '@material-ui/core/Grid';
+import TextField from '@material-ui/core/TextField';
+import useMediaQuery from '@material-ui/core/useMediaQuery';
+import { Button } from '@material-ui/core';
+import { useTheme } from '@material-ui/core/styles';
+import { Modal } from '@material-ui/core';
+import { Location } from 'common/locations';
+import { getLocationLabel } from './utils';
+import * as Styles from './LocationSelector.style';
+
+const getFips = (location: Location) =>
+  location.full_fips_code || location.state_fips_code;
+
+const getOptionSelected = (option: Location, value: Location) =>
+  getFips(option) === getFips(value);
+
+const AutocompleteLocations: React.FC<{
+  locations: Location[];
+  selectedLocations: Location[];
+  onChangeLocations: (
+    event: React.ChangeEvent<{}>,
+    newLocations: Location[],
+  ) => void;
+}> = ({ locations, onChangeLocations, selectedLocations }) => (
+  <Autocomplete
+    multiple
+    options={locations}
+    getOptionLabel={getLocationLabel}
+    onChange={onChangeLocations}
+    getOptionSelected={getOptionSelected}
+    value={selectedLocations}
+    renderInput={params => (
+      <TextField
+        variant="outlined"
+        {...params}
+        placeholder="Compare states or counties"
+      />
+    )}
+  />
+);
+
+const LocationSelector: React.FC<{
+  locations: Location[];
+  selectedLocations: Location[];
+  onChangeSelectedLocations: (newLocations: Location[]) => void;
+}> = ({ locations, selectedLocations, onChangeSelectedLocations }) => {
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('xs'));
+
+  const [modalOpen, setModalOpen] = useState(false);
+
+  const onChangeLocations = (
+    event: React.ChangeEvent<{}>,
+    newLocations: Location[],
+  ) => {
+    onChangeSelectedLocations(newLocations);
+  };
+
+  const onClickButton = () => setModalOpen(!modalOpen);
+  const closeModal = () => setModalOpen(false);
+
+  return isMobile ? (
+    <React.Fragment>
+      <Button
+        variant="outlined"
+        disableRipple
+        disableFocusRipple
+        disableTouchRipple
+        onClick={onClickButton}
+      >
+        Compare
+      </Button>
+      {modalOpen ? (
+        <Modal open={modalOpen} onClose={closeModal}>
+          <Styles.ModalContainer>
+            <Styles.ModalHeader>
+              <Grid container>
+                <Grid item xs={9}>
+                  <Styles.ModalTitle>Compare Locations</Styles.ModalTitle>
+                </Grid>
+                <Grid item xs container justify="flex-end">
+                  <Styles.DoneButton size="small" onClick={closeModal}>
+                    Done
+                  </Styles.DoneButton>
+                </Grid>
+              </Grid>
+            </Styles.ModalHeader>
+            <Styles.ModalBody>
+              <AutocompleteLocations
+                locations={locations}
+                onChangeLocations={onChangeLocations}
+                selectedLocations={selectedLocations}
+              />
+            </Styles.ModalBody>
+          </Styles.ModalContainer>
+        </Modal>
+      ) : null}
+    </React.Fragment>
+  ) : (
+    <AutocompleteLocations
+      locations={locations}
+      onChangeLocations={onChangeLocations}
+      selectedLocations={selectedLocations}
+    />
+  );
+};
+
+export default LocationSelector;

--- a/src/components/Explore/LocationSelector.tsx
+++ b/src/components/Explore/LocationSelector.tsx
@@ -39,7 +39,7 @@ const LocationSelector: React.FC<{
       >
         Compare
       </Button>
-      {modalOpen ? (
+      {modalOpen && (
         <Modal open={modalOpen} onClose={closeModal}>
           <Styles.ModalContainer>
             <Styles.ModalHeader>
@@ -63,7 +63,7 @@ const LocationSelector: React.FC<{
             </Styles.ModalBody>
           </Styles.ModalContainer>
         </Modal>
-      ) : null}
+      )}
     </React.Fragment>
   ) : (
     <AutocompleteLocations

--- a/src/components/Explore/LocationSelector.tsx
+++ b/src/components/Explore/LocationSelector.tsx
@@ -1,45 +1,12 @@
 import React, { useState } from 'react';
-import Autocomplete from '@material-ui/lab/Autocomplete';
 import Grid from '@material-ui/core/Grid';
-import TextField from '@material-ui/core/TextField';
 import useMediaQuery from '@material-ui/core/useMediaQuery';
 import { Button } from '@material-ui/core';
 import { useTheme } from '@material-ui/core/styles';
 import { Modal } from '@material-ui/core';
 import { Location } from 'common/locations';
-import { getLocationLabel } from './utils';
 import * as Styles from './LocationSelector.style';
-
-const getFips = (location: Location) =>
-  location.full_fips_code || location.state_fips_code;
-
-const getOptionSelected = (option: Location, value: Location) =>
-  getFips(option) === getFips(value);
-
-const AutocompleteLocations: React.FC<{
-  locations: Location[];
-  selectedLocations: Location[];
-  onChangeLocations: (
-    event: React.ChangeEvent<{}>,
-    newLocations: Location[],
-  ) => void;
-}> = ({ locations, onChangeLocations, selectedLocations }) => (
-  <Autocomplete
-    multiple
-    options={locations}
-    getOptionLabel={getLocationLabel}
-    onChange={onChangeLocations}
-    getOptionSelected={getOptionSelected}
-    value={selectedLocations}
-    renderInput={params => (
-      <TextField
-        variant="outlined"
-        {...params}
-        placeholder="Compare states or counties"
-      />
-    )}
-  />
-);
+import AutocompleteLocations from 'components/AutocompleteLocations';
 
 const LocationSelector: React.FC<{
   locations: Location[];

--- a/src/components/Explore/utils.ts
+++ b/src/components/Explore/utils.ts
@@ -298,7 +298,16 @@ export function getLocationLabel(location: Location) {
 }
 
 export function getLocationNames(locations: Location[]) {
-  return locations.map(getLocationLabel).join(', ');
+  if (locations.length === 1) {
+    return getLocationLabel(locations[0]);
+  }
+
+  const lastLocation = locations[locations.length - 1];
+  const otherLocations = locations.slice(0, locations.length - 1);
+
+  return `${otherLocations
+    .map(getLocationLabel)
+    .join(', ')} and ${getLocationLabel(lastLocation)}.`;
 }
 
 const isCounty = (location: Location) => location.county;

--- a/src/components/Explore/utils.ts
+++ b/src/components/Explore/utils.ts
@@ -19,6 +19,11 @@ import { Projection, DatasetId } from 'common/models/Projection';
 import { ChartType } from './interfaces';
 import { share_image_url } from 'assets/data/share_images_url.json';
 import {
+  isState,
+  isCounty,
+  belongsToState,
+} from 'components/AutocompleteLocations';
+import {
   getLocationNameForFips,
   getLocationUrlForFips,
   isStateFips,
@@ -309,11 +314,6 @@ export function getLocationNames(locations: Location[]) {
     .map(getLocationLabel)
     .join(', ')} and ${getLocationLabel(lastLocation)}.`;
 }
-
-const isCounty = (location: Location) => location.county;
-const isState = (location: Location) => !isCounty(location);
-const belongsToState = (location: Location, stateFips: string) =>
-  location.state_fips_code === stateFips;
 
 export function getAutocompleteLocations(locationFips: string) {
   const currentLocation = findLocationForFips(locationFips);


### PR DESCRIPTION
This PR implements the location selector for Explore v2

- State pages show only states as options
- County pages show only counties in the current state as options

Note that I'm leaving UI polish ~~and formatting of the location names~~ for later (see [CAN Explore - V2 Compare Locations](https://paper.dropbox.com/doc/CAN-Explore--A63xPTEkOs8MoTLBhyR8l3SoAg-RIlOIJkMWHcX0AmXQA5PW) so I can get a 1st version of the compare functionality working sooner.

**Mobile**
<img src="https://user-images.githubusercontent.com/114084/92015108-246d8c80-ed05-11ea-8d58-23652b51e5c7.png" width="400" />

**Desktop**
<img src="https://user-images.githubusercontent.com/114084/92015157-3b13e380-ed05-11ea-9f80-89e5338b315a.png" width="600" />

