### PR TITLE
explore: copy updates

### DIFF
--- a/src/components/Explore/Explore.tsx
+++ b/src/components/Explore/Explore.tsx
@@ -98,7 +98,7 @@ const Explore: React.FunctionComponent<{
     <Styles.Container>
       <Grid container spacing={1}>
         <Grid item sm={6} xs={12}>
-          <Styles.Heading variant="h4">Trends</Styles.Heading>
+          <Styles.Heading variant="h4">Raw data</Styles.Heading>
           <Styles.Subtitle>
             {currentMetricName} {normalizeData ? 'per 100k population' : ''} in{' '}
             {getLocationNames(selectedLocations)}

--- a/src/components/Explore/Explore.tsx
+++ b/src/components/Explore/Explore.tsx
@@ -100,8 +100,8 @@ const Explore: React.FunctionComponent<{
         <Grid item sm={6} xs={12}>
           <Styles.Heading variant="h4">Trends</Styles.Heading>
           <Styles.Subtitle>
-            {currentMetricName} {normalizeData ? 'per 100k population' : ''}{' '}
-            since march 1st in {getLocationNames(selectedLocations)}
+            {currentMetricName} {normalizeData ? 'per 100k population' : ''} in{' '}
+            {getLocationNames(selectedLocations)}
           </Styles.Subtitle>
         </Grid>
         <Grid item sm={6} xs={12}>

--- a/src/components/Explore/Explore.tsx
+++ b/src/components/Explore/Explore.tsx
@@ -99,7 +99,7 @@ const Explore: React.FunctionComponent<{
     <Styles.Container>
       <Grid container spacing={1}>
         <Grid item sm={6} xs={12}>
-          <Styles.Heading variant="h4">Raw data</Styles.Heading>
+          <Styles.Heading variant="h4">Trends</Styles.Heading>
           <Styles.Subtitle>
             {currentMetricName} {normalizeData ? 'per 100k population' : ''} in{' '}
             {getLocationNames(selectedLocations)}

--- a/src/components/Explore/Explore.tsx
+++ b/src/components/Explore/Explore.tsx
@@ -3,6 +3,7 @@ import { some, uniq } from 'lodash';
 import Grid from '@material-ui/core/Grid';
 import useMediaQuery from '@material-ui/core/useMediaQuery';
 import { useTheme } from '@material-ui/core/styles';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
 import { ParentSize } from '@vx/responsive';
 import { Projection } from 'common/models/Projection';
 import { useModelLastUpdatedDate } from 'common/utils/model';
@@ -29,9 +30,9 @@ import {
   getLocationNames,
   getAutocompleteLocations,
   getChartSeries,
+  getMetricName,
 } from './utils';
 import * as Styles from './Explore.style';
-import FormControlLabel from '@material-ui/core/FormControlLabel';
 
 const Explore: React.FunctionComponent<{
   projection: Projection;
@@ -52,7 +53,7 @@ const Explore: React.FunctionComponent<{
   const onChangeTab = (newMetric: number) => setCurrentMetric(newMetric);
 
   const metricLabels = getMetricLabels();
-  const currentMetricName = metricLabels[currentMetric];
+  const currentMetricName = getMetricName(currentMetric);
 
   const currentLocation = useMemo(() => findLocationForFips(fips), [fips]);
   const autocompleteLocations = useMemo(() => getAutocompleteLocations(fips), [

--- a/src/components/Explore/MultipleLocationsChart.tsx
+++ b/src/components/Explore/MultipleLocationsChart.tsx
@@ -46,7 +46,7 @@ const MultipleLocationsTooltip: React.FC<{
   const currentSeries = isNumber(seriesIndex) ? series[seriesIndex] : null;
   return (
     <Tooltip
-      width={'180px'}
+      width={'210px'}
       top={top}
       left={left}
       title={moment(pointInfo.x).format('MMM D, YYYY')}

--- a/src/components/Explore/SingleLocationChart.tsx
+++ b/src/components/Explore/SingleLocationChart.tsx
@@ -37,7 +37,7 @@ const SingleLocationTooltip: React.FC<{
 
   return pointSmooth && pointRaw ? (
     <Tooltip
-      width={'180px'}
+      width={'210px'}
       top={top(pointSmooth)}
       left={left(pointSmooth)}
       title={moment(date).format('MMM D, YYYY')}

--- a/src/components/Explore/utils.ts
+++ b/src/components/Explore/utils.ts
@@ -24,11 +24,7 @@ import {
 } from 'common/locations';
 import { share_image_url } from 'assets/data/share_images_url.json';
 import { SeriesType, Series } from './interfaces';
-import {
-  isState,
-  isCounty,
-  // belongsToState,
-} from 'components/AutocompleteLocations';
+import { isState, isCounty } from 'components/AutocompleteLocations';
 
 export function getMaxBy<T>(
   seriesList: Series[],
@@ -144,11 +140,11 @@ export const exploreMetricData: {
   },
   [ExploreMetric.HOSPITALIZATIONS]: {
     title: 'Hospitalizations',
-    name: 'COVID Hospitalizations',
+    name: 'Current COVID Hospitalizations',
     chartId: 'hospitalizations',
     seriesList: [
       {
-        label: 'COVID Hospitalizations',
+        label: 'Current COVID Hospitalizations',
         tooltipLabel: 'COVID Hospitalizations',
         datasetId: 'rawHospitalizations',
         type: SeriesType.BAR,
@@ -163,11 +159,11 @@ export const exploreMetricData: {
   },
   [ExploreMetric.ICU_HOSPITALIZATIONS]: {
     title: 'ICU Hospitalizations',
-    name: 'COVID ICU Hospitalizations',
+    name: 'Current COVID ICU Hospitalizations',
     chartId: 'icu-hospitalizations',
     seriesList: [
       {
-        label: 'COVID ICU Hospitalizations',
+        label: 'Current COVID ICU Hospitalizations',
         tooltipLabel: 'COVID ICU Hospitalizations',
         datasetId: 'rawICUHospitalizations',
         type: SeriesType.BAR,
@@ -237,7 +233,7 @@ function getAveragedSeriesForMetric(
   const datasetId = getDatasetIdByMetric(metric);
   const location = findLocationForFips(fips);
   const data = cleanSeries(projection.getDataset(datasetId));
-  const metricName = getMetricName(metric);
+  const metricName = exploreMetricData[metric].seriesList[0].tooltipLabel;
   return {
     data: normalizeData ? scalePer100k(data, totalPopulation) : data,
     type: SeriesType.LINE,

--- a/src/components/Explore/utils.ts
+++ b/src/components/Explore/utils.ts
@@ -96,6 +96,7 @@ interface SerieDescription {
 
 interface ExploreMetricDescription {
   title: string;
+  name: string;
   chartId: string;
   seriesList: SerieDescription[];
 }
@@ -105,6 +106,7 @@ export const exploreMetricData: {
 } = {
   [ExploreMetric.CASES]: {
     title: 'Cases',
+    name: 'Cases',
     chartId: 'cases',
     seriesList: [
       {
@@ -123,6 +125,7 @@ export const exploreMetricData: {
   },
   [ExploreMetric.DEATHS]: {
     title: 'Deaths',
+    name: 'Deaths',
     chartId: 'deaths',
     seriesList: [
       {
@@ -141,17 +144,18 @@ export const exploreMetricData: {
   },
   [ExploreMetric.HOSPITALIZATIONS]: {
     title: 'Hospitalizations',
+    name: 'COVID Hospitalizations',
     chartId: 'hospitalizations',
     seriesList: [
       {
-        label: 'Hospitalizations',
-        tooltipLabel: 'Hospitalizations',
+        label: 'COVID Hospitalizations',
+        tooltipLabel: 'COVID Hospitalizations',
         datasetId: 'rawHospitalizations',
         type: SeriesType.BAR,
       },
       {
         label: '7 Day Average',
-        tooltipLabel: 'Hospitalizations',
+        tooltipLabel: 'COVID Hospitalizations',
         datasetId: 'smoothedHospitalizations',
         type: SeriesType.LINE,
       },
@@ -159,17 +163,18 @@ export const exploreMetricData: {
   },
   [ExploreMetric.ICU_HOSPITALIZATIONS]: {
     title: 'ICU Hospitalizations',
+    name: 'COVID ICU Hospitalizations',
     chartId: 'icu-hospitalizations',
     seriesList: [
       {
-        label: 'ICU Hospitalizations',
-        tooltipLabel: 'ICU Hospitalizations',
+        label: 'COVID ICU Hospitalizations',
+        tooltipLabel: 'COVID ICU Hospitalizations',
         datasetId: 'rawICUHospitalizations',
         type: SeriesType.BAR,
       },
       {
         label: '7 Day Average',
-        tooltipLabel: 'ICU Hospitalizations',
+        tooltipLabel: 'COVID ICU Hospitalizations',
         datasetId: 'smoothedICUHospitalizations',
         type: SeriesType.LINE,
       },
@@ -232,7 +237,7 @@ function getAveragedSeriesForMetric(
   const datasetId = getDatasetIdByMetric(metric);
   const location = findLocationForFips(fips);
   const data = cleanSeries(projection.getDataset(datasetId));
-  const metricName = exploreMetricData[metric].title;
+  const metricName = getMetricName(metric);
   return {
     data: normalizeData ? scalePer100k(data, totalPopulation) : data,
     type: SeriesType.LINE,
@@ -251,12 +256,16 @@ export function getTitle(metric: ExploreMetric) {
   return exploreMetricData[metric].title;
 }
 
+export function getMetricName(metric: ExploreMetric) {
+  return exploreMetricData[metric].name;
+}
+
 export function getChartIdByMetric(metric: ExploreMetric) {
   return exploreMetricData[metric].chartId;
 }
 
 export function getMetricLabels() {
-  return EXPLORE_METRICS.map(metric => exploreMetricData[metric].title);
+  return EXPLORE_METRICS.map(getTitle);
 }
 
 export function findPointByDate(data: Column[], date: Date): Column | null {


### PR DESCRIPTION
- Remove "since March 1st" from the copy (From [Paper - CAN Explore](https://paper.dropbox.com/doc/CAN-Explore--A7ptCAakhRbthPiIlcrVsbKbAg-RIlOIJkMWHcX0AmXQA5PW))
- Change Trends → Raw Data [Slack thread](https://covidactnow.slack.com/archives/C018XQHEB1A/p1599778034007500)
- Change Hospitalizations and ICU Hospitalizations → COVID Hospitalizations and COVID ICU Hospitalizations (copy and tooltip). [Slack thread](https://covidactnow.slack.com/archives/C0110QQAPJA/p1600189192003700)