### PR TITLE
Reduce metric-related code duplication in ChartsHolder, LocationPageHeader, and LocationHeaderStats

### DIFF
--- a/src/components/LocationPage/ChartBlock.tsx
+++ b/src/components/LocationPage/ChartBlock.tsx
@@ -26,7 +26,6 @@ function ChartBlock(props: {
   metric: Metric;
   projections: Projections;
   stateId: string;
-  countyId?: string;
 }) {
   const { projections, metric, isMobile } = props;
   const projection: Projection = projections.primary;

--- a/src/components/LocationPage/ChartBlock.tsx
+++ b/src/components/LocationPage/ChartBlock.tsx
@@ -25,44 +25,39 @@ function ChartBlock(props: {
   shareButtonProps: { [key: string]: any };
   metric: Metric;
   projections: Projections;
-  data?: any;
   stateId: string;
   countyId?: string;
 }) {
-  const projection: Projection = props.projections.primary;
+  const { projections, metric, isMobile } = props;
+  const projection: Projection = projections.primary;
 
   const showBetaTag =
-    props.metric === Metric.HOSPITAL_USAGE ||
-    props.metric === Metric.CONTACT_TRACING;
+    metric === Metric.HOSPITAL_USAGE || metric === Metric.CONTACT_TRACING;
+
+  const hasMetric = projections.hasMetric(metric);
 
   return (
     <Fragment>
       <ChartHeaderWrapper>
         <ChartHeader ref={props.chartRef}>
-          {getMetricNameExtended(props.metric)}
+          {getMetricNameExtended(metric)}
           {showBetaTag && <BetaTag>Beta</BetaTag>}
         </ChartHeader>
-        {!props.isMobile && props.data && (
-          <ShareButtons
-            chartIdentifier={props.metric}
-            {...props.shareButtonProps}
-          />
+        {hasMetric && !isMobile && (
+          <ShareButtons chartIdentifier={metric} {...props.shareButtonProps} />
         )}
       </ChartHeaderWrapper>
       <ChartLocationName>{projection.locationName}</ChartLocationName>
       <ChartDescription>
-        {getMetricStatusText(props.metric, props.projections)}
+        {getMetricStatusText(metric, projections)}
       </ChartDescription>
-      {props.isMobile && props.data && (
-        <ShareButtons
-          chartIdentifier={props.metric}
-          {...props.shareButtonProps}
-        />
+      {hasMetric && isMobile && (
+        <ShareButtons chartIdentifier={metric} {...props.shareButtonProps} />
       )}
-      {props.data && (
+      {hasMetric && (
         <>
-          <MetricChart metric={props.metric} projections={props.projections} />
-          <Disclaimer metricName={props.metric} />
+          <MetricChart metric={metric} projections={projections} />
+          <Disclaimer metricName={metric} />
         </>
       )}
     </Fragment>

--- a/src/components/LocationPage/ChartsHolder.tsx
+++ b/src/components/LocationPage/ChartsHolder.tsx
@@ -34,14 +34,6 @@ const ChartsHolder = (props: {
   const { chartId } = props;
   const projection = props.projections.primary;
 
-  const {
-    rtRangeData,
-    testPositiveData,
-    icuUtilizationData,
-    contactTracingData,
-    caseDensityData,
-  } = getChartData(projection);
-
   const rtRangeRef = useRef<HTMLDivElement>(null);
   const testPositiveRef = useRef<HTMLDivElement>(null);
   const icuUtilizationRef = useRef<HTMLDivElement>(null);
@@ -96,35 +88,30 @@ const ChartsHolder = (props: {
         {
           chartRef: caseDensityRef,
           isMobile,
-          data: caseDensityData,
           shareButtonProps,
           metric: Metric.CASE_DENSITY,
         },
         {
           chartRef: rtRangeRef,
           isMobile,
-          data: rtRangeData,
           shareButtonProps,
           metric: Metric.CASE_GROWTH_RATE,
         },
         {
           chartRef: testPositiveRef,
           isMobile,
-          data: testPositiveData,
           shareButtonProps,
           metric: Metric.POSITIVE_TESTS,
         },
         {
           chartRef: icuUtilizationRef,
           isMobile,
-          data: icuUtilizationData,
           shareButtonProps,
           metric: Metric.HOSPITAL_USAGE,
         },
         {
           chartRef: contactTracingRef,
           isMobile,
-          data: contactTracingData,
           shareButtonProps,
           metric: Metric.CONTACT_TRACING,
         },
@@ -191,55 +178,5 @@ const ChartsHolder = (props: {
     </>
   );
 };
-
-// Exported for use by AllStates.js.
-export function getChartData(
-  projection: Projection | null,
-): {
-  rtRangeData: any;
-  testPositiveData: any;
-  icuUtilizationData: any;
-  contactTracingData: any;
-  caseDensityData: any;
-} {
-  const rtRangeData =
-    projection?.rt == null
-      ? null
-      : projection.getDataset('rtRange').map(d => ({
-          x: d.x,
-          y: d.y?.rt,
-          low: d.y?.low,
-          hi: d.y?.high,
-        }));
-
-  const testPositiveData =
-    projection?.currentTestPositiveRate == null
-      ? null
-      : projection.getDataset('testPositiveRate');
-
-  const icuUtilizationData =
-    projection?.icuHeadroomInfo == null ||
-    projection?.icuHeadroomInfo.overrideInPlace
-      ? null
-      : projection.getDataset('icuUtilization');
-
-  const contactTracingData =
-    projection?.currentContactTracerMetric == null
-      ? null
-      : projection.getDataset('contractTracers');
-
-  const caseDensityData =
-    projection?.currentCaseDensity == null
-      ? null
-      : projection.getDataset('caseDensityRange');
-
-  return {
-    rtRangeData,
-    testPositiveData,
-    icuUtilizationData,
-    contactTracingData,
-    caseDensityData,
-  };
-}
 
 export default ChartsHolder;

--- a/src/components/LocationPage/ChartsHolder.tsx
+++ b/src/components/LocationPage/ChartsHolder.tsx
@@ -11,18 +11,7 @@ import { useTheme } from '@material-ui/core/styles';
 import { Metric } from 'common/metric';
 import CompareMain from 'components/Compare/CompareMain';
 import Explore, { EXPLORE_CHART_IDS } from 'components/Explore';
-
-// TODO(michael): figure out where this type declaration should live.
-type County = {
-  county: string;
-  county_url_name: string;
-  county_fips_code: string;
-  state_fips_code: string;
-  state_code: string;
-  full_fips_code: string;
-  cities: string[];
-  population: string;
-};
+import { County } from 'common/locations';
 
 // TODO: 180 is rough accounting for the navbar and searchbar;
 // could make these constants so we don't have to manually update

--- a/src/components/LocationPage/ChartsHolder.tsx
+++ b/src/components/LocationPage/ChartsHolder.tsx
@@ -2,7 +2,6 @@ import React, { useRef, useEffect } from 'react';
 import { ChartContentWrapper, MainContentInner } from './ChartsHolder.style';
 import NoCountyDetail from './NoCountyDetail';
 import { Projections } from 'common/models/Projections';
-import { Projection } from 'common/models/Projection';
 import ShareModelBlock from 'components/ShareBlock/ShareModelBlock';
 import LocationPageHeader from 'components/LocationPage/LocationPageHeader';
 import ChartBlock from 'components/LocationPage/ChartBlock';
@@ -23,7 +22,6 @@ const scrollTo = (div: null | HTMLDivElement, offset: number = 180) =>
     behavior: 'smooth',
   });
 
-//TODO(chelsi): implement a metricToShareButtons map to get rid of repeated instances of ShareButtons
 const ChartsHolder = (props: {
   projections: Projections;
   stateId: string;
@@ -93,21 +91,7 @@ const ChartsHolder = (props: {
             <LocationPageHeader
               projections={props.projections}
               stats={props.projections.getMetricValues()}
-              onCaseDensityClick={() =>
-                scrollTo(metricRefs[Metric.CASE_DENSITY].current)
-              }
-              onRtRangeClick={() =>
-                scrollTo(metricRefs[Metric.CASE_GROWTH_RATE].current)
-              }
-              onTestPositiveClick={() =>
-                scrollTo(metricRefs[Metric.POSITIVE_TESTS].current)
-              }
-              onIcuUtilizationClick={() =>
-                scrollTo(metricRefs[Metric.HOSPITAL_USAGE].current)
-              }
-              onContactTracingClick={() =>
-                scrollTo(metricRefs[Metric.CONTACT_TRACING].current)
-              }
+              onMetricClick={metric => scrollTo(metricRefs[metric].current)}
               onHeaderShareClick={() => scrollTo(shareBlockRef.current, -372)}
               onHeaderSignupClick={() => scrollTo(shareBlockRef.current)}
               onNewUpdateClick={() => scrollTo(exploreChartRef.current)}

--- a/src/components/LocationPage/LocationPageHeader.tsx
+++ b/src/components/LocationPage/LocationPageHeader.tsx
@@ -34,6 +34,7 @@ import ShareOutlinedIcon from '@material-ui/icons/ShareOutlined';
 import LocationHeaderStats from 'components/SummaryStats/LocationHeaderStats';
 import { LEVEL_COLOR } from 'common/colors';
 import InfoOutlinedIcon from '@material-ui/icons/InfoOutlined';
+import { Metric } from 'common/metric';
 
 const NewFeatureCopy = (props: {
   locationName: string;
@@ -81,13 +82,9 @@ const LocationPageHeader = (props: {
   projections: Projections;
   condensed?: Boolean;
   stats: { [key: string]: number | null };
-  onRtRangeClick?: () => void;
-  onTestPositiveClick?: () => void;
-  onIcuUtilizationClick?: () => void;
-  onContactTracingClick?: () => void;
+  onMetricClick: (metric: Metric) => void;
   onHeaderShareClick: () => void;
   onHeaderSignupClick: () => void;
-  onCaseDensityClick: () => void;
   isMobile?: Boolean;
   onNewUpdateClick: () => void;
 }) => {
@@ -201,11 +198,7 @@ const LocationPageHeader = (props: {
           </HeaderSection>
           <LocationHeaderStats
             stats={props.stats}
-            onCaseDensityClick={props.onCaseDensityClick}
-            onRtRangeClick={props.onRtRangeClick}
-            onTestPositiveClick={props.onTestPositiveClick}
-            onIcuUtilizationClick={props.onIcuUtilizationClick}
-            onContactTracingClick={props.onContactTracingClick}
+            onMetricClick={props.onMetricClick}
             isMobile={props.isMobile}
             isHeader={true}
           />

--- a/src/components/SummaryStats/LocationHeaderStats.tsx
+++ b/src/components/SummaryStats/LocationHeaderStats.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Metric } from 'common/metric';
+import { Metric, ALL_METRICS } from 'common/metric';
 import { getMetricName, getLevelInfo, formatValue } from 'common/metric';
 import FiberManualRecordIcon from '@material-ui/icons/FiberManualRecord';
 
@@ -61,7 +61,6 @@ const SummaryStat = ({
   onClick,
   beta,
   condensed,
-  flipSignalStatusOrder,
   isMobile,
   isHeader,
   isEmbed,
@@ -73,7 +72,6 @@ const SummaryStat = ({
   onClick: () => void;
   beta?: Boolean;
   condensed?: Boolean;
-  flipSignalStatusOrder?: Boolean;
   isMobile?: Boolean;
   isHeader?: Boolean;
   isEmbed?: Boolean;
@@ -153,17 +151,11 @@ const SummaryStat = ({
   );
 };
 
-const noop = () => {};
-
 const LocationHeaderStats = (props: {
   stats: { [key: string]: number | null };
   condensed?: Boolean;
   isEmbed?: Boolean;
-  onCaseDensityClick?: () => void;
-  onRtRangeClick?: () => void;
-  onTestPositiveClick?: () => void;
-  onIcuUtilizationClick?: () => void;
-  onContactTracingClick?: () => void;
+  onMetricClick?: (metric: Metric) => void;
   isMobile?: Boolean;
   isHeader?: Boolean;
   embedOnClickBaseURL?: string;
@@ -187,39 +179,17 @@ const LocationHeaderStats = (props: {
           isHeader={props.isHeader}
           condensed={props.condensed}
         >
-          <SummaryStat
-            onClick={props.onCaseDensityClick || noop}
-            chartType={Metric.CASE_DENSITY}
-            value={props.stats[Metric.CASE_DENSITY] as number}
-            {...sharedStatProps}
-          />
-          <SummaryStat
-            onClick={props.onRtRangeClick || noop}
-            chartType={Metric.CASE_GROWTH_RATE}
-            value={props.stats[Metric.CASE_GROWTH_RATE] as number}
-            {...sharedStatProps}
-          />
-          <SummaryStat
-            onClick={props.onTestPositiveClick || noop}
-            chartType={Metric.POSITIVE_TESTS}
-            value={props.stats[Metric.POSITIVE_TESTS] as number}
-            {...sharedStatProps}
-          />
-          <SummaryStat
-            onClick={props.onIcuUtilizationClick || noop}
-            chartType={Metric.HOSPITAL_USAGE}
-            beta={true}
-            value={props.stats[Metric.HOSPITAL_USAGE] as number}
-            {...sharedStatProps}
-          />
-          <SummaryStat
-            onClick={props.onContactTracingClick || noop}
-            chartType={Metric.CONTACT_TRACING}
-            beta={true}
-            value={props.stats[Metric.CONTACT_TRACING] as number}
-            flipSignalStatusOrder
-            {...sharedStatProps}
-          />
+          {ALL_METRICS.map(metric => (
+            <SummaryStat
+              onClick={() => props.onMetricClick && props.onMetricClick(metric)}
+              chartType={metric}
+              value={props.stats[metric] as number}
+              {...sharedStatProps}
+              beta={[Metric.HOSPITAL_USAGE, Metric.CONTACT_TRACING].includes(
+                metric,
+              )}
+            />
+          ))}
         </SummaryStatsWrapper>
       )}
     </>


### PR DESCRIPTION
There were a few places where we repeated very similar code 5 times, once for each metric, and I simplified it to just map over ALL_METRICS.