### PR TITLE
accessibility: alt text for the can logo on the alert email template

### DIFF
--- a/scripts/alert_emails/template.html
+++ b/scripts/alert_emails/template.html
@@ -722,7 +722,7 @@
                                     <a href="https://covidactnow.org">
                                         <img style="display: block;height: auto;width: 100%;border: 0;max-width:
                                           162px;" src="https://data.covidactnow.org/thermometer_screenshot/canlogo.png"
-                                            alt="" width="160"></a></div>
+                                            alt="Covid Act Now Logo" width="160"></a></div>
                             </div>
                             <!--[if (mso)|(IE)]></td></tr></table><![endif]-->
                         </div>


### PR DESCRIPTION
Added the alt text for the only image that didn't have one in the alert email template.