### PR TITLE
accessibility: misc fixes

### DIFF
--- a/src/components/Footer/Footer.style.tsx
+++ b/src/components/Footer/Footer.style.tsx
@@ -63,11 +63,12 @@ export const StyledFooterBodyNav = styled.div`
     padding-top: 0.5rem;
   }
 
-  > span {
-    cursor: pointer;
+  > a {
     display: block;
     margin-bottom: 1rem;
     font-weight: bold;
+    text-decoration: none;
+    color: white;
 
     @media (min-width: 900px) {
       margin-bottom: 0;

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
+import { Link, useLocation } from 'react-router-dom';
 import Logo from 'assets/images/footerlogoDarkWithURL';
-import { useHistory, useLocation } from 'react-router-dom';
-
 import { useEmbed } from 'common/utils/hooks';
-
+import ExternalLink from 'components/ExternalLink';
 import FooterSocialLinks from './FooterSocialLinks';
 import {
   StyledFooter,
@@ -15,17 +14,8 @@ import {
 } from './Footer.style';
 
 const Footer = ({ children }: { children: React.ReactNode }) => {
-  const history = useHistory();
   const { pathname } = useLocation();
-
   const isMapPage = pathname.startsWith('/us') || pathname.startsWith('/state');
-
-  const goTo = (route: string) => {
-    history.push(route);
-
-    window.scrollTo(0, 0);
-  };
-
   const { isEmbed } = useEmbed();
 
   if (isEmbed) {
@@ -39,17 +29,13 @@ const Footer = ({ children }: { children: React.ReactNode }) => {
           <StyledFooterContent>
             <Logo />
             <StyledFooterBodyNav>
-              <span onClick={() => goTo('/')}>Map</span>
-              <span onClick={() => goTo('/about')}>About</span>
-              <span onClick={() => goTo('/resources')}>Resources</span>
-              <span
-                onClick={() => {
-                  window.location.href = 'https://blog.covidactnow.org';
-                }}
-              >
+              <Link to="/">Map</Link>
+              <Link to="/about">About</Link>
+              <Link to="/resources">Resources</Link>
+              <ExternalLink href="https://blog.covidactnow.org">
                 Blog
-              </span>
-              <span onClick={() => goTo('/contact')}>Contact Us</span>
+              </ExternalLink>
+              <Link to="/contact">Contact Us</Link>
             </StyledFooterBodyNav>
             <StyledFooterDivider />
             <StyledFooterBodyLinks>
@@ -57,9 +43,9 @@ const Footer = ({ children }: { children: React.ReactNode }) => {
             </StyledFooterBodyLinks>
             <StyledFooterDivider />
             <StyledFooterBodyLinks>
-              <span onClick={() => goTo('/contact')}>Contact</span>
+              <Link to="/contact">Contact</Link>
               {' ∙ '}
-              <span onClick={() => goTo('/terms')}>Terms</span>
+              <Link to="/terms">Terms</Link>
               {' ∙ '}
               <a href="mailto:press@covidactnow.org">Press</a>
             </StyledFooterBodyLinks>

--- a/src/components/Footer/FooterSocialLinks.js
+++ b/src/components/Footer/FooterSocialLinks.js
@@ -8,13 +8,13 @@ const FooterSocialLinks = props => {
 
   return (
     <Fragment>
-      <a href="https://www.facebook.com/covidactnow">
+      <a href="https://www.facebook.com/covidactnow" title="Facebook">
         <FacebookIcon size={iconSize} borderRadius={10} />
       </a>
-      <a href="https://www.instagram.com/covidactnow/">
+      <a href="https://www.instagram.com/covidactnow/" title="Instagram">
         <InstagramIcon size={iconSize} />
       </a>
-      <a href="https://twitter.com/CovidActNow">
+      <a href="https://twitter.com/CovidActNow" title="Twitter">
         <TwitterIcon size={iconSize} borderRadius={10} />
       </a>
     </Fragment>

--- a/src/components/Footer/FooterSocialLinks.js
+++ b/src/components/Footer/FooterSocialLinks.js
@@ -1,20 +1,19 @@
 import React, { Fragment } from 'react';
 import { FacebookIcon, TwitterIcon } from 'react-share';
-
-import InstagramIcon from '../../assets/images/InstagramIcon';
+import InstagramIcon from 'assets/images/InstagramIcon';
 
 const FooterSocialLinks = props => {
   const iconSize = 40;
 
   return (
     <Fragment>
-      <a href="https://www.facebook.com/covidactnow" title="Facebook">
+      <a href="https://www.facebook.com/covidactnow" aria-label="Facebook">
         <FacebookIcon size={iconSize} borderRadius={10} />
       </a>
-      <a href="https://www.instagram.com/covidactnow/" title="Instagram">
+      <a href="https://www.instagram.com/covidactnow/" aria-label="Instagram">
         <InstagramIcon size={iconSize} />
       </a>
-      <a href="https://twitter.com/CovidActNow" title="Twitter">
+      <a href="https://twitter.com/CovidActNow" aria-label="Twitter">
         <TwitterIcon size={iconSize} borderRadius={10} />
       </a>
     </Fragment>

--- a/src/components/LogoGrid/LogoGrid.tsx
+++ b/src/components/LogoGrid/LogoGrid.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+<<<<<<< HEAD
 import Grid from '@material-ui/core/Grid';
 import ExternalLink from 'components/ExternalLink';
 
@@ -50,6 +51,33 @@ export const PartnerLogoGrid = () => {
         </Grid>
       </Grid>
     </Grid>
+=======
+import ExternalLink from 'components/ExternalLink';
+import {
+  StyledPartnerLogoGrid,
+  StyledPressLogoGrid,
+  Logo,
+  LogoWrapper,
+} from './LogoGrid.style';
+
+export const PartnerLogoGrid = () => {
+  return (
+    <StyledPartnerLogoGrid>
+      <ExternalLink href="https://ghss.georgetown.edu/">
+        <Logo src="/images/ghss.png" alt="Georgetown University logo" />
+      </ExternalLink>
+      <ExternalLink href="http://med.stanford.edu/cerc.html">
+        <Logo
+          src="/images/cerc.jpg"
+          alt="Stanford Medicine Clinical Excellence Research Center logo"
+          style={{ transform: 'scale(1.1)' }}
+        />
+      </ExternalLink>
+      <ExternalLink href="https://grandrounds.com/">
+        <Logo src="/images/grand-rounds.png" alt="Grand Rounds logo" />
+      </ExternalLink>
+    </StyledPartnerLogoGrid>
+>>>>>>> minor accessibility fixes
   );
 };
 

--- a/src/components/LogoGrid/LogoGrid.tsx
+++ b/src/components/LogoGrid/LogoGrid.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-<<<<<<< HEAD
 import Grid from '@material-ui/core/Grid';
 import ExternalLink from 'components/ExternalLink';
 
@@ -51,33 +50,6 @@ export const PartnerLogoGrid = () => {
         </Grid>
       </Grid>
     </Grid>
-=======
-import ExternalLink from 'components/ExternalLink';
-import {
-  StyledPartnerLogoGrid,
-  StyledPressLogoGrid,
-  Logo,
-  LogoWrapper,
-} from './LogoGrid.style';
-
-export const PartnerLogoGrid = () => {
-  return (
-    <StyledPartnerLogoGrid>
-      <ExternalLink href="https://ghss.georgetown.edu/">
-        <Logo src="/images/ghss.png" alt="Georgetown University logo" />
-      </ExternalLink>
-      <ExternalLink href="http://med.stanford.edu/cerc.html">
-        <Logo
-          src="/images/cerc.jpg"
-          alt="Stanford Medicine Clinical Excellence Research Center logo"
-          style={{ transform: 'scale(1.1)' }}
-        />
-      </ExternalLink>
-      <ExternalLink href="https://grandrounds.com/">
-        <Logo src="/images/grand-rounds.png" alt="Grand Rounds logo" />
-      </ExternalLink>
-    </StyledPartnerLogoGrid>
->>>>>>> minor accessibility fixes
   );
 };
 

--- a/src/components/Map/USACountyMap.js
+++ b/src/components/Map/USACountyMap.js
@@ -74,7 +74,12 @@ const USACountyMap = ({ stateClickHandler, setTooltipContent, condensed }) => {
                   );
                 }
                 return stateCode ? (
-                  <Link key={stateCode} to={`/us/${stateCode.toLowerCase()}`}>
+                  <Link
+                    key={stateCode}
+                    to={`/us/${stateCode.toLowerCase()}`}
+                    title={name}
+                    aria-label={name}
+                  >
                     <Geography
                       key={geo.rsmKey}
                       geography={geo}
@@ -85,6 +90,7 @@ const USACountyMap = ({ stateClickHandler, setTooltipContent, condensed }) => {
                       onClick={() => stateClickHandler(name)}
                       fill={getFillColor(geo)}
                       stroke="white"
+                      role="img"
                     />
                   </Link>
                 ) : null;

--- a/src/components/Map/USACountyMap.js
+++ b/src/components/Map/USACountyMap.js
@@ -77,7 +77,6 @@ const USACountyMap = ({ stateClickHandler, setTooltipContent, condensed }) => {
                   <Link
                     key={stateCode}
                     to={`/us/${stateCode.toLowerCase()}`}
-                    title={name}
                     aria-label={name}
                   >
                     <Geography


### PR DESCRIPTION
Small accessibility fixes. This brings our accessibility score for the home page from 69 to 84, although I couldn't notice a difference when using the default Mac screen reader 🤷‍♂️ 

- Update the links in the footer to use links instead of span elements with an `onClick` handler
- Add the `aria-label` attribute to social links (they don't contain any text, just the social media logo)
- Add `alt` text to the homepage logos
- Add the `title` and `aria-label`s to the links for state shapes, and set the role of the shapes to `img` (they had an invalid role before)

### Learn more
- https://web.dev/image-alt
- https://web.dev/aria-roles
- https://web.dev/link-name
- https://www.deque.com/blog/text-links-practices-screen-readers/