### PR TITLE
Compare modal bug fix

### DIFF
--- a/src/components/Compare/LocationTable.tsx
+++ b/src/components/Compare/LocationTable.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { remove } from 'lodash';
 import { Table, TableBody } from '@material-ui/core';
 import { Metric } from 'common/metric';
 import { RankedLocationSummary, GeoScopeFilter } from 'common/utils/compare';
@@ -204,11 +205,25 @@ const LocationTable: React.FunctionComponent<{
   const allCountiesView =
     viewAllCounties || geoScope === GeoScopeFilter.COUNTRY;
 
+  const currentLocationRank = pinnedLocation?.rank;
+
+  const hideInlineLocation = isModal && currentLocationRank === 1;
+
+  // In the modal, if the rank of the pinned-location-row is #1, we remove
+  // the location's inline row, so as to not have the location listed twice consecutively:
+  const removePinnedIfRankedFirst = (location: any) =>
+    location.locationInfo.full_fips_code !==
+    pinnedLocation?.locationInfo.full_fips_code;
+
+  const modalLocations = hideInlineLocation
+    ? remove(sortedLocations, removePinnedIfRankedFirst)
+    : sortedLocations;
+
   const visibleLocations = !isModal
     ? sortedLocations.slice(0, numLocationsMain)
     : allCountiesView
     ? sortedLocations.slice(0, 100)
-    : sortedLocations;
+    : modalLocations;
 
   const showStateCode = allCountiesView || geoScope === GeoScopeFilter.NEARBY;
 
@@ -251,7 +266,7 @@ const LocationTable: React.FunctionComponent<{
           <LocationTableBody
             sorter={sorter}
             sortedLocations={visibleLocations}
-            currentLocationRank={pinnedLocation?.rank}
+            currentLocationRank={currentLocationRank}
             sortByPopulation={sortByPopulation}
             isHomepage={isHomepage}
             showStateCode={showStateCode}

--- a/src/components/Compare/LocationTable.tsx
+++ b/src/components/Compare/LocationTable.tsx
@@ -257,7 +257,7 @@ const LocationTable: React.FunctionComponent<{
             showStateCode={showStateCode}
           />
         </Styles.Body>
-        {pinnedLocation && showBottom && (
+        {pinnedLocation && showBottom && !isModal && (
           <Styles.Body>
             <LocationTableBody
               sorter={sorter}


### PR DESCRIPTION
- Fixes bug that was causing some county-rows to appear 3x in modal (image # 1)
- Edits modal locations to exclude inline current-county-row if current county is ranked # 1 (causing consecutive repeating rows in image # 2) 

![image](https://user-images.githubusercontent.com/44076375/93115902-89709d00-f68a-11ea-8f9e-56e5762b11a8.png)

![Screen Shot 2020-09-14 at 1 03 05 PM](https://user-images.githubusercontent.com/44076375/93115975-a73e0200-f68a-11ea-8217-507ac4ef5e43.png)