### PR TITLE
explore v2: disable sharing buttons when comparing multiple locations

### DIFF
--- a/src/components/Explore/Explore.tsx
+++ b/src/components/Explore/Explore.tsx
@@ -100,6 +100,7 @@ const Explore: React.FunctionComponent<{
               url={getChartUrl(fips, currentMetric)}
               quote={getSocialQuote(fips, currentMetric)}
               hashtags={['COVIDActNow']}
+              disabled={hasMultipleLocations}
             />
           </Styles.ShareBlock>
         </Grid>

--- a/src/components/ShareButtons/ShareButtonGroup.tsx
+++ b/src/components/ShareButtons/ShareButtonGroup.tsx
@@ -15,7 +15,8 @@ const ShareImageButtons: React.FC<{
   url: string;
   quote: string;
   hashtags: string[];
-}> = ({ imageUrl, imageFilename, url, quote, hashtags }) => {
+  disabled?: boolean;
+}> = ({ imageUrl, imageFilename, url, quote, hashtags, disabled = false }) => {
   const [showSocialButtons, setShowSocialButtons] = useState(false);
   const hideSocialButtons = () => {
     const timeoutId = setTimeout(() => setShowSocialButtons(false), 1500);
@@ -44,6 +45,7 @@ const ShareImageButtons: React.FC<{
             disableRipple
             disableFocusRipple
             disableTouchRipple
+            disabled={disabled}
           >
             Save
           </ShareButton>
@@ -52,6 +54,7 @@ const ShareImageButtons: React.FC<{
             disableRipple
             disableFocusRipple
             disableTouchRipple
+            disabled={disabled}
           >
             Share
           </ShareButton>


### PR DESCRIPTION
Disable the sharing buttons when there are multiple locations selected.