### PR TITLE
explore v2: calculate series to compare locations

### DIFF
--- a/src/common/locations.ts
+++ b/src/common/locations.ts
@@ -157,3 +157,7 @@ export function getCountyMsaCode(fips: string): string | undefined {
     return ADJACENT_COUNTIES[fips].msa_code;
   }
 }
+
+export function findLocationForFips(fips: string): Location {
+  return isStateFips(fips) ? findStateByFips(fips) : findCountyByFips(fips);
+}

--- a/src/components/Explore/ChartTooltips.tsx
+++ b/src/components/Explore/ChartTooltips.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import moment from 'moment';
+import { formatInteger } from 'common/utils';
+import { Column } from 'common/models/Projection';
+import { Tooltip } from 'components/Charts';
+import { Series } from './interfaces';
+import { findPointByDate } from './utils';
+import * as Styles from './Explore.style';
+
+const SingleLocationTooltip: React.FC<{
+  date: Date;
+  series: Series[];
+  left: (d: Column) => number;
+  top: (d: Column) => number;
+  subtext: string;
+}> = ({ series, left, top, date, subtext }) => {
+  const [seriesRaw, seriesSmooth] = series;
+  const pointSmooth = findPointByDate(seriesSmooth.data, date);
+  const pointRaw = findPointByDate(seriesRaw.data, date);
+
+  return pointSmooth && pointRaw ? (
+    <Tooltip
+      width={'180px'}
+      top={top(pointSmooth)}
+      left={left(pointSmooth)}
+      title={moment(date).format('MMM D, YYYY')}
+    >
+      <Styles.TooltipSubtitle>
+        {`${seriesRaw.tooltipLabel}: ${formatInteger(pointRaw.y)} `}
+      </Styles.TooltipSubtitle>
+      <Styles.TooltipMetric>
+        {`7-day avg. ${formatInteger(pointSmooth.y)}`}
+      </Styles.TooltipMetric>
+      <Styles.TooltipLocation>{subtext}</Styles.TooltipLocation>
+    </Tooltip>
+  ) : null;
+};
+
+export { SingleLocationTooltip };

--- a/src/components/Explore/Explore.style.ts
+++ b/src/components/Explore/Explore.style.ts
@@ -164,6 +164,15 @@ export const TodayLabel = styled.g`
   }
 `;
 
+export const LineLabel = styled.text`
+  font-family: Source Code Pro;
+  font-style: normal;
+  font-weight: 500;
+  font-size: 11px;
+  dominant-baseline: middle;
+  dx: 5px;
+`;
+
 export const DateMarker = styled.div`
   position: absolute;
   bottom: 0;

--- a/src/components/Explore/Explore.tsx
+++ b/src/components/Explore/Explore.tsx
@@ -1,4 +1,4 @@
-import React, { useState, FunctionComponent } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import { some } from 'lodash';
 import Grid from '@material-ui/core/Grid';
 import useMediaQuery from '@material-ui/core/useMediaQuery';
@@ -16,12 +16,11 @@ import ShareImageButtonGroup from 'components/ShareButtons';
 import ExploreTabs from './ExploreTabs';
 import ExploreChart from './ExploreChart';
 import Legend from './Legend';
-import { ExploreMetric } from './interfaces';
+import { ExploreMetric, Series } from './interfaces';
 import EmptyChart from './EmptyChart';
 import LocationSelector from './LocationSelector';
 import {
   getMetricLabels,
-  getSeries,
   getMetricByChartId,
   getImageFilename,
   getExportImageUrl,
@@ -29,6 +28,7 @@ import {
   getSocialQuote,
   getLocationNames,
   getAutocompleteLocations,
+  getChartSeries,
 } from './utils';
 import * as Styles from './Explore.style';
 
@@ -50,8 +50,10 @@ const Explore: React.FunctionComponent<{
 
   const metricLabels = getMetricLabels();
 
-  const currentLocation = findLocationForFips(fips);
-  const autocompleteLocations = getAutocompleteLocations(fips);
+  const currentLocation = useMemo(() => findLocationForFips(fips), [fips]);
+  const autocompleteLocations = useMemo(() => getAutocompleteLocations(fips), [
+    fips,
+  ]);
 
   const [selectedLocations, setSelectedLocations] = useState<Location[]>([
     currentLocation,
@@ -61,13 +63,19 @@ const Explore: React.FunctionComponent<{
     setSelectedLocations(newLocations);
   };
 
-  const series = getSeries(currentMetric, projection);
+  const [chartSeries, setChartSeries] = useState<Series[]>([]);
 
-  const hasData = some(series, ({ data }) => data.length > 0);
+  useEffect(() => {
+    const fetchSeries = () => getChartSeries(currentMetric, selectedLocations);
+    fetchSeries().then(series => setChartSeries(series));
+  }, [selectedLocations, currentMetric]);
 
   const lastUpdatedDate: Date | null = useModelLastUpdatedDate() || new Date();
   const lastUpdatedDateString =
     lastUpdatedDate !== null ? lastUpdatedDate.toLocaleDateString() : '';
+
+  const hasData = some(chartSeries, ({ data }) => data.length > 0);
+  const showMultipleLocations = selectedLocations.length > 1;
 
   return (
     <Styles.Container>
@@ -104,9 +112,11 @@ const Explore: React.FunctionComponent<{
               onChangeSelectedLocations={onChangeSelectedLocations}
             />
           </Grid>
-          <Grid key="legend" item sm xs={12}>
-            <Legend series={series} />
-          </Grid>
+          {showMultipleLocations ? null : (
+            <Grid key="legend" item sm xs={12}>
+              <Legend series={chartSeries} />
+            </Grid>
+          )}
         </Grid>
       </Styles.ChartControlsContainer>
       {hasData ? (
@@ -115,11 +125,13 @@ const Explore: React.FunctionComponent<{
           <ParentSize>
             {({ width }) => (
               <ExploreChart
-                series={series}
+                series={chartSeries}
                 isMobile={isMobile}
-                width={width}
+                width={Math.max(100, width)}
                 height={400}
                 tooltipSubtext={`in ${locationName}`}
+                showLabels={showMultipleLocations}
+                marginRight={showMultipleLocations ? 100 : 10}
               />
             )}
           </ParentSize>

--- a/src/components/Explore/ExploreChart.tsx
+++ b/src/components/Explore/ExploreChart.tsx
@@ -39,6 +39,9 @@ const ExploreTooltip: React.FC<{
   top: (d: Column) => number;
   subtext: string;
 }> = ({ series, left, top, date, subtext }) => {
+  if (series.length < 2) {
+    return null;
+  }
   const [seriesRaw, seriesSmooth] = series;
   const pointSmooth = findPointByDate(seriesSmooth.data, date);
   const pointRaw = findPointByDate(seriesRaw.data, date);
@@ -105,6 +108,7 @@ const ExploreChart: React.FC<{
   marginRight?: number;
   barOpacity?: number;
   barOpacityHover?: number;
+  showLabels?: boolean;
 }> = ({
   width,
   height,
@@ -117,6 +121,7 @@ const ExploreChart: React.FC<{
   marginRight = 10,
   barOpacity,
   barOpacityHover,
+  showLabels = false,
 }) => {
   const dateFrom = new Date('2020-03-01');
   const today = new Date();
@@ -172,7 +177,7 @@ const ExploreChart: React.FC<{
             <GridRows<number> scale={yScale} width={innerWidth} />
           </ChartStyle.LineGrid>
           <RectClipGroup width={innerWidth} height={innerHeight}>
-            {series.map(({ label, data, type }) => (
+            {series.map(({ label, data, type, params }) => (
               <SeriesChart
                 key={`series-chart-${label}`}
                 data={data}
@@ -182,6 +187,7 @@ const ExploreChart: React.FC<{
                 yMax={innerHeight}
                 barWidth={barWidth}
                 barOpacity={barOpacity}
+                chartParams={params}
               />
             ))}
           </RectClipGroup>
@@ -194,6 +200,17 @@ const ExploreChart: React.FC<{
               y2={innerHeight}
             />
           </ChartStyle.LineGrid>
+          {showLabels &&
+            series.map(({ label, data, params }) => (
+              <Styles.LineLabel
+                key={`label-${label}`}
+                x={innerWidth}
+                y={getYPosition(data[data.length - 1])}
+                fill={params?.stroke || '#000'}
+              >
+                {label}
+              </Styles.LineLabel>
+            ))}
           <Styles.TodayLabel>
             <text x={dateScale(today)} y={innerHeight} dy={21}>
               Today

--- a/src/components/Explore/Legend.tsx
+++ b/src/components/Explore/Legend.tsx
@@ -6,10 +6,10 @@ import { LegendMarker } from './SeriesChart';
 const Legend: React.FC<{ series: Series[] }> = ({ series }) => {
   return (
     <Styles.LegendContainer>
-      {series.map(({ type, label }, i) => (
+      {series.map(({ type, label, params }, i) => (
         <Styles.LegendItem key={`legend-item-${i}`}>
           <Styles.LegendItemMarker>
-            <LegendMarker type={type} />
+            <LegendMarker type={type} params={params} />
           </Styles.LegendItemMarker>
           <Styles.LegendItemLabel>{label}</Styles.LegendItemLabel>
         </Styles.LegendItem>

--- a/src/components/Explore/LocationSelector.style.ts
+++ b/src/components/Explore/LocationSelector.style.ts
@@ -1,0 +1,41 @@
+import styled from 'styled-components';
+import { Button } from '@material-ui/core';
+import theme from 'assets/theme';
+import palette from 'assets/theme/palette';
+
+export const ModalContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  background-color: white;
+  width: 90%;
+  margin: 200px auto;
+  border-radius: ${theme.spacing(1)}px;
+  padding: ${theme.spacing(2)}px;
+`;
+
+export const ModalHeader = styled.div`
+  flex: 0 1 auto;
+  margin-bottom: ${theme.spacing(3)}px;
+
+  /* TODO(Pablo): Use the theme */
+  font-family: Roboto;
+  font-style: normal;
+  font-weight: 500;
+  font-size: 12px;
+  line-height: 14px;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+`;
+
+export const ModalTitle = styled.div`
+  padding: ${theme.spacing(1)}px 0;
+`;
+
+export const ModalBody = styled.div`
+  flex: 1 0 auto;
+`;
+
+export const DoneButton = styled(Button)`
+  text-transform: none;
+  color: ${palette.lightBlue};
+`;

--- a/src/components/Explore/LocationSelector.tsx
+++ b/src/components/Explore/LocationSelector.tsx
@@ -1,0 +1,110 @@
+import React, { useState } from 'react';
+import Autocomplete from '@material-ui/lab/Autocomplete';
+import Grid from '@material-ui/core/Grid';
+import TextField from '@material-ui/core/TextField';
+import useMediaQuery from '@material-ui/core/useMediaQuery';
+import { Button } from '@material-ui/core';
+import { useTheme } from '@material-ui/core/styles';
+import { Modal } from '@material-ui/core';
+import { Location } from 'common/locations';
+import { getLocationLabel } from './utils';
+import * as Styles from './LocationSelector.style';
+
+const getFips = (location: Location) =>
+  location.full_fips_code || location.state_fips_code;
+
+const getOptionSelected = (option: Location, value: Location) =>
+  getFips(option) === getFips(value);
+
+const AutocompleteLocations: React.FC<{
+  locations: Location[];
+  selectedLocations: Location[];
+  onChangeLocations: (
+    event: React.ChangeEvent<{}>,
+    newLocations: Location[],
+  ) => void;
+}> = ({ locations, onChangeLocations, selectedLocations }) => (
+  <Autocomplete
+    multiple
+    options={locations}
+    getOptionLabel={getLocationLabel}
+    onChange={onChangeLocations}
+    getOptionSelected={getOptionSelected}
+    value={selectedLocations}
+    renderInput={params => (
+      <TextField
+        variant="outlined"
+        {...params}
+        placeholder="Compare states or counties"
+      />
+    )}
+  />
+);
+
+const LocationSelector: React.FC<{
+  locations: Location[];
+  selectedLocations: Location[];
+  onChangeSelectedLocations: (newLocations: Location[]) => void;
+}> = ({ locations, selectedLocations, onChangeSelectedLocations }) => {
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('xs'));
+
+  const [modalOpen, setModalOpen] = useState(false);
+
+  const onChangeLocations = (
+    event: React.ChangeEvent<{}>,
+    newLocations: Location[],
+  ) => {
+    onChangeSelectedLocations(newLocations);
+  };
+
+  const onClickButton = () => setModalOpen(!modalOpen);
+  const closeModal = () => setModalOpen(false);
+
+  return isMobile ? (
+    <React.Fragment>
+      <Button
+        variant="outlined"
+        disableRipple
+        disableFocusRipple
+        disableTouchRipple
+        onClick={onClickButton}
+      >
+        Compare
+      </Button>
+      {modalOpen ? (
+        <Modal open={modalOpen} onClose={closeModal}>
+          <Styles.ModalContainer>
+            <Styles.ModalHeader>
+              <Grid container>
+                <Grid item xs={9}>
+                  <Styles.ModalTitle>Compare Locations</Styles.ModalTitle>
+                </Grid>
+                <Grid item xs container justify="flex-end">
+                  <Styles.DoneButton size="small" onClick={closeModal}>
+                    Done
+                  </Styles.DoneButton>
+                </Grid>
+              </Grid>
+            </Styles.ModalHeader>
+            <Styles.ModalBody>
+              <AutocompleteLocations
+                locations={locations}
+                onChangeLocations={onChangeLocations}
+                selectedLocations={selectedLocations}
+              />
+            </Styles.ModalBody>
+          </Styles.ModalContainer>
+        </Modal>
+      ) : null}
+    </React.Fragment>
+  ) : (
+    <AutocompleteLocations
+      locations={locations}
+      onChangeLocations={onChangeLocations}
+      selectedLocations={selectedLocations}
+    />
+  );
+};
+
+export default LocationSelector;

--- a/src/components/Explore/SeriesChart.tsx
+++ b/src/components/Explore/SeriesChart.tsx
@@ -2,7 +2,7 @@ import React, { FunctionComponent } from 'react';
 import { curveCardinal } from '@vx/curve';
 import { LinePath } from '@vx/shape';
 import * as Styles from './Explore.style';
-import { ChartType } from './interfaces';
+import { ChartType, ChartParams } from './interfaces';
 import { Column } from 'common/models/Projection';
 import BarChart from 'components/Charts/BarChart';
 import { findPointByDate } from './utils';
@@ -15,11 +15,12 @@ const SeriesChart: FunctionComponent<{
   yMax: number;
   barWidth: number;
   barOpacity?: number;
-}> = ({ type, data, x, y, yMax, barWidth, barOpacity }) => {
+  chartParams?: ChartParams;
+}> = ({ type, data, x, y, yMax, barWidth, barOpacity, chartParams }) => {
   switch (type) {
     case ChartType.LINE:
       return (
-        <Styles.MainSeriesLine>
+        <Styles.MainSeriesLine stroke={chartParams?.stroke || '#000'}>
           <LinePath data={data} x={x} y={y} curve={curveCardinal} />
         </Styles.MainSeriesLine>
       );
@@ -32,7 +33,10 @@ const SeriesChart: FunctionComponent<{
   }
 };
 
-export const LegendMarker: React.FC<{ type: ChartType }> = ({ type }) => {
+export const LegendMarker: React.FC<{
+  type: ChartType;
+  params?: ChartParams;
+}> = ({ type, params }) => {
   // TODO(pablo): Transform into optional parameters
   const width = 12;
   const height = 12;
@@ -41,7 +45,7 @@ export const LegendMarker: React.FC<{ type: ChartType }> = ({ type }) => {
     case ChartType.LINE:
       return (
         <svg width={width} height={height}>
-          <Styles.MainSeriesLine>
+          <Styles.MainSeriesLine stroke={params?.stroke || '#000'}>
             <line x1={0} y1={height / 2} x2={width} y2={height / 2} />
           </Styles.MainSeriesLine>
         </svg>

--- a/src/components/Explore/interfaces.ts
+++ b/src/components/Explore/interfaces.ts
@@ -5,11 +5,16 @@ export enum ChartType {
   BAR,
 }
 
+export interface ChartParams {
+  stroke: string;
+}
+
 export interface Series {
   data: Column[];
   type: ChartType;
   label: string;
   tooltipLabel: string;
+  params?: ChartParams;
 }
 
 export enum ExploreMetric {

--- a/src/components/Explore/utils.ts
+++ b/src/components/Explore/utils.ts
@@ -8,6 +8,7 @@ import {
   isNumber,
   dropRightWhile,
   dropWhile,
+  flatten,
 } from 'lodash';
 import { Series } from './interfaces';
 import {
@@ -25,6 +26,7 @@ import {
   findStateByFips,
   Location,
 } from 'common/locations';
+import { fetchProjections } from 'common/utils/model';
 
 export function getMaxBy<T>(
   series: Series[],
@@ -67,6 +69,19 @@ export function getMetricByChartId(chartId: string): ExploreMetric | undefined {
       return ExploreMetric.HOSPITALIZATIONS;
     case 'icu-hospitalizations':
       return ExploreMetric.ICU_HOSPITALIZATIONS;
+  }
+}
+
+function getDatasetIdByMetric(metric: ExploreMetric): DatasetId {
+  switch (metric) {
+    case ExploreMetric.CASES:
+      return 'smoothedDailyCases';
+    case ExploreMetric.DEATHS:
+      return 'smoothedDailyDeaths';
+    case ExploreMetric.HOSPITALIZATIONS:
+      return 'smoothedHospitalizations';
+    case ExploreMetric.ICU_HOSPITALIZATIONS:
+      return 'smoothedICUHospitalizations';
   }
 }
 
@@ -315,4 +330,53 @@ export function getAutocompleteLocations(locationFips: string) {
     : allLocations
         .filter(isCounty)
         .filter(location => belongsToState(location, stateFips));
+}
+
+const colors = [
+  '#1f77b4',
+  '#ff7f0e',
+  '#2ca02c',
+  '#d62728',
+  '#9467bd',
+  '#8c564b',
+  '#e377c2',
+  '#7f7f7f',
+  '#bcbd22',
+  '#17becf',
+];
+
+function getSmoothedSeries(
+  metric: ExploreMetric,
+  projection: Projection,
+  color: string,
+): Series {
+  const datasetId = getDatasetIdByMetric(metric);
+  const location = findLocationForFips(projection.fips);
+  return {
+    data: cleanSeries(projection.getDataset(datasetId)),
+    type: ChartType.LINE,
+    params: {
+      stroke: color,
+    },
+    label: getLocationLabel(location),
+    tooltipLabel: '',
+  };
+}
+
+export function getChartSeries(metric: ExploreMetric, locations: Location[]) {
+  if (locations.length === 1) {
+    return fetchProjections(
+      locations[0].state_code,
+      locations[0].county,
+    ).then(projections => getSeries(metric, projections.primary));
+  } else {
+    return Promise.all(
+      locations.map((location, i) => {
+        const { state_code, county } = location;
+        return fetchProjections(state_code, county).then(projections =>
+          getSmoothedSeries(metric, projections.primary, colors[i % 10]),
+        );
+      }),
+    ).then(series => flatten(series));
+  }
 }


### PR DESCRIPTION
_work in progress_

This PR calculates the series to show when selecting multiple locations and updates the chart to show colored lines and labels.

### TODO
- Fix the tooltip
- Highlight the series on hover
- Add the tracker marker

### Notes
- We need to change the base of this PR to `pablo/explore-v2` before merging (and fix potential conflicts with that branch after merging `pablo/explore-v2--location-selector`)