### PR TITLE
analytics: update pages title and description

### DIFF
--- a/cypress/integration/ModelPage_spec.js
+++ b/cypress/integration/ModelPage_spec.js
@@ -3,7 +3,7 @@ describe('/state/:id', () => {
     cy.visit('/us/ny');
     cy.title().should(
       'eq',
-      'New York, NY - America’s COVID Warning System - Covid Act Now',
+      'New York, (NY) - America’s COVID Warning System - Covid Act Now',
     );
     cy.get('head meta[name="description"]')
       .should('have.attr', 'content')

--- a/cypress/integration/ModelPage_spec.js
+++ b/cypress/integration/ModelPage_spec.js
@@ -3,7 +3,7 @@ describe('/state/:id', () => {
     cy.visit('/us/ny');
     cy.title().should(
       'eq',
-      'New York, (NY) - America’s COVID Warning System - Covid Act Now',
+      'New York (NY) - America’s COVID Warning System - Covid Act Now',
     );
     cy.get('head meta[name="description"]')
       .should('have.attr', 'content')

--- a/cypress/integration/ModelPage_spec.js
+++ b/cypress/integration/ModelPage_spec.js
@@ -1,14 +1,12 @@
 describe('/state/:id', () => {
-  it(`Stay At Home has the correct title & description`, () => {
+  it(`State page has the correct title & description`, () => {
     cy.visit('/us/ny');
     cy.title().should(
       'eq',
-      'Real-time modeling and metrics to understand where we stand against COVID. - Covid Act Now',
+      'New York, NY - America’s COVID Warning System - Covid Act Now',
     );
-    cy.get('head meta[name="description"]').should(
-      'have.attr',
-      'content',
-      'Real-time modeling and metrics to understand where we stand against COVID. 50 states. 3,000+ counties. Click the map to dive in.',
-    );
+    cy.get('head meta[name="description"]')
+      .should('have.attr', 'content')
+      .and('match', /York/);
   });
 });

--- a/src/screens/HomePage/HomePage.js
+++ b/src/screens/HomePage/HomePage.js
@@ -68,7 +68,7 @@ export default function HomePage() {
       <EnsureSharingIdInUrl />
       <AppMetaTags
         canonicalUrl="/"
-        pageTitle={undefined}
+        pageTitle="Covid Act Now - America’s COVID Warning System"
         pageDescription="Real-time modeling and metrics to understand where we stand against COVID. 50 states. 3,000+ counties. Click the map to dive in"
       />
       <HomePageHeader

--- a/src/screens/LocationPage/LocationPage.js
+++ b/src/screens/LocationPage/LocationPage.js
@@ -10,7 +10,7 @@ import EnsureSharingIdInUrl from 'components/EnsureSharingIdInUrl';
 import ChartsHolder from 'components/LocationPage/ChartsHolder';
 import { LoadingScreen } from './LocationPage.style';
 import { useProjections } from 'common/utils/model';
-import { getPageTitle, getPageDescription } from './utils';
+import { getPageTitle, getPageDescription, getCanonicalUrl } from './utils';
 
 function LocationPage() {
   let { stateId, countyId, chartId } = useParams();
@@ -48,12 +48,13 @@ function LocationPage() {
 
   const pageTitle = getPageTitle(projections);
   const pageDescription = getPageDescription(projections);
+  const canonicalUrl = getCanonicalUrl(projections.fips);
 
   return (
     <div>
       <EnsureSharingIdInUrl />
       <AppMetaTags
-        canonicalUrl={`/us/${stateId.toLowerCase()}`}
+        canonicalUrl={canonicalUrl}
         pageTitle={pageTitle}
         pageDescription={pageDescription}
       />

--- a/src/screens/LocationPage/LocationPage.js
+++ b/src/screens/LocationPage/LocationPage.js
@@ -1,6 +1,5 @@
 import React, { useState, useMemo } from 'react';
 import { find } from 'lodash';
-import moment from 'moment';
 import { useParams } from 'react-router-dom';
 import US_STATE_DATASET from 'components/MapSelectors/datasets/us_states_dataset_01_02_2020';
 import { MAP_FILTERS } from './Enums/MapFilterEnums';
@@ -11,30 +10,7 @@ import EnsureSharingIdInUrl from 'components/EnsureSharingIdInUrl';
 import ChartsHolder from 'components/LocationPage/ChartsHolder';
 import { LoadingScreen } from './LocationPage.style';
 import { useProjections } from 'common/utils/model';
-import { findLocationForFips, findStateByFips } from 'common/locations';
-import { LOCATION_SUMMARY_LEVELS } from 'common/metrics/location_summary';
-
-function getPageTitle(projections) {
-  const location = findLocationForFips(projections.fips);
-  const state = findStateByFips(location.state_fips_code);
-  const locationName = location.county
-    ? `${location.county}, ${state.state}`
-    : `${location.state}`;
-  return `${locationName}, ${location.state_code} - America’s COVID Warning System`;
-}
-
-function getPageDescription(projections) {
-  const dateToday = moment().format('MMM DD, YYYY');
-  const location = findLocationForFips(projections.fips);
-  const state = findStateByFips(location.state_fips_code);
-  const alarmLevel = projections.getAlarmLevel();
-  const levelInfo = LOCATION_SUMMARY_LEVELS[alarmLevel];
-  const locationName = location.county
-    ? `${location.county}, ${state.state}/${location.state_code}`
-    : `${location.state}`;
-
-  return `${dateToday} COVID THREAT LEVEL: ${levelInfo.detail(locationName)}`;
-}
+import { getPageTitle, getPageDescription } from './utils';
 
 function LocationPage() {
   let { stateId, countyId, chartId } = useParams();

--- a/src/screens/LocationPage/index.ts
+++ b/src/screens/LocationPage/index.ts
@@ -1,0 +1,2 @@
+import { getPageTitle, getPageDescription } from './utils';
+export { getPageTitle, getPageDescription };

--- a/src/screens/LocationPage/utils.ts
+++ b/src/screens/LocationPage/utils.ts
@@ -9,7 +9,7 @@ function getLocationName(fipsCode: string) {
   const { county: countyName, state_code: stateCode } = location;
   const locationName = location.county
     ? `${countyName}, ${stateName} (${stateCode})`
-    : `${stateName}, (${stateCode})`;
+    : `${stateName} (${stateCode})`;
   return locationName;
 }
 

--- a/src/screens/LocationPage/utils.ts
+++ b/src/screens/LocationPage/utils.ts
@@ -1,0 +1,27 @@
+import moment from 'moment';
+import { Projections } from 'common/models/Projections';
+import { findLocationForFips, findStateByFips } from 'common/locations';
+import { LOCATION_SUMMARY_LEVELS } from 'common/metrics/location_summary';
+
+function getLocationName(fipsCode: string) {
+  const location = findLocationForFips(fipsCode);
+  const { state: stateName } = findStateByFips(location.state_fips_code);
+  const { county: countyName, state_code: stateCode } = location;
+  const locationName = location.county
+    ? `${countyName}, ${stateName} (${stateCode})`
+    : `${stateName}, (${stateCode})`;
+  return locationName;
+}
+
+export function getPageTitle(projections: Projections): string {
+  const locationName = getLocationName(projections.fips);
+  return `${locationName} - America’s COVID Warning System`;
+}
+
+export function getPageDescription(projections: Projections): string {
+  const dateToday = moment().format('MMM DD, YYYY');
+  const alarmLevel = projections.getAlarmLevel();
+  const levelInfo = LOCATION_SUMMARY_LEVELS[alarmLevel];
+  const locationName = getLocationName(projections.fips);
+  return `${dateToday} Risk Level: ${levelInfo.detail(locationName)}`;
+}

--- a/src/screens/LocationPage/utils.ts
+++ b/src/screens/LocationPage/utils.ts
@@ -25,3 +25,12 @@ export function getPageDescription(projections: Projections): string {
   const locationName = getLocationName(projections.fips);
   return `${dateToday} Risk Level: ${levelInfo.detail(locationName)}`;
 }
+
+export function getCanonicalUrl(fipsCode: string) {
+  const location = findLocationForFips(fipsCode);
+  const { county, state_code } = location;
+  const stateId = state_code.toLowerCase();
+  return county
+    ? `us/${stateId}/county/${location.county_url_name}`
+    : `us/${stateId}`;
+}


### PR DESCRIPTION
This PR updates the title and description metatag for the home page and location pages to increase our search rankings. 

Gaia's analysis reveals that people search using the county name and state name and/or state code. People in some states tend to use the state code, while others use the full name. Adding this information on the title and description of the page helps our page rank higher when people search for it.

Check the [Growth Analytics Roadmap](https://docs.google.com/document/d/110tRmOW-Y_BcmYF0OcxVjV5-lDf0RTkqfRx1oWdyK6o/edit#) document for the proposed changes.