### PR TITLE
Use Firestore to store share parameters so we can create predictable URLs.

### DIFF
--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -4,5 +4,18 @@ service cloud.firestore {
     match /alerts-subscriptions/{email} {
       allow read, write;
     }
+
+    // Document for tracking the next ID to be used for sharing compare params.
+    match /compare-shared-params/__nextId {
+      allow read;
+      // Only allow increments.
+      allow write: if resource == null || request.resource.data.id == resource.data.id + 1;
+    }
+    // Each document stores a set of share params corresponding to a shared compare table.
+    match /compare-shared-params/{sharingId} {
+      allow read;
+      // Can write only if it doesn't exist.
+      allow write: if resource == null;
+    }
   }
 }

--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -12,7 +12,7 @@ service cloud.firestore {
       allow write: if resource == null || request.resource.data.id == resource.data.id + 1;
     }
     // Each document stores a set of share params corresponding to a shared compare table.
-    match /compare-shared-params/{sharingId} {
+    match /compare-shared-params/{compareShareId} {
       allow read;
       // Can write only if it doesn't exist.
       allow write: if resource == null;

--- a/scripts/generate_index_pages.ts
+++ b/scripts/generate_index_pages.ts
@@ -29,6 +29,10 @@ const COUNTIES = Object.keys(LocationSummariesByFIPS).filter(
   fips => fips.length === 5,
 );
 
+// TODO(michael): We will need to increase this once people share 2000 tables
+// (or come up with a new strategy).
+const COMPARE_IDS_TO_GENERATE = 2000;
+
 const BLACKLISTED_COUNTIES = [
   '11001', // Washington, DC - We treat it as a state, not a county.
 ];
@@ -151,6 +155,17 @@ async function main() {
     '/index.html',
     homePageTags(builder.fullImageUrl('home.png')),
   );
+
+  for (let i = 1; i < COMPARE_IDS_TO_GENERATE; i++) {
+    // Minor hack: Just use the location page tags, but insert "your community"
+    // for the locationName since we don't know it.
+    const url = urls.addSharingId(`https://covidactnow.org/compare/${i}/`);
+    const imageUrl = builder.fullImageUrl(`/compare/${i}.png`);
+    await builder.writeTemplatedPage(
+      `/compare/${i}/index.html`,
+      locationPageTags(imageUrl, url, 'your community'),
+    );
+  }
 
   for (const stateCode in STATES) {
     const stateName = (STATES as any)[stateCode];

--- a/src/App.js
+++ b/src/App.js
@@ -42,7 +42,7 @@ export default function App() {
             <Switch>
               <Route exact path="/" component={HomePage} />
               <Route exact path="/alert_signup" component={HomePage} />
-              <Route exact path="/compare" component={HomePage} />
+              <Route exact path="/compare/:sharingId?" component={HomePage} />
 
               <Route
                 exact
@@ -68,7 +68,7 @@ export default function App() {
               />
               <Route
                 exact
-                path="/us/:stateId/compare"
+                path="/us/:stateId/compare/:sharingId?"
                 component={LocationPage}
               />
               <Route
@@ -83,7 +83,7 @@ export default function App() {
               />
               <Route
                 exact
-                path="/us/:stateId/county/:countyId/compare"
+                path="/us/:stateId/county/:countyId/compare/:sharingId?"
                 component={LocationPage}
               />
               {/* /state/ routes are deprecated but still supported. */}
@@ -165,9 +165,6 @@ export default function App() {
               <Route path="/internal/all" component={AllStates} />
 
               {/** Internal endpoint for comparing API snapshots. */}
-              <Route path="/compare">
-                <Redirect to="/internal/compare" />
-              </Route>
               <Route path="/internal/compare" component={CompareSnapshots} />
 
               {/** Internal endpoints we use to generate the content that we

--- a/src/App.js
+++ b/src/App.js
@@ -42,7 +42,11 @@ export default function App() {
             <Switch>
               <Route exact path="/" component={HomePage} />
               <Route exact path="/alert_signup" component={HomePage} />
-              <Route exact path="/compare/:sharingId?" component={HomePage} />
+              <Route
+                exact
+                path="/compare/:compareShareId?"
+                component={HomePage}
+              />
 
               <Route
                 exact
@@ -68,7 +72,7 @@ export default function App() {
               />
               <Route
                 exact
-                path="/us/:stateId/compare/:sharingId?"
+                path="/us/:stateId/compare/:compareShareId?"
                 component={LocationPage}
               />
               <Route
@@ -83,7 +87,7 @@ export default function App() {
               />
               <Route
                 exact
-                path="/us/:stateId/county/:countyId/compare/:sharingId?"
+                path="/us/:stateId/county/:countyId/compare/:compareShareId?"
                 component={LocationPage}
               />
               {/* /state/ routes are deprecated but still supported. */}

--- a/src/App.js
+++ b/src/App.js
@@ -29,6 +29,7 @@ import ScrollToTop from 'components/ScrollToTop';
 import theme from 'assets/theme';
 import { getFeedbackSurveyUrl } from 'components/Banner';
 import ExternalRedirect from 'components/ExternalRedirect';
+import HandleRedirectTo from 'components/HandleRedirectTo/HandleRedirectTo';
 
 export default function App() {
   return (
@@ -37,6 +38,7 @@ export default function App() {
         <StylesProvider injectFirst>
           <CssBaseline />
           <BrowserRouter>
+            <HandleRedirectTo />
             <ScrollToTop />
             <AppBar />
             <Switch>

--- a/src/common/urls.ts
+++ b/src/common/urls.ts
@@ -64,22 +64,22 @@ export function getPageUrl(
 export function getComparePageUrl(
   stateId: string | undefined,
   county: County | undefined,
-  sharingId: string,
+  compareShareId: string,
 ): string {
   return addSharingId(
-    urlJoin(getPageBaseUrl(stateId, county), 'compare', sharingId),
+    urlJoin(getPageBaseUrl(stateId, county), 'compare', compareShareId),
   );
 }
 
 export function getCompareShareImageUrl(
   stateId: string | undefined,
   county: County | undefined,
-  sharingId: string,
+  compareShareId: string,
 ): string {
   return urlJoin(
     getShareImageBaseUrl(stateId, county),
     'compare',
-    `${sharingId}.png`,
+    `${compareShareId}.png`,
   );
 }
 

--- a/src/common/urls.ts
+++ b/src/common/urls.ts
@@ -1,7 +1,7 @@
 import ShareImageUrlJSON from 'assets/data/share_images_url.json';
-import * as QueryString from 'query-string';
 import { assert } from 'common/utils';
 import { County } from './locations';
+import urlJoin from 'url-join';
 
 /**
  * We append a short unique string corresponding to the currently published
@@ -39,6 +39,20 @@ function getPageBaseUrl(
   return shareURL;
 }
 
+function getShareImageBaseUrl(
+  stateId: string | undefined,
+  county: County | undefined,
+): string {
+  const imageBaseUrl = ShareImageUrlJSON.share_image_url;
+  if (county) {
+    return urlJoin(imageBaseUrl, 'counties', county.full_fips_code);
+  } else if (stateId) {
+    return urlJoin(imageBaseUrl, 'states', stateId);
+  } else {
+    return imageBaseUrl;
+  }
+}
+
 // TODO(michael): Move existing code over to use this method.
 export function getPageUrl(
   stateId: string | undefined,
@@ -50,11 +64,23 @@ export function getPageUrl(
 export function getComparePageUrl(
   stateId: string | undefined,
   county: County | undefined,
-  shareParams: { [key: string]: unknown },
+  sharingId: string,
 ): string {
-  const url = getPageBaseUrl(stateId, county) + '/compare';
-  ensureSharingIdInQueryParams(shareParams);
-  return url + '?' + QueryString.stringify(shareParams);
+  return addSharingId(
+    urlJoin(getPageBaseUrl(stateId, county), 'compare', sharingId),
+  );
+}
+
+export function getCompareShareImageUrl(
+  stateId: string | undefined,
+  county: County | undefined,
+  sharingId: string,
+): string {
+  return urlJoin(
+    getShareImageBaseUrl(stateId, county),
+    'compare',
+    `${sharingId}.png`,
+  );
 }
 
 /**

--- a/src/components/Compare/CompareMain.tsx
+++ b/src/components/Compare/CompareMain.tsx
@@ -132,13 +132,13 @@ const CompareMain = (props: {
     geoScope,
   };
 
-  // createSharingId() stores the current share params to Firestore under a
+  // createCompareShareId() stores the current share params to Firestore under a
   // newly-assigned numeric ID and returns it. We cache the result so multiple
   // calls don't generate extra IDs.
-  let createSharingIdPromise: Promise<string> | null = null;
-  const createSharingId = async () => {
-    if (!createSharingIdPromise) {
-      createSharingIdPromise = firestore.runTransaction(async txn => {
+  let createCompareShareIdPromise: Promise<string> | null = null;
+  const createCompareShareId = async () => {
+    if (!createCompareShareIdPromise) {
+      createCompareShareIdPromise = firestore.runTransaction(async txn => {
         const nextIdDoc = await txn.get(nextIdDocRef);
         const id = nextIdDoc.data()?.id || 0;
 
@@ -149,12 +149,12 @@ const CompareMain = (props: {
       });
     }
 
-    return createSharingIdPromise;
+    return createCompareShareIdPromise;
   };
 
-  // Check for a /compare/{sharingId} in the URL and use it to repopulate the
+  // Check for a /compare/{compareShareId} in the URL and use it to repopulate the
   // compare table if it's there.
-  const { sharingId } = useParams();
+  const { compareShareId } = useParams();
   useEffect(() => {
     async function fetchParamsFromFirestore(id: string) {
       const doc = await paramsCollection.doc(id).get();
@@ -168,13 +168,13 @@ const CompareMain = (props: {
         setGeoScope(params['geoScope']);
         setSliderValue(scopeValueMap[params['geoScope'] as GeoScopeFilter]);
       } else {
-        console.error('Invalid Sharing ID:', sharingId);
+        console.error('Invalid Sharing ID:', compareShareId);
       }
     }
-    if (sharingId) {
-      fetchParamsFromFirestore(sharingId);
+    if (compareShareId) {
+      fetchParamsFromFirestore(compareShareId);
     }
-  }, [sharingId]);
+  }, [compareShareId]);
 
   if (locations.length === 0) {
     return null;
@@ -198,7 +198,7 @@ const CompareMain = (props: {
     sliderValue,
     setSliderValue,
     setShowFaqModal,
-    createSharingId,
+    createCompareShareId,
   };
 
   return (

--- a/src/components/Compare/CompareMain.tsx
+++ b/src/components/Compare/CompareMain.tsx
@@ -28,6 +28,7 @@ import { Metric } from 'common/metric';
 import { getFirebase } from 'common/firebase';
 import { countySummary } from 'common/location_summaries';
 import { findCountyByFips } from 'common/locations';
+import { ScreenshotReady } from 'components/Screenshot';
 
 const firestore = getFirebase().firestore();
 const paramsCollection = firestore.collection('compare-shared-params');
@@ -170,6 +171,8 @@ const CompareMain = (props: {
     return createCompareShareIdPromise;
   };
 
+  const [screenshotReady, setScreenshotReady] = useState(false);
+
   // Check for a /compare/{compareShareId} in the URL and use it to repopulate the
   // compare table if it's there.
   const { compareShareId } = useParams();
@@ -193,6 +196,9 @@ const CompareMain = (props: {
         setViewAllCounties(params['viewAllCounties']);
         setGeoScope(params['geoScope']);
         setSliderValue(scopeValueMap[params['geoScope'] as GeoScopeFilter]);
+
+        // Now that the UI is populated, we can capture the screenshot.
+        setScreenshotReady(true);
       } else {
         console.error('Invalid Sharing ID:', compareShareId);
       }
@@ -243,6 +249,7 @@ const CompareMain = (props: {
       <CenteredContentModal open={showFaqModal} onClose={handleCloseModal}>
         <ModalFaq handleCloseModal={handleCloseModal} />
       </CenteredContentModal>
+      {screenshotReady && <ScreenshotReady />}
     </Fragment>
   );
 };

--- a/src/components/Compare/CompareTable.tsx
+++ b/src/components/Compare/CompareTable.tsx
@@ -24,6 +24,7 @@ import { COLOR_MAP } from 'common/colors';
 import ShareImageButtons from 'components/ShareButtons/ShareButtonGroup';
 import HelpOutlineIcon from '@material-ui/icons/HelpOutline';
 import { sliderNumberToFilterMap } from 'components/Compare/Filters';
+import { getComparePageUrl, getCompareShareImageUrl } from 'common/urls';
 
 const CompareTable = (props: {
   stateName?: string;
@@ -51,7 +52,7 @@ const CompareTable = (props: {
   sliderValue: GeoScopeFilter;
   setSliderValue: React.Dispatch<React.SetStateAction<GeoScopeFilter>>;
   setShowFaqModal: React.Dispatch<React.SetStateAction<boolean>>;
-  shareUrl: string;
+  createSharingId: () => Promise<string>;
 }) => {
   const {
     sorter,
@@ -63,6 +64,7 @@ const CompareTable = (props: {
     sliderValue,
     setSliderValue,
     stateId,
+    county,
   } = props;
   const { setViewAllCounties } = props;
 
@@ -176,6 +178,15 @@ const CompareTable = (props: {
   // Only showing the view more text when all locations are not available.
   const showViewMore = amountDisplayed !== sortedLocationsArr.length;
 
+  const getShareUrl = () =>
+    props
+      .createSharingId()
+      .then(id => `${getComparePageUrl(stateId, county, id)}`);
+  const getDownloadImageUrl = () =>
+    props
+      .createSharingId()
+      .then(id => `${getCompareShareImageUrl(stateId, county, id)}`);
+
   return (
     <Wrapper isModal={props.isModal} isHomepage={props.isHomepage}>
       {!props.isModal && (
@@ -184,9 +195,9 @@ const CompareTable = (props: {
             <Header isHomepage={props.isHomepage}>
               Compare
               <ShareImageButtons
-                imageUrl=""
-                imageFilename=""
-                url={props.shareUrl}
+                imageUrl={getDownloadImageUrl}
+                imageFilename="CovidActNow-compare.png"
+                url={getShareUrl}
                 quote={shareQuote}
                 hashtags={['COVIDActNow']}
               />

--- a/src/components/Compare/CompareTable.tsx
+++ b/src/components/Compare/CompareTable.tsx
@@ -183,9 +183,7 @@ const CompareTable = (props: {
       .createCompareShareId()
       .then(id => `${getComparePageUrl(stateId, county, id)}`);
   const getDownloadImageUrl = () =>
-    props
-      .createCompareShareId()
-      .then(id => `${getCompareShareImageUrl(stateId, county, id)}`);
+    props.createCompareShareId().then(id => `${getCompareShareImageUrl(id)}`);
 
   return (
     <Wrapper isModal={props.isModal} isHomepage={props.isHomepage}>

--- a/src/components/Compare/CompareTable.tsx
+++ b/src/components/Compare/CompareTable.tsx
@@ -52,7 +52,7 @@ const CompareTable = (props: {
   sliderValue: GeoScopeFilter;
   setSliderValue: React.Dispatch<React.SetStateAction<GeoScopeFilter>>;
   setShowFaqModal: React.Dispatch<React.SetStateAction<boolean>>;
-  createSharingId: () => Promise<string>;
+  createCompareShareId: () => Promise<string>;
 }) => {
   const {
     sorter,
@@ -180,11 +180,11 @@ const CompareTable = (props: {
 
   const getShareUrl = () =>
     props
-      .createSharingId()
+      .createCompareShareId()
       .then(id => `${getComparePageUrl(stateId, county, id)}`);
   const getDownloadImageUrl = () =>
     props
-      .createSharingId()
+      .createCompareShareId()
       .then(id => `${getCompareShareImageUrl(stateId, county, id)}`);
 
   return (

--- a/src/components/Compare/LocationTable.tsx
+++ b/src/components/Compare/LocationTable.tsx
@@ -9,6 +9,7 @@ import * as CompareStyles from './Compare.style';
 import { COLOR_MAP } from 'common/colors';
 import ExpandLessIcon from '@material-ui/icons/ExpandLess';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
+import { SCREENSHOT_CLASS } from 'components/Screenshot';
 
 const LocationTableHead: React.FunctionComponent<{
   setSorter: React.Dispatch<React.SetStateAction<number>>;
@@ -213,7 +214,7 @@ const LocationTable: React.FunctionComponent<{
   const showStateCode = allCountiesView || geoScope === GeoScopeFilter.NEARBY;
 
   return (
-    <Styles.TableContainer isModal={isModal}>
+    <Styles.TableContainer isModal={isModal} className={SCREENSHOT_CLASS}>
       <Container finalHeaderOffset={finalHeaderOffset}>
         <Styles.Head isModal={isModal} pinnedLocation={pinnedLocation}>
           <LocationTableHead

--- a/src/components/Compare/ModalCompare.tsx
+++ b/src/components/Compare/ModalCompare.tsx
@@ -41,7 +41,7 @@ const ModalCompare = (props: {
   sliderValue: GeoScopeFilter;
   setSliderValue: React.Dispatch<React.SetStateAction<GeoScopeFilter>>;
   setShowFaqModal: React.Dispatch<React.SetStateAction<boolean>>;
-  createSharingId: () => Promise<string>;
+  createCompareShareId: () => Promise<string>;
 }) => {
   const { handleCloseModal } = props;
 
@@ -103,7 +103,7 @@ const ModalCompare = (props: {
         sliderValue={props.sliderValue}
         setSliderValue={props.setSliderValue}
         setShowFaqModal={props.setShowFaqModal}
-        createSharingId={props.createSharingId}
+        createCompareShareId={props.createCompareShareId}
       />
     </Fragment>
   );

--- a/src/components/Compare/ModalCompare.tsx
+++ b/src/components/Compare/ModalCompare.tsx
@@ -41,7 +41,7 @@ const ModalCompare = (props: {
   sliderValue: GeoScopeFilter;
   setSliderValue: React.Dispatch<React.SetStateAction<GeoScopeFilter>>;
   setShowFaqModal: React.Dispatch<React.SetStateAction<boolean>>;
-  shareUrl: string;
+  createSharingId: () => Promise<string>;
 }) => {
   const { handleCloseModal } = props;
 
@@ -103,7 +103,7 @@ const ModalCompare = (props: {
         sliderValue={props.sliderValue}
         setSliderValue={props.setSliderValue}
         setShowFaqModal={props.setShowFaqModal}
-        shareUrl={props.shareUrl}
+        createSharingId={props.createSharingId}
       />
     </Fragment>
   );

--- a/src/components/HandleRedirectTo/HandleRedirectTo.tsx
+++ b/src/components/HandleRedirectTo/HandleRedirectTo.tsx
@@ -1,0 +1,20 @@
+import { useLocation } from 'react-router-dom';
+import { useHistory } from 'react-router-dom';
+import * as QueryString from 'query-string';
+
+/**
+ * Component that detects the presence of a ?redirectTo=... query param and
+ * implements the desired redirect.  Used as part of our meta tag / share images
+ * strategy.
+ */
+export default function HandleRedirectTo() {
+  const location = useLocation();
+  const history = useHistory();
+  const params = QueryString.parse(location.search);
+  const redirectTo = params['redirectTo'] as string;
+  if (redirectTo) {
+    history.replace(redirectTo);
+  }
+
+  return null;
+}

--- a/src/components/LocationPage/ChartsHolder.tsx
+++ b/src/components/LocationPage/ChartsHolder.tsx
@@ -1,5 +1,4 @@
 import React, { useRef, useEffect } from 'react';
-import { useLocation } from 'react-router-dom';
 import { ChartContentWrapper, MainContentInner } from './ChartsHolder.style';
 import NoCountyDetail from './NoCountyDetail';
 import { Projections } from 'common/models/Projections';
@@ -46,8 +45,6 @@ const ChartsHolder = (props: {
 }) => {
   const { chartId } = props;
   const projection = props.projections.primary;
-  const location = useLocation();
-  const scrollToCompare = location.pathname.endsWith('/compare');
 
   const {
     rtRangeData,
@@ -180,7 +177,6 @@ const ChartsHolder = (props: {
               locationsViewable={6}
               currentCounty={currentCountyForCompare}
               stateId={props.stateId}
-              autoScroll={scrollToCompare}
             />
             <MainContentInner>
               {chartPropsForMap.map(chartProps => (

--- a/src/components/LocationPage/ChartsHolder.tsx
+++ b/src/components/LocationPage/ChartsHolder.tsx
@@ -10,7 +10,6 @@ import useMediaQuery from '@material-ui/core/useMediaQuery';
 import { useTheme } from '@material-ui/core/styles';
 import { Metric } from 'common/metric';
 import CompareMain from 'components/Compare/CompareMain';
-import { countySummary } from 'common/location_summaries';
 import Explore, { EXPLORE_CHART_IDS } from 'components/Explore';
 
 // TODO(michael): figure out where this type declaration should live.
@@ -143,11 +142,6 @@ const ChartsHolder = (props: {
       ]
     : [];
 
-  const currentCountyForCompare = props.county && {
-    locationInfo: props.county,
-    metricsInfo: countySummary(props.county.full_fips_code),
-  };
-
   // TODO(pablo): Create separate refs for signup and share
   return (
     <>
@@ -175,7 +169,6 @@ const ChartsHolder = (props: {
               stateName={props.projections.stateName}
               county={props.county}
               locationsViewable={6}
-              currentCounty={currentCountyForCompare}
               stateId={props.stateId}
             />
             <MainContentInner>

--- a/src/screens/HomePage/HomePage.js
+++ b/src/screens/HomePage/HomePage.js
@@ -28,7 +28,6 @@ import CompareMain from 'components/Compare/CompareMain';
 export default function HomePage() {
   const shareBlockRef = useRef(null);
   const location = useLocation();
-  const scrollToCompare = location.pathname.endsWith('/compare');
 
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('xs'));
@@ -89,11 +88,7 @@ export default function HomePage() {
             </SearchBarThermometerWrapper>
             <Map hideLegend />
             {isMobile && <HomePageThermometer />}
-            <CompareMain
-              locationsViewable={8}
-              isHomepage
-              autoScroll={scrollToCompare}
-            />
+            <CompareMain locationsViewable={8} isHomepage />
             <SectionWrapper ref={indicatorsRef}>
               <CriteriaExplanation isMobile={isMobile} />
             </SectionWrapper>

--- a/src/screens/internal/ShareImage/CompareTableImage.tsx
+++ b/src/screens/internal/ShareImage/CompareTableImage.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import CompareMain from 'components/Compare/CompareMain';
+
+const CompareTableImage = () => {
+  return <CompareMain county={null} locationsViewable={6} />;
+};
+
+export default CompareTableImage;

--- a/src/screens/internal/ShareImage/ShareImage.tsx
+++ b/src/screens/internal/ShareImage/ShareImage.tsx
@@ -5,16 +5,27 @@ import ChartShareImage from './ChartShareImage';
 import ChartExportImage from './ChartExportImage';
 import ExploreChartImage from './ExploreChartImage';
 import ExploreChartExportImage from './ExploreChartExportImage';
+import CompareTableImage from './CompareTableImage';
 
 export default function ShareImage({ match }: RouteComponentProps<{}>) {
   return (
     <Switch>
+      {/* HOME PAGE SHARE CARD */}
       <Route exact path={`${match.path}`} component={ShareCardImage} />
+
+      {/* LOCATION PAGES SHARE CARD */}
       <Route
         exact
         path={`${match.path}states/:stateId`}
         component={ShareCardImage}
       />
+      <Route
+        exact
+        path={`${match.path}counties/:countyFipsId`}
+        component={ShareCardImage}
+      />
+
+      {/* METRIC CHARTS */}
       <Route
         exact
         path={`${match.path}states/:stateId/chart/:metric`}
@@ -27,11 +38,6 @@ export default function ShareImage({ match }: RouteComponentProps<{}>) {
       />
       <Route
         exact
-        path={`${match.path}counties/:countyFipsId`}
-        component={ShareCardImage}
-      />
-      <Route
-        exact
         path={`${match.path}counties/:countyFipsId/chart/:metric`}
         component={ChartShareImage}
       />
@@ -40,6 +46,8 @@ export default function ShareImage({ match }: RouteComponentProps<{}>) {
         path={`${match.path}counties/:countyFipsId/chart/:metric/export`}
         component={ChartExportImage}
       />
+
+      {/* EXPLORE CHARTS */}
       <Route
         exact
         path={`${match.path}states/:stateId/explore/:chartId`}
@@ -60,6 +68,15 @@ export default function ShareImage({ match }: RouteComponentProps<{}>) {
         path={`${match.path}states/:stateId/explore/:chartId/export`}
         component={ExploreChartExportImage}
       />
+
+      {/* COMPARE TABLES */}
+      <Route
+        exact
+        path={`${match.path}compare/:compareShareId`}
+        component={CompareTableImage}
+      />
+
+      {/* DEFAULT */}
       <Route path="/*">Bad Share Image URL.</Route>
     </Switch>
   );


### PR DESCRIPTION
This moves us away from using query params for compare sharing and instead uses Firestore to store your compare parameters when you share the table, so we can create predictable URLs.  This is necessary so we can pre-generate index.html pages that have meta tags that point to the corresponding share image URL.

One consequence of this change is we don't generate the share URL until the user clicks on the share / save buttons, so I had to rework ShareButtonGroup so you don't necessarily need to know the URLs up front but can instead pass in functions that generate a URL (asynchronously) and then return it.  The code's a bit more complicated and now there's a small delay when you click the share button. 😢  I may see if I can improve that by showing the buttons even before we have the right URL.