### PR TITLE
explore v2: ensure that the current location is always selected

### DIFF
--- a/src/components/Explore/Explore.tsx
+++ b/src/components/Explore/Explore.tsx
@@ -1,5 +1,5 @@
 import React, { useState, FunctionComponent } from 'react';
-import { some } from 'lodash';
+import { some, uniq } from 'lodash';
 import Grid from '@material-ui/core/Grid';
 import useMediaQuery from '@material-ui/core/useMediaQuery';
 import { useTheme } from '@material-ui/core/styles';
@@ -58,7 +58,8 @@ const Explore: React.FunctionComponent<{
   ]);
 
   const onChangeSelectedLocations = (newLocations: Location[]) => {
-    setSelectedLocations(newLocations);
+    // make sure that the current location is always selected
+    setSelectedLocations(uniq([currentLocation, ...newLocations]));
   };
   const currentMetricName = metricLabels[currentMetric];
 


### PR DESCRIPTION
This ensures that the current location is always selected and also avoids having to handle the case where the user just unselects all the locations.