### PR TITLE
Improve computation of maxTick

### DIFF
--- a/src/components/Charts/utils.ts
+++ b/src/components/Charts/utils.ts
@@ -86,7 +86,7 @@ export const computeTickPositions = (
   zones: LevelInfoMap,
 ) => {
   const maxZones = zones[Level.HIGH].upperLimit;
-  const maxTick = maxY < maxZones ? 1.5 * maxZones : maxY;
+  const maxTick = maxY < 1.5 * maxZones ? 1.5 * maxZones : maxY;
   return [
     minY,
     zones[Level.LOW].upperLimit,


### PR DESCRIPTION
Addressing the y-axis issue: https://trello.com/c/82IW2Lvm/323-poor-y-axis-range-when-graph-barely-enters-critical-range

If the highest y coordinate of the dataset surpassed upper limit (in this case 20%) of the High level, the maxTick would be set to that Y, rather than 1.5 x the upper limit.  This is why maxTick went from 35% to 21% as soon as the data passed 20%.