### PR TITLE
Rework compare sharing and implement explore sharing.

### DIFF
--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -5,17 +5,21 @@ service cloud.firestore {
       allow read, write;
     }
 
-    // Document for tracking the next ID to be used for sharing compare params.
-    match /compare-shared-params/__nextId {
-      allow read;
-      // Only allow increments.
-      allow write: if resource == null || request.resource.data.id == resource.data.id + 1;
-    }
-    // Each document stores a set of share params corresponding to a shared compare table.
-    match /compare-shared-params/{compareShareId} {
-      allow read;
-      // Can write only if it doesn't exist.
-      allow write: if resource == null;
+    // Collection for storing component params each time somebody shares a
+    // component (compare, explore, etc.)
+    match /shared-component-params {
+      // Document for tracking the next ID to be used.
+      match /__nextId {
+        allow read;
+        // Only allow increments.
+        allow write: if resource == null || request.resource.data.id == resource.data.id + 1;
+      }
+      // Each document stores a set of params corresponding to a shared component.
+      match /{sharedComponentId} {
+        allow read;
+        // Can write only if it doesn't exist.
+        allow write: if resource == null;
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -58,8 +58,9 @@
   "scripts": {
     "start": "cross-env TSC_COMPILE_ON_ERROR=false react-scripts -r @cypress/instrument-cra start",
     "build": "react-scripts build",
-    "build:staging": "cross-env REACT_APP_ENVIRONMENT=staging yarn build && yarn generate-index-pages",
-    "build:prod": "cross-env REACT_APP_ENVIRONMENT=prod yarn build && yarn generate-index-pages",
+    "build-with-index-pages": "yarn build && yarn generate-index-pages",
+    "build:staging": "cross-env REACT_APP_ENVIRONMENT=staging yarn build-with-index-pages",
+    "build:prod": "cross-env REACT_APP_ENVIRONMENT=prod yarn build-with-index-pages",
     "serve": "react-scripts build && serve -s build",
     "eject": "react-scripts eject",
     "test": "start-server-and-test start http://localhost:3000 cy.open",

--- a/src/App.js
+++ b/src/App.js
@@ -39,7 +39,6 @@ export default function App() {
         <StylesProvider injectFirst>
           <CssBaseline />
           <BrowserRouter>
-            <HandleRedirectTo />
             <ScrollToTop />
             <AppBar />
             <Switch>
@@ -47,7 +46,7 @@ export default function App() {
               <Route exact path="/alert_signup" component={HomePage} />
               <Route
                 exact
-                path="/compare/:compareShareId?"
+                path="/compare/:sharedComponentId?"
                 component={HomePage}
               />
 
@@ -76,7 +75,7 @@ export default function App() {
               />
               <Route
                 exact
-                path="/us/:stateId/compare/:compareShareId?"
+                path="/us/:stateId/compare/:sharedComponentId?"
                 component={LocationPage}
               />
               <Route
@@ -91,7 +90,7 @@ export default function App() {
               />
               <Route
                 exact
-                path="/us/:stateId/county/:countyId/compare/:compareShareId?"
+                path="/us/:stateId/county/:countyId/compare/:sharedComponentId?"
                 component={LocationPage}
               />
               {/* /state/ routes are deprecated but still supported. */}
@@ -184,6 +183,7 @@ export default function App() {
               exports images. */}
               <Route path="/internal/export-image/" component={ExportImage} />
 
+              <HandleRedirectTo />
               <Route path="/*">
                 <Redirect to="/" />
               </Route>

--- a/src/App.js
+++ b/src/App.js
@@ -70,7 +70,7 @@ export default function App() {
               />
               <Route
                 exact
-                path="/us/:stateId/explore/:chartId"
+                path="/us/:stateId/explore/:sharedComponentId?"
                 component={LocationPage}
               />
               <Route
@@ -85,7 +85,7 @@ export default function App() {
               />
               <Route
                 exact
-                path="/us/:stateId/county/:countyId/explore/:chartId"
+                path="/us/:stateId/county/:countyId/explore/:sharedComponentId?"
                 component={LocationPage}
               />
               <Route

--- a/src/common/locations.ts
+++ b/src/common/locations.ts
@@ -124,17 +124,15 @@ export function getLocationNameForFips(fips: string): string {
   }
 }
 
-export function getLocationUrlForFips(fips: string): string {
-  // TODO(pablo): Make sure that these urls are uniform, here, the state
-  // URL ends on / but not the county one
+export function getRelativeUrlForFips(fips: string): string {
   if (isStateFips(fips)) {
     const state = findStateByFips(fips);
-    return `https://covidactnow.org/us/${state.state_code.toLowerCase()}/`;
+    return `/us/${state.state_code.toLowerCase()}/`;
   } else {
     const county = findCountyByFips(fips);
-    return `https://covidactnow.org/us/${county.state_code.toLowerCase()}/county/${
+    return `/us/${county.state_code.toLowerCase()}/county/${
       county.county_url_name
-    }`;
+    }/`;
   }
 }
 

--- a/src/common/sharing.ts
+++ b/src/common/sharing.ts
@@ -1,0 +1,141 @@
+import { getFirebase } from 'common/firebase';
+import { isEqual, pickBy } from 'lodash';
+import { useParams } from 'react-router-dom';
+import { useEffect, useState } from 'react';
+
+const firestore = getFirebase().firestore();
+const collection = firestore.collection('shared-component-params');
+const nextIdDocRef = collection.doc('__nextId');
+
+type Params = { [key: string]: any };
+
+type ComponentName = 'compare' | 'explore';
+
+// A cache of component params that we have (or are) storing to Firestore. This
+// allows components to be a bit sloppy and call storeSharedComponentParams()
+// multiple times for the same params without triggering extra Firestore
+// requests and multiple share IDs generated.
+const storedComponentParams: Array<{
+  id: Promise<string>;
+  params: Params;
+}> = [];
+
+/**
+ * Stores the provided params to Firestore (and associates them with the
+ * specific componentName).
+ *
+ * Returns an assigned component share ID that will correspond to the stored
+ * params going forward.
+ */
+export async function storeSharedComponentParams(
+  componentName: ComponentName,
+  params: Params,
+): Promise<string> {
+  // Add the componentName and filter out any undefined values, since Firestore
+  // doesn't allow them to be written.
+  params = pickBy(
+    {
+      componentName,
+      ...params,
+    },
+    v => v !== undefined,
+  );
+  let cachedParams = storedComponentParams.find(cached =>
+    isEqual(cached.params, params),
+  );
+  if (!cachedParams) {
+    const id = firestore.runTransaction<string>(async txn => {
+      const nextIdDoc = await txn.get(nextIdDocRef);
+
+      // Get the next available ID and increment it for the next share.
+      const id = nextIdDoc.data()?.id || 0;
+      nextIdDocRef.set({ id: id + 1 });
+      const idString = id.toString();
+
+      // Write the params under the ID we got.
+      collection.doc(idString).set(params);
+
+      return idString;
+    });
+    cachedParams = { id, params };
+    storedComponentParams.push(cachedParams);
+  }
+  return cachedParams.id;
+}
+
+// A cache of component params that we have read from Firestore. Ensures that we
+// don't re-fetch the same params multiple times (causing extra delays).
+const fetchedComponentParams: {
+  [id: string]: Promise<Params | undefined>;
+} = {};
+
+/**
+ * Fetches previously stored component params for a particular component share ID.
+ *
+ * Returns the params if they match the specified componentName (or
+ * componentName is undefined), else returns undefined.
+ */
+async function fetchSharedComponentParams(
+  componentName: ComponentName | undefined,
+  sharedComponentId: string,
+): Promise<Params | undefined> {
+  let cachedParams = fetchedComponentParams[sharedComponentId];
+  if (!cachedParams) {
+    const fetch = async () => {
+      const doc = await collection.doc(sharedComponentId).get();
+      const params = doc.data();
+      if (
+        !params ||
+        (componentName && params['componentName'] !== componentName)
+      ) {
+        return undefined;
+      }
+      return params;
+    };
+    cachedParams = fetch();
+    fetchedComponentParams[sharedComponentId] = cachedParams;
+  }
+
+  return cachedParams;
+}
+
+/**
+ * React Hook to fetch and return the previously-stored component params for a
+ * particular component share ID.
+ *
+ * Returns the params if they match the specified componentName (or
+ * componentName is undefined), else returns undefined.
+ */
+export function useSharedComponentParams(
+  componentName: ComponentName | undefined,
+): Params | undefined {
+  const { sharedComponentId } = useParams();
+
+  const [componentParams, setComponentParams] = useState<Params | undefined>(
+    undefined,
+  );
+  useEffect(() => {
+    let cancelled = false;
+    if (sharedComponentId) {
+      const fetchParams = async () => {
+        const params = await fetchSharedComponentParams(
+          componentName,
+          sharedComponentId,
+        );
+        if (params && !cancelled) {
+          setComponentParams(params);
+        }
+      };
+      fetchParams();
+      return () => {
+        cancelled = true;
+      };
+    }
+  }, [componentName, sharedComponentId]);
+  return componentParams;
+}
+
+export async function getNextSharedComponentId(): Promise<number> {
+  const doc = await nextIdDocRef.get();
+  return doc.get('id') || 0;
+}

--- a/src/common/sharing.ts
+++ b/src/common/sharing.ts
@@ -84,19 +84,19 @@ async function fetchSharedComponentParams(
     const fetch = async () => {
       const doc = await collection.doc(sharedComponentId).get();
       const params = doc.data();
-      if (
-        !params ||
-        (componentName && params['componentName'] !== componentName)
-      ) {
-        return undefined;
-      }
       return params;
     };
     cachedParams = fetch();
     fetchedComponentParams[sharedComponentId] = cachedParams;
   }
 
-  return cachedParams;
+  const params = await cachedParams;
+  // Only return the params if they're for the requested component.
+  if (componentName && componentName !== params?.componentName) {
+    return undefined;
+  } else {
+    return params;
+  }
 }
 
 /**

--- a/src/common/urls.ts
+++ b/src/common/urls.ts
@@ -69,16 +69,14 @@ export function getComparePageUrl(
   // location page, so we add on a ?redirectTo= query param to redirect to the
   // right place.
 
-  let url = urlJoin(getPageBaseUrl(), 'compare', compareShareId);
+  let url = urlJoin(getPageBaseUrl(), 'share', compareShareId);
   let params: { [key: string]: unknown } = {};
   ensureSharingIdInQueryParams(params);
-  if (stateId) {
-    params['redirectTo'] = urlJoin(
-      getPagePath(stateId, county),
-      'compare',
-      compareShareId,
-    );
-  }
+  params['redirectTo'] = urlJoin(
+    getPagePath(stateId, county),
+    'compare',
+    compareShareId,
+  );
 
   // NOTE: Trailing '/' is significant so we hit the index.html page with correct meta tags and
   // so we don't get redirected and lose the query params.
@@ -86,7 +84,7 @@ export function getComparePageUrl(
 }
 
 export function getCompareShareImageUrl(compareShareId: string): string {
-  return urlJoin(getShareImageBaseUrl(), 'compare', `${compareShareId}.png`);
+  return urlJoin(getShareImageBaseUrl(), 'share', `${compareShareId}.png`);
 }
 
 /**

--- a/src/common/utils/model.ts
+++ b/src/common/utils/model.ts
@@ -6,7 +6,7 @@ import {
   RegionDescriptor,
 } from './RegionDescriptor';
 import { Api } from 'api';
-import { findCountyByFips } from 'common/locations';
+import { County, findCountyByFips } from 'common/locations';
 import moment from 'moment';
 import { RegionSummaryWithTimeseries } from 'api/schema/RegionSummaryWithTimeseries';
 import { assert } from '.';
@@ -92,7 +92,7 @@ export function fetchAllCountyProjections(snapshotUrl: string | null = null) {
   return cachedCountiesProjections[key];
 }
 
-export function useProjections(location: string, county = null) {
+export function useProjections(location: string, county?: County) {
   const [projections, setProjections] = useState<Projections>();
 
   useEffect(() => {

--- a/src/components/Compare/CompareMain.tsx
+++ b/src/components/Compare/CompareMain.tsx
@@ -29,6 +29,7 @@ import { countySummary } from 'common/location_summaries';
 import { findCountyByFips } from 'common/locations';
 import { ScreenshotReady } from 'components/Screenshot';
 import {
+  SharedComponent,
   storeSharedComponentParams,
   useSharedComponentParams,
 } from 'common/sharing';
@@ -150,14 +151,14 @@ const CompareMain = (props: {
   };
 
   const createCompareShareId = async () => {
-    return storeSharedComponentParams('compare', uiState);
+    return storeSharedComponentParams(SharedComponent.Compare, uiState);
   };
 
   const [screenshotReady, setScreenshotReady] = useState(false);
 
   // Repopulate state from shared parameters if we're being rendered via a
   // sharing URL.
-  const sharedParams = useSharedComponentParams('compare');
+  const sharedParams = useSharedComponentParams(SharedComponent.Compare);
   useEffect(() => {
     if (sharedParams) {
       const { stateId, countyId } = sharedParams;

--- a/src/components/Explore/Explore.tsx
+++ b/src/components/Explore/Explore.tsx
@@ -41,6 +41,7 @@ import {
 } from './utils';
 import * as Styles from './Explore.style';
 import {
+  SharedComponent,
   storeSharedComponentParams,
   useSharedComponentParams,
 } from 'common/sharing';
@@ -174,7 +175,7 @@ const Explore: React.FunctionComponent<{
   );
 
   const createSharedComponentId = async () => {
-    return storeSharedComponentParams('explore', {
+    return storeSharedComponentParams(SharedComponent.Explore, {
       currentMetric,
       normalizeData,
       selectedFips: selectedLocations.map(
@@ -183,7 +184,7 @@ const Explore: React.FunctionComponent<{
     });
   };
 
-  const sharedParams = useSharedComponentParams('explore');
+  const sharedParams = useSharedComponentParams(SharedComponent.Explore);
   useEffect(() => {
     if (sharedParams) {
       setCurrentMetric(sharedParams.currentMetric);

--- a/src/components/Explore/MultipleLocationsChart.tsx
+++ b/src/components/Explore/MultipleLocationsChart.tsx
@@ -230,7 +230,7 @@ const MultipleLocationsChart: React.FC<{
           />
         </Group>
       </svg>
-      {width > 0 && <ScreenshotReady />}
+      {width > 0 && seriesList.length > 0 && <ScreenshotReady />}
       {tooltipOpen && tooltipData && (
         <Fragment>
           <MultipleLocationsTooltip

--- a/src/components/Explore/SingleLocationChart.tsx
+++ b/src/components/Explore/SingleLocationChart.tsx
@@ -227,7 +227,7 @@ const SingleLocationChart: React.FC<{
           />
         </Fragment>
       )}
-      {width > 0 && <ScreenshotReady />}
+      {width > 0 && seriesList.length > 0 && <ScreenshotReady />}
     </Styles.PositionRelative>
   );
 };

--- a/src/components/Explore/utils.ts
+++ b/src/components/Explore/utils.ts
@@ -18,7 +18,7 @@ import {
   findLocationForFips,
   getLocationNames as getAllLocations,
   getLocationNameForFips,
-  getLocationUrlForFips,
+  getRelativeUrlForFips,
   isStateFips,
   findStateByFips,
   Location,
@@ -304,19 +304,25 @@ function getRelativeUrl(fips: string) {
  * It needs to be consistent with the path on the share image generation
  * script in `scripts/generate_share_images/index.ts`
  */
-export function getExportImageUrl(fips: string, metric: ExploreMetric) {
-  const chartId = getChartIdByMetric(metric);
+export function getExportImageUrl(fips: string, sharedComponentId: string) {
   const relativeUrl = getRelativeUrl(fips);
-  return urlJoin(share_image_url, relativeUrl, `explore/${chartId}/export.png`);
+  return urlJoin(
+    share_image_url,
+    relativeUrl,
+    `share/${sharedComponentId}/export.png`,
+  );
 }
 
-export function getChartUrl(fips: string, metric: ExploreMetric) {
-  const chartId = getChartIdByMetric(metric);
-  const locationUrl = getLocationUrlForFips(fips);
-  const isState = isStateFips(fips);
-  return isState
-    ? `${locationUrl}explore/${chartId}`
-    : `${locationUrl}/explore/${chartId}`;
+export function getChartUrl(fips: string, sharedComponentId: string) {
+  const redirectTo = urlJoin(
+    getRelativeUrlForFips(fips),
+    'explore',
+    sharedComponentId,
+  );
+  const url = urlJoin(window.location.origin, 'share', sharedComponentId);
+  // NOTE: Trailing '/' is significant so we hit the index.html page with correct meta tags and
+  // so we don't get redirected and lose the query params.
+  return `${url}/?redirectTo=${encodeURIComponent(redirectTo)}`;
 }
 
 export function getSocialQuote(fips: string, metric: ExploreMetric) {

--- a/src/components/Explore/utils.ts
+++ b/src/components/Explore/utils.ts
@@ -20,7 +20,6 @@ import {
   getLocationNameForFips,
   getRelativeUrlForFips,
   isStateFips,
-  findStateByFips,
   Location,
 } from 'common/locations';
 import { share_image_url } from 'assets/data/share_images_url.json';

--- a/src/components/Explore/utils.ts
+++ b/src/components/Explore/utils.ts
@@ -290,27 +290,13 @@ export function getImageFilename(fips: string, metric: ExploreMetric) {
   return `${sanitizeLocationName(locationName)}-${chartId}-${downloadDate}.png`;
 }
 
-function getRelativeUrl(fips: string) {
-  if (isStateFips(fips)) {
-    const { state_code } = findStateByFips(fips);
-    return `states/${state_code.toLowerCase()}`;
-  } else {
-    return `counties/${fips}`;
-  }
-}
-
 /**
  * Generates the URL of the export images for the given fips code and chart.
  * It needs to be consistent with the path on the share image generation
  * script in `scripts/generate_share_images/index.ts`
  */
 export function getExportImageUrl(fips: string, sharedComponentId: string) {
-  const relativeUrl = getRelativeUrl(fips);
-  return urlJoin(
-    share_image_url,
-    relativeUrl,
-    `share/${sharedComponentId}/export.png`,
-  );
+  return urlJoin(share_image_url, `share/${sharedComponentId}/export.png`);
 }
 
 export function getChartUrl(fips: string, sharedComponentId: string) {

--- a/src/components/LocationPage/ChartsHolder.tsx
+++ b/src/components/LocationPage/ChartsHolder.tsx
@@ -9,7 +9,7 @@ import useMediaQuery from '@material-ui/core/useMediaQuery';
 import { useTheme } from '@material-ui/core/styles';
 import { Metric, ALL_METRICS } from 'common/metric';
 import CompareMain from 'components/Compare/CompareMain';
-import Explore, { EXPLORE_CHART_IDS } from 'components/Explore';
+import Explore from 'components/Explore';
 import { County } from 'common/locations';
 
 // TODO: 180 is rough accounting for the navbar and searchbar;
@@ -48,9 +48,7 @@ const ChartsHolder = (props: {
   useEffect(() => {
     const scrollToChart = () => {
       const timeoutId = setTimeout(() => {
-        if (chartId && EXPLORE_CHART_IDS.includes(chartId)) {
-          scrollTo(exploreChartRef.current);
-        } else if (chartId in metricRefs) {
+        if (chartId in metricRefs) {
           const metricRef = metricRefs[(chartId as unknown) as Metric];
           if (metricRef.current) {
             scrollTo(metricRef.current);
@@ -113,10 +111,7 @@ const ChartsHolder = (props: {
               ))}
             </MainContentInner>
             <MainContentInner ref={exploreChartRef}>
-              <Explore
-                projection={props.projections.primary}
-                chartId={chartId}
-              />
+              <Explore fips={props.projections.primary.fips} />
             </MainContentInner>
           </ChartContentWrapper>
           <div ref={shareBlockRef}>

--- a/src/screens/internal/ShareImage/ChartExportImage.style.ts
+++ b/src/screens/internal/ShareImage/ChartExportImage.style.ts
@@ -44,6 +44,16 @@ export const MetricName = styled.div`
   letter-spacing: -0.01em;
 `;
 
+export const ExploreTitle = styled.div`
+  margin-top: 10px;
+  text-transform: capitalize;
+  font-family: 'Roboto';
+  font-weight: bold;
+  font-size: 24px;
+  line-height: 24px;
+  width: 900px;
+`;
+
 export const LastUpdated = styled.div`
   margin-top: 10px;
   font-family: 'Source Code Pro';
@@ -62,6 +72,11 @@ export const ChartWrapper = styled.div`
   span {
     font-family: 'Roboto' !important;
   }
+`;
+
+export const ExploreChartWrapper = styled(ChartWrapper)`
+  margin-left: 60px;
+  width: 1060px;
 `;
 
 export const LogoHolder = styled.div`

--- a/src/screens/internal/ShareImage/ChartShareImage.style.ts
+++ b/src/screens/internal/ShareImage/ChartShareImage.style.ts
@@ -20,6 +20,15 @@ export const Title = styled.div`
   font-size: 24px;
   line-height: 18px;
   text-transform: capitalize;
+  width: 400px;
+`;
+
+export const ExploreTitle = styled(Title)`
+  font-size: 18px;
+  line-height: 19px;
+  text-transform: capitalize;
+  height: 75px;
+  overflow: hidden;
 `;
 
 export const Subtitle = styled.div`
@@ -34,8 +43,9 @@ export const Subtitle = styled.div`
 `;
 
 export const ChartWrapper = styled.div`
-  margin-left: 60px;
-  margin-top: 25px;
+  position: absolute;
+  left: 60px;
+  top: 88px;
   width: 495px;
   height: 225px;
 
@@ -43,6 +53,11 @@ export const ChartWrapper = styled.div`
   span {
     font-family: 'Roboto' !important;
   }
+`;
+
+export const ExploreChartWrapper = styled(ChartWrapper)`
+  left: 20px;
+  width: 535px;
 `;
 
 export const LogoHolder = styled.div`

--- a/src/screens/internal/ShareImage/ShareImage.tsx
+++ b/src/screens/internal/ShareImage/ShareImage.tsx
@@ -8,12 +8,18 @@ import ExploreChartExportImage from './ExploreChartExportImage';
 import CompareTableImage from './CompareTableImage';
 import { useSharedComponentParams } from 'common/sharing';
 
-function SharedComponentImage() {
+function SharedComponentImage({ exportImage }: { exportImage: boolean }) {
   const componentParams = useSharedComponentParams(undefined);
   if (componentParams) {
     switch (componentParams['componentName']) {
       case 'compare':
         return <CompareTableImage />;
+      case 'explore':
+        return exportImage ? (
+          <ExploreChartExportImage componentParams={componentParams} />
+        ) : (
+          <ExploreChartImage componentParams={componentParams} />
+        );
     }
   }
 
@@ -88,6 +94,9 @@ export default function ShareImage({ match }: RouteComponentProps<{}>) {
         path={`${match.path}share/:sharedComponentId`}
         component={SharedComponentImage}
       />
+      <Route exact path={`${match.path}share/:sharedComponentId/export`}>
+        <SharedComponentImage exportImage={true} />
+      </Route>
 
       {/* DEFAULT */}
       <Route path="/*">Bad Share Image URL.</Route>

--- a/src/screens/internal/ShareImage/ShareImage.tsx
+++ b/src/screens/internal/ShareImage/ShareImage.tsx
@@ -6,15 +6,15 @@ import ChartExportImage from './ChartExportImage';
 import ExploreChartImage from './ExploreChartImage';
 import ExploreChartExportImage from './ExploreChartExportImage';
 import CompareTableImage from './CompareTableImage';
-import { useSharedComponentParams } from 'common/sharing';
+import { SharedComponent, useSharedComponentParams } from 'common/sharing';
 
 function SharedComponentImage({ exportImage }: { exportImage: boolean }) {
-  const componentParams = useSharedComponentParams(undefined);
+  const componentParams = useSharedComponentParams(SharedComponent.Any);
   if (componentParams) {
-    switch (componentParams['componentName']) {
-      case 'compare':
+    switch (componentParams.component as SharedComponent) {
+      case SharedComponent.Compare:
         return <CompareTableImage />;
-      case 'explore':
+      case SharedComponent.Explore:
         return exportImage ? (
           <ExploreChartExportImage componentParams={componentParams} />
         ) : (

--- a/src/screens/internal/ShareImage/ShareImage.tsx
+++ b/src/screens/internal/ShareImage/ShareImage.tsx
@@ -6,6 +6,19 @@ import ChartExportImage from './ChartExportImage';
 import ExploreChartImage from './ExploreChartImage';
 import ExploreChartExportImage from './ExploreChartExportImage';
 import CompareTableImage from './CompareTableImage';
+import { useSharedComponentParams } from 'common/sharing';
+
+function SharedComponentImage() {
+  const componentParams = useSharedComponentParams(undefined);
+  if (componentParams) {
+    switch (componentParams['componentName']) {
+      case 'compare':
+        return <CompareTableImage />;
+    }
+  }
+
+  return <>Could not find / read component sharing params</>;
+}
 
 export default function ShareImage({ match }: RouteComponentProps<{}>) {
   return (
@@ -69,11 +82,11 @@ export default function ShareImage({ match }: RouteComponentProps<{}>) {
         component={ExploreChartExportImage}
       />
 
-      {/* COMPARE TABLES */}
+      {/* SHARED COMPONENTS (Compare, Explore, etc.) */}
       <Route
         exact
-        path={`${match.path}compare/:compareShareId`}
-        component={CompareTableImage}
+        path={`${match.path}share/:sharedComponentId`}
+        component={SharedComponentImage}
       />
 
       {/* DEFAULT */}


### PR DESCRIPTION
FYI- This is split into two commits.  
1. A refactor / reimplementation of compare sharing to make it more general-purpose. The second one uses that infrastructure to implement explore sharing. It mostly has no functional changes though it does point at /share/xyz/ URLs instead of /compare/XYZ URLs which lets us unify the index.html pages we generate to just /share/xyz for compare, explore, and any future components that implement sharing.
2. Actual sharing implementation for the explore component (based on above refactor).

NOTE: Preexisting shared explore URLs should continue to work, but going forward instead of a URL like /us/wa/explore/cases it'll end up being /share/123?redierctTo=/us/wa/explore/123.

With this PR, the following should work:
1. You make an arbitrary explore chart and select copy link. You should get a URL something like: http://localhost:3000/share/15/?redirectTo=%2Fus%2Fwa%2Fexplore%2F15
2. Going to that URL should work (it'll redirect you to the right page and re-load the explore params).
3. If you run `firebase serve` from the `firebase` directory, you can go to http://localhost:5000/0-123/share/15.png or http://localhost:5000/0-123/share/15/export.png to get the correct share or download images.

The following won't work locally:
1. Actually sharing to Facebook / Twitter will insert a prod URL that doesn't work (since we haven't deployed these changes yet) but should look similar to the localhost URLs that do work.
2. The "Save" button won't work since it tries to load from prod, but if you look at the URL in the network tab it should be similar to the localhost URL that does work. 
