### PR TITLE
explore: optimize margin size

### DIFF
--- a/src/components/Explore/Explore.tsx
+++ b/src/components/Explore/Explore.tsx
@@ -35,6 +35,33 @@ import {
 } from './utils';
 import * as Styles from './Explore.style';
 
+const MARGIN_SINGLE_LOCATION = 20;
+const MARGIN_STATE_CODE = 60;
+const MARGIN_COUNTY = 120;
+
+function getMarginRight(
+  showLabels: boolean,
+  shortLabels: boolean,
+  seriesList: Series[],
+) {
+  const maxLabelLength =
+    max(seriesList.map(series => getLabelLength(series, shortLabels))) || 0;
+
+  // We only show the labels when multiple locations are selected. If only
+  // states are selected, we only need space for the state code, if at least
+  // one county is selected, we need more space.
+  return showLabels
+    ? maxLabelLength > 2
+      ? MARGIN_COUNTY
+      : MARGIN_STATE_CODE
+    : MARGIN_SINGLE_LOCATION;
+}
+
+function getLabelLength(series: Series, shortLabel: boolean) {
+  const label = getSeriesLabel(series, shortLabel);
+  return label.length;
+}
+
 const Explore: React.FunctionComponent<{
   projection: Projection;
   chartId?: string;
@@ -105,17 +132,10 @@ const Explore: React.FunctionComponent<{
     setNormalizeData,
   };
 
-  const seriesLabels = chartSeries.map(series =>
-    getSeriesLabel(series, isMobileXs),
+  const marginRight = useMemo(
+    () => getMarginRight(hasMultipleLocations, isMobileXs, chartSeries),
+    [hasMultipleLocations, isMobileXs, chartSeries],
   );
-
-  const maxLabelLength = max(seriesLabels.map(label => label.length)) || 0;
-
-  const adjustedMarginRight = hasMultipleLocations
-    ? maxLabelLength > 2
-      ? 120
-      : 60
-    : 20;
 
   return (
     <Styles.Container>
@@ -205,7 +225,7 @@ const Explore: React.FunctionComponent<{
                   tooltipSubtext={`in ${locationName}`}
                   hasMultipleLocations={hasMultipleLocations}
                   isMobileXs={isMobileXs}
-                  marginRight={adjustedMarginRight}
+                  marginRight={marginRight}
                 />
               ) : (
                 <div style={{ height: 400 }} />

--- a/src/components/Explore/Explore.tsx
+++ b/src/components/Explore/Explore.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useMemo, useEffect } from 'react';
-import { some, uniq } from 'lodash';
+import { some, uniq, max } from 'lodash';
 import Grid from '@material-ui/core/Grid';
 import useMediaQuery from '@material-ui/core/useMediaQuery';
 import { useTheme } from '@material-ui/core/styles';
@@ -31,6 +31,7 @@ import {
   getAutocompleteLocations,
   getChartSeries,
   getMetricName,
+  getSeriesLabel,
 } from './utils';
 import * as Styles from './Explore.style';
 
@@ -103,6 +104,18 @@ const Explore: React.FunctionComponent<{
     normalizeData,
     setNormalizeData,
   };
+
+  const seriesLabels = chartSeries.map(series =>
+    getSeriesLabel(series, isMobileXs),
+  );
+
+  const maxLabelLength = max(seriesLabels.map(label => label.length)) || 0;
+
+  const adjustedMarginRight = hasMultipleLocations
+    ? maxLabelLength > 2
+      ? 120
+      : 60
+    : 20;
 
   return (
     <Styles.Container>
@@ -192,6 +205,7 @@ const Explore: React.FunctionComponent<{
                   tooltipSubtext={`in ${locationName}`}
                   hasMultipleLocations={hasMultipleLocations}
                   isMobileXs={isMobileXs}
+                  marginRight={adjustedMarginRight}
                 />
               ) : (
                 <div style={{ height: 400 }} />

--- a/src/components/Explore/MultipleLocationsChart.tsx
+++ b/src/components/Explore/MultipleLocationsChart.tsx
@@ -8,7 +8,7 @@ import { Column } from 'common/models/Projection';
 import { Tooltip, RectClipGroup } from 'components/Charts';
 import { Series } from './interfaces';
 import ChartSeries, { SeriesMarker } from './SeriesChart';
-import { getMaxBy } from './utils';
+import { getMaxBy, getSeriesLabel } from './utils';
 import * as Styles from './Explore.style';
 import { COLOR_MAP } from 'common/colors';
 import { ScreenshotReady } from 'components/Screenshot';
@@ -18,7 +18,6 @@ import { Line } from '@vx/shape';
 import DateMarker from './DateMarker';
 import GridLines from './GridLines';
 import Axes from './Axes';
-import { getStateCode } from 'common/locations';
 
 const getDate = (d: Column) => new Date(d.x);
 const getY = (d: Column) => d.y;
@@ -121,7 +120,7 @@ const MultipleLocationsChart: React.FC<{
   marginLeft = 60,
   marginRight = 100,
   barOpacity,
-  isMobileXs,
+  isMobileXs = false,
 }) => {
   const dateFrom = new Date('2020-03-01');
   const dateTo = new Date();
@@ -180,19 +179,16 @@ const MultipleLocationsChart: React.FC<{
             dateScale={dateScale}
             strokeColor={axisGridColor}
           />
-          {seriesList.map(({ label, data, params }, i) => {
-            const locationLabel = !isMobileXs
-              ? label
-              : getStateCode(label) || label.slice(0, 3);
-            return data.length > 0 ? (
+          {seriesList.map((series, i) => {
+            return series.data.length > 0 ? (
               <Styles.LineLabel
-                key={`label-${label}`}
+                key={`label-${series.label}`}
                 x={innerWidth + 5}
-                y={getYPosition(data[data.length - 1])}
-                fill={params?.stroke || '#000'}
+                y={getYPosition(series.data[series.data.length - 1])}
+                fill={series.params?.stroke || '#000'}
                 fillOpacity={getSeriesOpacity(i, tooltipOpen, tooltipData)}
               >
-                {locationLabel}
+                {getSeriesLabel(series, isMobileXs)}
               </Styles.LineLabel>
             ) : null;
           })}

--- a/src/components/Explore/interfaces.ts
+++ b/src/components/Explore/interfaces.ts
@@ -15,6 +15,7 @@ export interface Series {
   data: Column[];
   type: SeriesType;
   label: string;
+  shortLabel: string;
   tooltipLabel: string;
   params?: SeriesParams;
 }

--- a/src/components/Explore/utils.ts
+++ b/src/components/Explore/utils.ts
@@ -30,6 +30,7 @@ import {
   isCounty,
   belongsToState,
 } from 'components/AutocompleteLocations';
+import { getAbbreviatedCounty } from '../../common/utils/compare';
 
 export function getMaxBy<T>(
   seriesList: Series[],
@@ -215,6 +216,7 @@ export function getAllSeriesForMetric(
     data: cleanSeries(projection.getDataset(item.datasetId)),
     type: item.type,
     label: item.label,
+    shortLabel: item.label,
     tooltipLabel: item.tooltipLabel,
   }));
 }
@@ -247,6 +249,7 @@ function getAveragedSeriesForMetric(
       fill: color,
     },
     label: getLocationLabel(location),
+    shortLabel: getShortLocationLabel(location),
     tooltipLabel: normalizeData
       ? `${metricName} per 100k population`
       : metricName,
@@ -358,9 +361,25 @@ export function weeksAgo(dateFrom: Date, dateTo: Date) {
 }
 
 export function getLocationLabel(location: Location) {
-  return location.county
-    ? `${location.county}, ${location.state_code}`
-    : location.state;
+  const { county: countyName, state_code, state: stateName } = location;
+  const stateCode = state_code.toUpperCase();
+  return countyName
+    ? `${getAbbreviatedCounty(countyName)} ${stateCode}`
+    : stateName;
+}
+
+function truncateCountyName(countyName: string) {
+  return countyName.length < 8
+    ? countyName
+    : `${countyName.slice(0, 7).trim()}…`;
+}
+
+function getShortLocationLabel(location: Location) {
+  const { county: countyName, state_code } = location;
+  const stateCode = state_code.toUpperCase();
+  return countyName
+    ? `${truncateCountyName(getAbbreviatedCounty(countyName))} ${stateCode}`
+    : stateCode;
 }
 
 export function getLocationNames(locations: Location[]) {
@@ -429,4 +448,8 @@ export function getChartSeries(
       }),
     ).then(flatten);
   }
+}
+
+export function getSeriesLabel(series: Series, isMobile: boolean) {
+  return isMobile ? series.shortLabel : series.label;
 }

--- a/src/components/Explore/utils.ts
+++ b/src/components/Explore/utils.ts
@@ -369,17 +369,16 @@ export function getLocationLabel(location: Location) {
 }
 
 function truncateCountyName(countyName: string) {
-  return countyName.length < 8
+  return countyName.length <= 11
     ? countyName
-    : `${countyName.slice(0, 7).trim()}…`;
+    : `${countyName.slice(0, 11).trim()}…`;
 }
 
 function getShortLocationLabel(location: Location) {
   const { county: countyName, state_code } = location;
-  const stateCode = state_code.toUpperCase();
   return countyName
-    ? `${truncateCountyName(getAbbreviatedCounty(countyName))} ${stateCode}`
-    : stateCode;
+    ? `${truncateCountyName(getAbbreviatedCounty(countyName))}`
+    : state_code.toUpperCase();
 }
 
 export function getLocationNames(locations: Location[]) {


### PR DESCRIPTION
This PR optimizes the labels for the explore chart when there are multiple locations selected. There are 3 main cases:

- Desktop: We show the full name, hoping that it will fit (it will overflow if not)
- Mobile (states only): We show only the state code, so we need a narrow right margin
- Mobile (with counties): We show a cropped version of the county name and expand the margin so it will fit.

**Desktop**
<img src="https://user-images.githubusercontent.com/114084/93538999-651ff500-f904-11ea-9247-124f4695a046.png" width="980px" />

**Mobile (states only)**
<img src="https://user-images.githubusercontent.com/114084/93539030-7bc64c00-f904-11ea-86ff-772d9419f0fd.png" width="375px" />

**Mobile (states + county)**
<img src="https://user-images.githubusercontent.com/114084/93539070-94366680-f904-11ea-9b3e-de0ebd29efd9.png" width="375px" />
