### PR TITLE
Only use ICU bed capacity from the timeseries if it's from the last 7 days.

### DIFF
--- a/src/common/models/ICUHeadroom.ts
+++ b/src/common/models/ICUHeadroom.ts
@@ -106,8 +106,10 @@ export function calcICUHeadroom(
     lastUpdated,
   );
 
+  // Use capacity from the timeseries if it's within the last 7 days, else use the
+  // non-timeseries value.
   const finalTotalBeds =
-    lastValue(actualTimeseries.map(r => r?.ICUBeds.capacity)) ||
+    lastValue(actualTimeseries.map(r => r?.ICUBeds.capacity).slice(-7)) ||
     actuals.ICUBeds.totalCapacity;
 
   const nonCovidPatientsResult = calcNonCovidICUPatientsSeries(


### PR DESCRIPTION
https://trello.com/c/nvHzgI0r/420-icuutilization-total-beds-disconnect-between-actuals-and-actualstimeseries

Imperial County before (20 beds):
![image](https://user-images.githubusercontent.com/206364/92043074-3b75a400-ed30-11ea-8e58-babf27a8e1c0.png)

Imperial County after (28 beds):
![image](https://user-images.githubusercontent.com/206364/92043083-3fa1c180-ed30-11ea-9bb0-9724d522efbf.png)
