### PR TITLE
explore v2: normalize per 100k population

### DIFF
--- a/src/common/locations.ts
+++ b/src/common/locations.ts
@@ -4,6 +4,7 @@ import { each, sortBy, takeRight, has } from 'lodash';
 import { assert } from './utils';
 import countyAdjacencyMsa from './data/county_adjacency_msa.json';
 import collegesByFips from './data/colleges_by_fips.json';
+import { REVERSED_STATES } from 'common';
 
 interface AdjacencyData {
   [fips: string]: {
@@ -177,4 +178,8 @@ export function findLocationForFips(fips: string): Location {
 
 export function getColleges(fips: string): CollegeData[] {
   return COLLEGES[fips] || [];
+}
+
+export function getStateCode(stateName: string) {
+  return REVERSED_STATES[stateName];
 }

--- a/src/components/AutocompleteLocations/AutocompleteLocations.tsx
+++ b/src/components/AutocompleteLocations/AutocompleteLocations.tsx
@@ -32,11 +32,7 @@ const AutocompleteLocations: React.FC<{
     getOptionSelected={getOptionSelected}
     value={selectedLocations}
     renderInput={params => (
-      <TextField
-        variant="outlined"
-        {...params}
-        placeholder="Compare states or counties"
-      />
+      <TextField variant="outlined" {...params} placeholder="+ Add" />
     )}
   />
 );

--- a/src/components/Explore/Explore.style.ts
+++ b/src/components/Explore/Explore.style.ts
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 import Box from '@material-ui/core/Box';
+import MuiCheckbox from '@material-ui/core/Checkbox';
 import Typography from '@material-ui/core/Typography';
 import MuiTab from '@material-ui/core/Tab';
 import MuiTabs from '@material-ui/core/Tabs';
@@ -70,6 +71,8 @@ export const Tab = styled(MuiTab)`
 export const ChartControlsContainer = styled.div`
   margin: ${theme.spacing(2)}px auto;
 `;
+
+export const NormalizeCheckbox = styled(MuiCheckbox)``;
 
 export const LegendContainer = styled(Box)`
   display: flex;

--- a/src/components/Explore/Explore.style.ts
+++ b/src/components/Explore/Explore.style.ts
@@ -7,6 +7,7 @@ import MuiTabs from '@material-ui/core/Tabs';
 import theme from 'assets/theme';
 import colorPalette from 'assets/theme/palette';
 import { charts } from 'components/Charts/Charts.style';
+import { COLOR_MAP } from 'common/colors';
 
 /** Gets the chart palette based on the current theme. */
 function palette(props: any) {
@@ -72,12 +73,34 @@ export const ChartControlsContainer = styled.div`
   margin: ${theme.spacing(2)}px auto;
 `;
 
-export const NormalizeCheckbox = styled(MuiCheckbox)``;
+export const TableAutocompleteHeader = styled.div`
+  display: none;
+
+  @media (min-width: 600px) {
+    display: flex;
+    font-size: 0.75rem;
+    letter-spacing: 0.03em;
+    text-transform: uppercase;
+    color: ${COLOR_MAP.GRAY_BODY_COPY};
+  }
+`;
+
+export const NormalizeCheckbox = styled(MuiCheckbox)`
+  svg {
+    fill: ${COLOR_MAP.GRAY.DARK};
+  }
+`;
 
 export const LegendContainer = styled(Box)`
   display: flex;
   flex-direction: row;
   justify-content: center;
+
+  @media (min-width: 600px) {
+    flex-direction: column;
+    align-items: flex-start;
+    margin-left: 2rem;
+  }
 `;
 
 export const LegendItem = styled(Box)`
@@ -104,9 +127,17 @@ export const LegendItemLabel = styled.span`
 
 // CHARTS
 
-export const ChartContainer = styled.div`
+export const ChartContainer = styled.div<{ adjustContainerWidth?: boolean }>`
   margin-top: ${theme.spacing(4)}px;
   margin-bottom: ${theme.spacing(3)}px;
+  margin-left: ${({ adjustContainerWidth }) => adjustContainerWidth && '-1rem'};
+  margin-right: ${({ adjustContainerWidth }) =>
+    adjustContainerWidth && '-3rem'};
+
+  @media (min-width: 600px) {
+    margin-left: 0;
+    margin-right: 0;
+  }
 `;
 
 export const PositionRelative = styled.div`
@@ -239,4 +270,25 @@ export const TooltipLocation = styled.div`
   font-size: 11px;
   line-height: 13px;
   color: ${colorPalette.white};
+`;
+
+export const NormalizeDataContainer = styled.div<{
+  hideNormalizeControl?: boolean;
+}>`
+  display: flex;
+  flex-direction: column;
+  padding-top: 1.25rem;
+  display: ${({ hideNormalizeControl }) => hideNormalizeControl && 'none'};
+
+  @media (min-width: 600px) {
+    padding-top: 0;
+    margin-left: 2rem;
+  }
+`;
+
+export const NormalizeSubLabel = styled.div`
+  font-size: 0.75rem;
+  color: ${COLOR_MAP.GRAY_BODY_COPY};
+  margin-left: 2rem;
+  transform: translateY(-0.75rem);
 `;

--- a/src/components/Explore/Explore.tsx
+++ b/src/components/Explore/Explore.tsx
@@ -31,6 +31,7 @@ import {
   getChartSeries,
 } from './utils';
 import * as Styles from './Explore.style';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
 
 const Explore: React.FunctionComponent<{
   projection: Projection;
@@ -43,6 +44,8 @@ const Explore: React.FunctionComponent<{
   const defaultMetric =
     (chartId && getMetricByChartId(chartId)) || ExploreMetric.CASES;
   const [currentMetric, setCurrentMetric] = useState(defaultMetric);
+
+  const [normalizeData, setNormalizeData] = useState(true);
 
   const onChangeTab = (newMetric: number) => setCurrentMetric(newMetric);
 
@@ -71,9 +74,10 @@ const Explore: React.FunctionComponent<{
 
   const [chartSeries, setChartSeries] = useState<Series[]>([]);
   useEffect(() => {
-    const fetchSeries = () => getChartSeries(currentMetric, selectedLocations);
-    fetchSeries().then(seriesList => setChartSeries(seriesList));
-  }, [selectedLocations, currentMetric]);
+    const fetchSeries = () =>
+      getChartSeries(currentMetric, selectedLocations, normalizeData);
+    fetchSeries().then(setChartSeries);
+  }, [selectedLocations, currentMetric, normalizeData]);
 
   const hasData = some(chartSeries, ({ data }) => data.length > 0);
   const hasMultipleLocations = selectedLocations.length > 1;
@@ -88,8 +92,8 @@ const Explore: React.FunctionComponent<{
         <Grid item sm={6} xs={12}>
           <Styles.Heading variant="h4">Trends</Styles.Heading>
           <Styles.Subtitle>
-            {currentMetricName} since march 1st in{' '}
-            {getLocationNames(selectedLocations)}
+            {currentMetricName} {normalizeData ? 'per 100k population' : ''}{' '}
+            since march 1st in {getLocationNames(selectedLocations)}
           </Styles.Subtitle>
         </Grid>
         <Grid item sm={6} xs={12}>
@@ -121,6 +125,24 @@ const Explore: React.FunctionComponent<{
           {!hasMultipleLocations && (
             <Grid key="legend" item sm xs={12}>
               <Legend seriesList={chartSeries} />
+            </Grid>
+          )}
+          {hasMultipleLocations && (
+            <Grid key="legend" item sm xs={12}>
+              <FormControlLabel
+                control={
+                  <Styles.NormalizeCheckbox
+                    checked={normalizeData}
+                    onChange={() => {
+                      setNormalizeData(!normalizeData);
+                    }}
+                    name="normalize data"
+                    disableRipple
+                    id="normalize-data-control"
+                  />
+                }
+                label="Normalize Data"
+              />
             </Grid>
           )}
         </Grid>

--- a/src/components/Explore/Explore.tsx
+++ b/src/components/Explore/Explore.tsx
@@ -36,10 +36,12 @@ import FormControlLabel from '@material-ui/core/FormControlLabel';
 const Explore: React.FunctionComponent<{
   projection: Projection;
   chartId?: string;
-}> = ({ projection, chartId }) => {
+  compareCopy: string;
+}> = ({ projection, chartId, compareCopy }) => {
   const { locationName, fips } = projection;
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+  const isMobileXs = useMediaQuery(theme.breakpoints.down('xs'));
 
   const defaultMetric =
     (chartId && getMetricByChartId(chartId)) || ExploreMetric.CASES;
@@ -86,6 +88,12 @@ const Explore: React.FunctionComponent<{
   const lastUpdatedDateString =
     lastUpdatedDate !== null ? lastUpdatedDate.toLocaleDateString() : '';
 
+  const modalNormalizeCheckboxProps = {
+    hasMultipleLocations,
+    normalizeData,
+    setNormalizeData,
+  };
+
   return (
     <Styles.Container>
       <Grid container spacing={1}>
@@ -114,12 +122,17 @@ const Explore: React.FunctionComponent<{
         onChangeTab={onChangeTab}
       />
       <Styles.ChartControlsContainer>
+        <Styles.TableAutocompleteHeader>
+          {compareCopy}
+        </Styles.TableAutocompleteHeader>
         <Grid container spacing={1}>
           <Grid key="location-selector" item sm={6} xs={6}>
             <LocationSelector
               locations={autocompleteLocations}
               selectedLocations={selectedLocations}
               onChangeSelectedLocations={onChangeSelectedLocations}
+              {...modalNormalizeCheckboxProps}
+              compareCopy={compareCopy}
             />
           </Grid>
           {!hasMultipleLocations && (
@@ -128,27 +141,32 @@ const Explore: React.FunctionComponent<{
             </Grid>
           )}
           {hasMultipleLocations && (
-            <Grid key="legend" item sm xs={12}>
-              <FormControlLabel
-                control={
-                  <Styles.NormalizeCheckbox
-                    checked={normalizeData}
-                    onChange={() => {
-                      setNormalizeData(!normalizeData);
-                    }}
-                    name="normalize data"
-                    disableRipple
-                    id="normalize-data-control"
-                  />
-                }
-                label="Normalize Data"
-              />
-            </Grid>
+            <Styles.NormalizeDataContainer hideNormalizeControl={isMobileXs}>
+              <Grid key="legend" item sm xs={12}>
+                <FormControlLabel
+                  control={
+                    <Styles.NormalizeCheckbox
+                      checked={normalizeData}
+                      onChange={() => {
+                        setNormalizeData(!normalizeData);
+                      }}
+                      name="normalize data"
+                      disableRipple
+                      id="normalize-data-control"
+                    />
+                  }
+                  label="Normalize Data"
+                />
+                <Styles.NormalizeSubLabel>
+                  Per 100k population
+                </Styles.NormalizeSubLabel>
+              </Grid>
+            </Styles.NormalizeDataContainer>
           )}
         </Grid>
       </Styles.ChartControlsContainer>
       {hasData ? (
-        <Styles.ChartContainer>
+        <Styles.ChartContainer adjustContainerWidth={hasMultipleLocations}>
           {/**
            * The width is set to zero while the parent div is rendering, the
            * placeholder div below prevents the page from jumping.
@@ -163,6 +181,7 @@ const Explore: React.FunctionComponent<{
                   height={400}
                   tooltipSubtext={`in ${locationName}`}
                   hasMultipleLocations={hasMultipleLocations}
+                  isMobileXs={isMobileXs}
                 />
               ) : (
                 <div style={{ height: 400 }} />

--- a/src/components/Explore/ExploreChart.tsx
+++ b/src/components/Explore/ExploreChart.tsx
@@ -16,6 +16,7 @@ const ExploreChart: React.FC<{
   marginRight?: number;
   barOpacity?: number;
   barOpacityHover?: number;
+  isMobileXs?: boolean;
 }> = ({
   hasMultipleLocations,
   barOpacity,

--- a/src/components/Explore/LocationSelector.style.ts
+++ b/src/components/Explore/LocationSelector.style.ts
@@ -38,4 +38,11 @@ export const ModalBody = styled.div`
 export const DoneButton = styled(Button)`
   text-transform: none;
   color: ${palette.lightBlue};
+  min-width: fit-content;
+`;
+
+export const ModalOpenButton = styled(Button)`
+  white-space: nowrap;
+  width: fit-content;
+  margin-bottom: 0.5rem;
 `;

--- a/src/components/Explore/LocationSelector.tsx
+++ b/src/components/Explore/LocationSelector.tsx
@@ -1,20 +1,33 @@
 import React, { useState } from 'react';
 import Grid from '@material-ui/core/Grid';
 import useMediaQuery from '@material-ui/core/useMediaQuery';
-import { Button } from '@material-ui/core';
 import { useTheme } from '@material-ui/core/styles';
 import { Modal } from '@material-ui/core';
 import { Location } from 'common/locations';
 import * as Styles from './LocationSelector.style';
 import AutocompleteLocations from 'components/AutocompleteLocations';
 
+import FormControlLabel from '@material-ui/core/FormControlLabel';
+import * as ExploreStyles from './Explore.style';
+
 const LocationSelector: React.FC<{
   locations: Location[];
   selectedLocations: Location[];
   onChangeSelectedLocations: (newLocations: Location[]) => void;
-}> = ({ locations, selectedLocations, onChangeSelectedLocations }) => {
+  normalizeData: boolean;
+  setNormalizeData: React.Dispatch<React.SetStateAction<boolean>>;
+  compareCopy: string;
+}> = ({
+  locations,
+  selectedLocations,
+  onChangeSelectedLocations,
+  normalizeData,
+  setNormalizeData,
+  compareCopy,
+}) => {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('xs'));
+  const hasMultipleLocations = selectedLocations.length > 1;
 
   const [modalOpen, setModalOpen] = useState(false);
 
@@ -30,22 +43,26 @@ const LocationSelector: React.FC<{
 
   return isMobile ? (
     <React.Fragment>
-      <Button
+      <Styles.ModalOpenButton
         variant="outlined"
         disableRipple
         disableFocusRipple
         disableTouchRipple
         onClick={onClickButton}
       >
-        Compare
-      </Button>
+        {compareCopy}
+      </Styles.ModalOpenButton>
       {modalOpen && (
-        <Modal open={modalOpen} onClose={closeModal}>
+        <Modal
+          open={modalOpen}
+          onClose={closeModal}
+          style={{ touchAction: 'none' }}
+        >
           <Styles.ModalContainer>
             <Styles.ModalHeader>
               <Grid container>
                 <Grid item xs={9}>
-                  <Styles.ModalTitle>Compare Locations</Styles.ModalTitle>
+                  <Styles.ModalTitle>{compareCopy}</Styles.ModalTitle>
                 </Grid>
                 <Grid item xs container justify="flex-end">
                   <Styles.DoneButton size="small" onClick={closeModal}>
@@ -60,6 +77,29 @@ const LocationSelector: React.FC<{
                 onChangeLocations={onChangeLocations}
                 selectedLocations={selectedLocations}
               />
+              {hasMultipleLocations && (
+                <ExploreStyles.NormalizeDataContainer>
+                  <Grid key="legend" item sm xs={12}>
+                    <FormControlLabel
+                      control={
+                        <ExploreStyles.NormalizeCheckbox
+                          checked={normalizeData}
+                          onChange={() => {
+                            setNormalizeData(!normalizeData);
+                          }}
+                          name="normalize data"
+                          disableRipple
+                          id="normalize-data-control"
+                        />
+                      }
+                      label="Normalize Data"
+                    />
+                  </Grid>
+                  <ExploreStyles.NormalizeSubLabel>
+                    Per 100k population
+                  </ExploreStyles.NormalizeSubLabel>
+                </ExploreStyles.NormalizeDataContainer>
+              )}
             </Styles.ModalBody>
           </Styles.ModalContainer>
         </Modal>

--- a/src/components/Explore/MultipleLocationsChart.tsx
+++ b/src/components/Explore/MultipleLocationsChart.tsx
@@ -19,6 +19,7 @@ import { Line } from '@vx/shape';
 import DateMarker from './DateMarker';
 import GridLines from './GridLines';
 import Axes from './Axes';
+import { getStateCode } from 'common/locations';
 
 const getDate = (d: Column) => new Date(d.x);
 const getY = (d: Column) => d.y;
@@ -110,6 +111,7 @@ const MultipleLocationsChart: React.FC<{
   marginLeft?: number;
   marginRight?: number;
   barOpacity?: number;
+  isMobileXs?: boolean;
 }> = ({
   width,
   height,
@@ -120,6 +122,7 @@ const MultipleLocationsChart: React.FC<{
   marginLeft = 60,
   marginRight = 100,
   barOpacity,
+  isMobileXs,
 }) => {
   const dateFrom = new Date('2020-03-01');
   const dateTo = new Date();
@@ -178,8 +181,11 @@ const MultipleLocationsChart: React.FC<{
             dateScale={dateScale}
             strokeColor={axisGridColor}
           />
-          {seriesList.map(({ label, data, params }, i) =>
-            data.length > 0 ? (
+          {seriesList.map(({ label, data, params }, i) => {
+            const locationLabel = !isMobileXs
+              ? label
+              : getStateCode(label) || label.slice(0, 3);
+            return data.length > 0 ? (
               <Styles.LineLabel
                 key={`label-${label}`}
                 x={innerWidth + 5}
@@ -187,10 +193,10 @@ const MultipleLocationsChart: React.FC<{
                 fill={params?.stroke || '#000'}
                 fillOpacity={getSeriesOpacity(i, tooltipOpen, tooltipData)}
               >
-                {label}
+                {locationLabel}
               </Styles.LineLabel>
-            ) : null,
-          )}
+            ) : null;
+          })}
           <RectClipGroup width={innerWidth} height={innerHeight}>
             {seriesList.map(({ label, data, type, params }, i) => (
               <ChartSeries

--- a/src/components/Explore/utils.ts
+++ b/src/components/Explore/utils.ts
@@ -372,9 +372,8 @@ export function getAutocompleteLocations(locationFips: string) {
   const allLocations = getAllLocations();
   return isState(currentLocation)
     ? allLocations.filter(isState)
-    : allLocations
-        .filter(isCounty)
-        .filter(location => belongsToState(location, stateFips));
+    : allLocations.filter(isCounty);
+  // .filter(location => belongsToState(location, stateFips));
 }
 
 /**

--- a/src/components/Explore/utils.ts
+++ b/src/components/Explore/utils.ts
@@ -27,7 +27,7 @@ import { SeriesType, Series } from './interfaces';
 import {
   isState,
   isCounty,
-  belongsToState,
+  // belongsToState,
 } from 'components/AutocompleteLocations';
 
 export function getMaxBy<T>(
@@ -366,9 +366,11 @@ export function getLocationNames(locations: Location[]) {
     .join(', ')} and ${getLocationLabel(lastLocation)}.`;
 }
 
+// note (Chelsi): commenting out belongsToState filter
+// so we can compare all US counties:
 export function getAutocompleteLocations(locationFips: string) {
   const currentLocation = findLocationForFips(locationFips);
-  const stateFips = currentLocation.state_fips_code;
+  // const stateFips = currentLocation.state_fips_code;
   const allLocations = getAllLocations();
   return isState(currentLocation)
     ? allLocations.filter(isState)

--- a/src/components/LocationPage/ChartsHolder.tsx
+++ b/src/components/LocationPage/ChartsHolder.tsx
@@ -151,6 +151,10 @@ const ChartsHolder = (props: {
     metricsInfo: countySummary(props.county.full_fips_code),
   };
 
+  const exploreCompareCopy: string = props.county
+    ? 'Compare counties'
+    : 'Compare states';
+
   // TODO(pablo): Create separate refs for signup and share
   return (
     <>
@@ -196,6 +200,7 @@ const ChartsHolder = (props: {
               <Explore
                 projection={props.projections.primary}
                 chartId={chartId}
+                compareCopy={exploreCompareCopy}
               />
             </MainContentInner>
           </ChartContentWrapper>

--- a/src/components/Map/USACountyMap.js
+++ b/src/components/Map/USACountyMap.js
@@ -5,13 +5,9 @@ import { colorFromLocationSummary } from 'common/colors';
 import { geoAlbersUsaTerritories } from 'geo-albers-usa-territories';
 import STATES_JSON from './data/states-10m.json';
 import { USMapWrapper, USStateMapWrapper } from './Map.style';
-import { REVERSED_STATES } from 'common';
 import { useSummaries } from 'common/location_summaries';
 import { ScreenshotReady } from 'components/Screenshot';
-
-function getStateCode(stateName) {
-  return REVERSED_STATES[stateName];
-}
+import { getStateCode } from 'common/locations';
 
 const USACountyMap = ({ stateClickHandler, setTooltipContent, condensed }) => {
   const locationSummaries = useSummaries();


### PR DESCRIPTION
This PR implements normalization of Explore metrics per 100k population.

### Pending
- Styling the checkbox, labels, spacing, etc.
- Add the normalization control for mobile (see designs in [Figma](https://www.figma.com/file/nkoC6P02eXxkB95ukdU6Ms/Explore?node-id=260%3A747))