### PR TITLE
explore: enable comparing with states and counties

### DIFF
--- a/src/components/Explore/Explore.tsx
+++ b/src/components/Explore/Explore.tsx
@@ -37,8 +37,7 @@ import * as Styles from './Explore.style';
 const Explore: React.FunctionComponent<{
   projection: Projection;
   chartId?: string;
-  compareCopy: string;
-}> = ({ projection, chartId, compareCopy }) => {
+}> = ({ projection, chartId }) => {
   const { locationName, fips } = projection;
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
@@ -135,7 +134,7 @@ const Explore: React.FunctionComponent<{
       />
       <Styles.ChartControlsContainer>
         <Styles.TableAutocompleteHeader>
-          {compareCopy}
+          Compare states or counties
         </Styles.TableAutocompleteHeader>
         <Grid container spacing={1}>
           <Grid key="location-selector" item sm={6} xs={6}>
@@ -144,7 +143,6 @@ const Explore: React.FunctionComponent<{
               selectedLocations={selectedLocations}
               onChangeSelectedLocations={onChangeSelectedLocations}
               {...modalNormalizeCheckboxProps}
-              compareCopy={compareCopy}
             />
           </Grid>
           {!hasMultipleLocations && (

--- a/src/components/Explore/LocationSelector.tsx
+++ b/src/components/Explore/LocationSelector.tsx
@@ -16,14 +16,12 @@ const LocationSelector: React.FC<{
   onChangeSelectedLocations: (newLocations: Location[]) => void;
   normalizeData: boolean;
   setNormalizeData: React.Dispatch<React.SetStateAction<boolean>>;
-  compareCopy: string;
 }> = ({
   locations,
   selectedLocations,
   onChangeSelectedLocations,
   normalizeData,
   setNormalizeData,
-  compareCopy,
 }) => {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('xs'));
@@ -50,7 +48,7 @@ const LocationSelector: React.FC<{
         disableTouchRipple
         onClick={onClickButton}
       >
-        {compareCopy}
+        Compare states or counties
       </Styles.ModalOpenButton>
       {modalOpen && (
         <Modal
@@ -62,7 +60,9 @@ const LocationSelector: React.FC<{
             <Styles.ModalHeader>
               <Grid container>
                 <Grid item xs={9}>
-                  <Styles.ModalTitle>{compareCopy}</Styles.ModalTitle>
+                  <Styles.ModalTitle>
+                    Compare states or counties
+                  </Styles.ModalTitle>
                 </Grid>
                 <Grid item xs container justify="flex-end">
                   <Styles.DoneButton size="small" onClick={closeModal}>

--- a/src/components/Explore/utils.ts
+++ b/src/components/Explore/utils.ts
@@ -9,6 +9,7 @@ import {
   max,
   range,
   words,
+  partition,
 } from 'lodash';
 import { schemeCategory10 } from 'd3-scale-chromatic';
 import { fetchProjections } from 'common/utils/model';
@@ -27,7 +28,7 @@ import { SeriesType, Series } from './interfaces';
 import {
   isState,
   isCounty,
-  // belongsToState,
+  belongsToState,
 } from 'components/AutocompleteLocations';
 
 export function getMaxBy<T>(
@@ -366,16 +367,23 @@ export function getLocationNames(locations: Location[]) {
     .join(', ')} and ${getLocationLabel(lastLocation)}.`;
 }
 
-// note (Chelsi): commenting out belongsToState filter
-// so we can compare all US counties:
+/**
+ * Returns a list of locations for the autocomplete component. We try to show
+ * the most relevant options first. For a state, we show states, counties in
+ * the state and then other counties. For a county, we show counties in the
+ * state, then states and then other counties.
+ */
 export function getAutocompleteLocations(locationFips: string) {
-  const currentLocation = findLocationForFips(locationFips);
-  // const stateFips = currentLocation.state_fips_code;
   const allLocations = getAllLocations();
-  return isState(currentLocation)
-    ? allLocations.filter(isState)
-    : allLocations.filter(isCounty);
-  // .filter(location => belongsToState(location, stateFips));
+  const currentLocation = findLocationForFips(locationFips);
+  const [states, allCounties] = partition(allLocations, isState);
+  const [stateCounties, otherCounties] = partition(allCounties, county =>
+    belongsToState(county, currentLocation.state_fips_code),
+  );
+
+  return isStateFips(locationFips)
+    ? [...states, ...stateCounties, ...otherCounties]
+    : [...stateCounties, ...states, ...otherCounties];
 }
 
 /**

--- a/src/components/LocationPage/ChartsHolder.tsx
+++ b/src/components/LocationPage/ChartsHolder.tsx
@@ -186,7 +186,6 @@ const ChartsHolder = (props: {
               <Explore
                 projection={props.projections.primary}
                 chartId={chartId}
-                compareCopy="Compare states or counties"
               />
             </MainContentInner>
           </ChartContentWrapper>

--- a/src/components/LocationPage/ChartsHolder.tsx
+++ b/src/components/LocationPage/ChartsHolder.tsx
@@ -142,10 +142,6 @@ const ChartsHolder = (props: {
       ]
     : [];
 
-  const exploreCompareCopy: string = props.county
-    ? 'Compare counties'
-    : 'Compare states';
-
   // TODO(pablo): Create separate refs for signup and share
   return (
     <>
@@ -190,7 +186,7 @@ const ChartsHolder = (props: {
               <Explore
                 projection={props.projections.primary}
                 chartId={chartId}
-                compareCopy={exploreCompareCopy}
+                compareCopy="Compare states or counties"
               />
             </MainContentInner>
           </ChartContentWrapper>


### PR DESCRIPTION
This PR enables comparing states and counties from any location page (state or county). 

I'm not sure about the ordering of the options is [components/Explore/utils.ts#123](https://github.com/covid-projections/covid-projections/pull/1489/files#diff-dd7f086fa1c0daa9a9fbd34229f306e4R384-R386). That order shows the most relevant locations first, but showing states in the county page, or counties in the state page might make the change more discoverable. Thoughts?