### PR TITLE
default to not-normalized

### DIFF
--- a/src/components/Explore/Explore.tsx
+++ b/src/components/Explore/Explore.tsx
@@ -64,14 +64,18 @@ const Explore: React.FunctionComponent<{
   ]);
 
   const onChangeSelectedLocations = (newLocations: Location[]) => {
-    const selectedLocations = uniq([currentLocation, ...newLocations]);
+    const changedLocations = uniq([currentLocation, ...newLocations]);
 
-    // if there is multiple locations, automatically normalize
-    // if there is only one location, no need to normalize
-    setNormalizeData(selectedLocations.length > 1);
+    if (selectedLocations.length > 1 && changedLocations.length === 1) {
+      // if switching from multiple to a single location, disable normalization
+      setNormalizeData(false);
+    } else if (selectedLocations.length === 1 && changedLocations.length > 1) {
+      // if switching from single to multiple locations, enable normalization
+      setNormalizeData(true);
+    }
 
     // make sure that the current location is always selected
-    setSelectedLocations(selectedLocations);
+    setSelectedLocations(changedLocations);
   };
 
   // Resets the state when navigating locations

--- a/src/components/Explore/Explore.tsx
+++ b/src/components/Explore/Explore.tsx
@@ -47,7 +47,7 @@ const Explore: React.FunctionComponent<{
     (chartId && getMetricByChartId(chartId)) || ExploreMetric.CASES;
   const [currentMetric, setCurrentMetric] = useState(defaultMetric);
 
-  const [normalizeData, setNormalizeData] = useState(true);
+  const [normalizeData, setNormalizeData] = useState(false);
 
   const onChangeTab = (newMetric: number) => setCurrentMetric(newMetric);
 
@@ -64,8 +64,14 @@ const Explore: React.FunctionComponent<{
   ]);
 
   const onChangeSelectedLocations = (newLocations: Location[]) => {
+    const selectedLocations = uniq([currentLocation, ...newLocations]);
+
+    // if there is multiple locations, automatically normalize
+    // if there is only one location, no need to normalize
+    setNormalizeData(selectedLocations.length > 1);
+
     // make sure that the current location is always selected
-    setSelectedLocations(uniq([currentLocation, ...newLocations]));
+    setSelectedLocations(selectedLocations);
   };
 
   // Resets the state when navigating locations


### PR DESCRIPTION
When the component loads, there is only a single location and the data is not normalized.

When a 2nd location is selected, normalization is automatically enabled.

When the 2nd location is removed, normalization is disabled.

Fixes issue #1471 