### PR TITLE
Fix error when navigating to county after adding to explore

### DIFF
--- a/src/screens/LocationPage/LocationPage.js
+++ b/src/screens/LocationPage/LocationPage.js
@@ -30,17 +30,18 @@ function LocationPage() {
     );
   }
   const [selectedCounty, setSelectedCounty] = useState(countyOption);
-
   useMemo(() => {
     setSelectedCounty(countyOption);
   }, [countyOption]);
 
   const projections = useProjections(stateId, selectedCounty);
-
   // Projections haven't loaded yet
   // If a new county has just been selected, we may not have projections
   // for the new county loaded yet
-  if (!projections || projections.county !== selectedCounty) {
+  if (
+    !projections ||
+    projections.county?.full_fips_code !== selectedCounty?.full_fips_code
+  ) {
     return <LoadingScreen></LoadingScreen>;
   }
 


### PR DESCRIPTION
I'm not 100% sure why the equality didn't work (I also tried lodash equality, which I thought would've fixed it) but I ran into a bug where navigating to a county page after adding it to explore just showed the loading page.  

I think this fix is fine - comparing the fips code should give the result we want, but I'm not super familiar with this code.  let me know if there's a better way to handle this!