### PR TITLE
Deploy explore sharing (#1517)

### DIFF
--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -5,17 +5,21 @@ service cloud.firestore {
       allow read, write;
     }
 
-    // Document for tracking the next ID to be used for sharing compare params.
-    match /compare-shared-params/__nextId {
-      allow read;
-      // Only allow increments.
-      allow write: if resource == null || request.resource.data.id == resource.data.id + 1;
-    }
-    // Each document stores a set of share params corresponding to a shared compare table.
-    match /compare-shared-params/{compareShareId} {
-      allow read;
-      // Can write only if it doesn't exist.
-      allow write: if resource == null;
+    // Collection for storing component params each time somebody shares a
+    // component (compare, explore, etc.)
+    match /shared-component-params {
+      // Document for tracking the next ID to be used.
+      match /__nextId {
+        allow read;
+        // Only allow increments.
+        allow write: if resource == null || request.resource.data.id == resource.data.id + 1;
+      }
+      // Each document stores a set of params corresponding to a shared component.
+      match /{sharedComponentId} {
+        allow read;
+        // Can write only if it doesn't exist.
+        allow write: if resource == null;
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -58,8 +58,9 @@
   "scripts": {
     "start": "cross-env TSC_COMPILE_ON_ERROR=false react-scripts -r @cypress/instrument-cra start",
     "build": "react-scripts build",
-    "build:staging": "cross-env REACT_APP_ENVIRONMENT=staging yarn build && yarn generate-index-pages",
-    "build:prod": "cross-env REACT_APP_ENVIRONMENT=prod yarn build && yarn generate-index-pages",
+    "build-with-index-pages": "yarn build && yarn generate-index-pages",
+    "build:staging": "cross-env REACT_APP_ENVIRONMENT=staging yarn build-with-index-pages",
+    "build:prod": "cross-env REACT_APP_ENVIRONMENT=prod yarn build-with-index-pages",
     "serve": "react-scripts build && serve -s build",
     "eject": "react-scripts eject",
     "test": "start-server-and-test start http://localhost:3000 cy.open",

--- a/src/App.js
+++ b/src/App.js
@@ -39,7 +39,6 @@ export default function App() {
         <StylesProvider injectFirst>
           <CssBaseline />
           <BrowserRouter>
-            <HandleRedirectTo />
             <ScrollToTop />
             <AppBar />
             <Switch>
@@ -47,7 +46,7 @@ export default function App() {
               <Route exact path="/alert_signup" component={HomePage} />
               <Route
                 exact
-                path="/compare/:compareShareId?"
+                path="/compare/:sharedComponentId?"
                 component={HomePage}
               />
 
@@ -71,12 +70,12 @@ export default function App() {
               />
               <Route
                 exact
-                path="/us/:stateId/explore/:chartId"
+                path="/us/:stateId/explore/:sharedComponentId?"
                 component={LocationPage}
               />
               <Route
                 exact
-                path="/us/:stateId/compare/:compareShareId?"
+                path="/us/:stateId/compare/:sharedComponentId?"
                 component={LocationPage}
               />
               <Route
@@ -86,12 +85,12 @@ export default function App() {
               />
               <Route
                 exact
-                path="/us/:stateId/county/:countyId/explore/:chartId"
+                path="/us/:stateId/county/:countyId/explore/:sharedComponentId?"
                 component={LocationPage}
               />
               <Route
                 exact
-                path="/us/:stateId/county/:countyId/compare/:compareShareId?"
+                path="/us/:stateId/county/:countyId/compare/:sharedComponentId?"
                 component={LocationPage}
               />
               {/* /state/ routes are deprecated but still supported. */}
@@ -184,6 +183,7 @@ export default function App() {
               exports images. */}
               <Route path="/internal/export-image/" component={ExportImage} />
 
+              <HandleRedirectTo />
               <Route path="/*">
                 <Redirect to="/" />
               </Route>

--- a/src/common/locations.ts
+++ b/src/common/locations.ts
@@ -124,17 +124,15 @@ export function getLocationNameForFips(fips: string): string {
   }
 }
 
-export function getLocationUrlForFips(fips: string): string {
-  // TODO(pablo): Make sure that these urls are uniform, here, the state
-  // URL ends on / but not the county one
+export function getRelativeUrlForFips(fips: string): string {
   if (isStateFips(fips)) {
     const state = findStateByFips(fips);
-    return `https://covidactnow.org/us/${state.state_code.toLowerCase()}/`;
+    return `/us/${state.state_code.toLowerCase()}/`;
   } else {
     const county = findCountyByFips(fips);
-    return `https://covidactnow.org/us/${county.state_code.toLowerCase()}/county/${
+    return `/us/${county.state_code.toLowerCase()}/county/${
       county.county_url_name
-    }`;
+    }/`;
   }
 }
 

--- a/src/common/sharing.ts
+++ b/src/common/sharing.ts
@@ -1,0 +1,146 @@
+import { getFirebase } from 'common/firebase';
+import { isEqual, pickBy } from 'lodash';
+import { useParams } from 'react-router-dom';
+import { useEffect, useState } from 'react';
+import { assert } from './utils';
+
+const firestore = getFirebase().firestore();
+const collection = firestore.collection('shared-component-params');
+const nextIdDocRef = collection.doc('__nextId');
+
+type Params = { [key: string]: any };
+
+export enum SharedComponent {
+  Any = 'any',
+  Compare = 'compare',
+  Explore = 'explore',
+}
+
+// A cache of component params that we have (or are) storing to Firestore. This
+// allows components to be a bit sloppy and call storeSharedComponentParams()
+// multiple times for the same params without triggering extra Firestore
+// requests and multiple share IDs generated.
+const storedComponentParams: Array<{
+  id: Promise<string>;
+  params: Params;
+}> = [];
+
+/**
+ * Stores the provided params to Firestore (and associates them with the
+ * specified component).
+ *
+ * Returns an assigned component share ID that will correspond to the stored
+ * params going forward.
+ */
+export async function storeSharedComponentParams(
+  component: SharedComponent,
+  params: Params,
+): Promise<string> {
+  assert(component !== SharedComponent.Any, 'Must specify a valid component');
+
+  // Add the component name and filter out any undefined values, since Firestore
+  // doesn't allow them to be written.
+  params = pickBy(
+    {
+      component: component,
+      ...params,
+    },
+    v => v !== undefined,
+  );
+  let cachedParams = storedComponentParams.find(cached =>
+    isEqual(cached.params, params),
+  );
+  if (!cachedParams) {
+    const id = firestore.runTransaction<string>(async txn => {
+      const nextIdDoc = await txn.get(nextIdDocRef);
+
+      // Get the next available ID and increment it for the next share.
+      const id = nextIdDoc.data()?.id || 0;
+      nextIdDocRef.set({ id: id + 1 });
+      const idString = id.toString();
+
+      // Write the params under the ID we got.
+      collection.doc(idString).set(params);
+
+      return idString;
+    });
+    cachedParams = { id, params };
+    storedComponentParams.push(cachedParams);
+  }
+  return cachedParams.id;
+}
+
+// A cache of component params that we have read from Firestore. Ensures that we
+// don't re-fetch the same params multiple times (causing extra delays).
+const fetchedComponentParams: {
+  [id: string]: Promise<Params | undefined>;
+} = {};
+
+/**
+ * Fetches previously stored component params for a particular component share ID.
+ *
+ * Returns the params if they match the specified component, else returns undefined.
+ */
+async function fetchSharedComponentParams(
+  component: SharedComponent,
+  sharedComponentId: string,
+): Promise<Params | undefined> {
+  let cachedParams = fetchedComponentParams[sharedComponentId];
+  if (!cachedParams) {
+    const fetch = async () => {
+      const doc = await collection.doc(sharedComponentId).get();
+      const params = doc.data();
+      return params;
+    };
+    cachedParams = fetch();
+    fetchedComponentParams[sharedComponentId] = cachedParams;
+  }
+
+  const params = await cachedParams;
+  // Only return the params if they're for the requested component.
+  if (component !== SharedComponent.Any && component !== params?.component) {
+    return undefined;
+  } else {
+    return params;
+  }
+}
+
+/**
+ * React Hook to fetch and return the previously-stored component params for a
+ * particular component share ID.
+ *
+ * Returns the params if they match the specified component, else returns undefined.
+ */
+export function useSharedComponentParams(
+  component: SharedComponent,
+): Params | undefined {
+  const { sharedComponentId } = useParams();
+
+  const [componentParams, setComponentParams] = useState<Params | undefined>(
+    undefined,
+  );
+  useEffect(() => {
+    let cancelled = false;
+    if (sharedComponentId) {
+      const fetchParams = async () => {
+        const params = await fetchSharedComponentParams(
+          component,
+          sharedComponentId,
+        );
+        if (params && !cancelled) {
+          setComponentParams(params);
+        }
+      };
+      fetchParams();
+      return () => {
+        cancelled = true;
+      };
+    }
+  }, [component, sharedComponentId]);
+  return componentParams;
+}
+
+export async function getNextSharedComponentId(): Promise<number> {
+  const doc = await nextIdDocRef.get();
+  return doc.get('id') || 0;
+}

--- a/src/common/urls.ts
+++ b/src/common/urls.ts
@@ -69,16 +69,14 @@ export function getComparePageUrl(
   // location page, so we add on a ?redirectTo= query param to redirect to the
   // right place.
 
-  let url = urlJoin(getPageBaseUrl(), 'compare', compareShareId);
+  let url = urlJoin(getPageBaseUrl(), 'share', compareShareId);
   let params: { [key: string]: unknown } = {};
   ensureSharingIdInQueryParams(params);
-  if (stateId) {
-    params['redirectTo'] = urlJoin(
-      getPagePath(stateId, county),
-      'compare',
-      compareShareId,
-    );
-  }
+  params['redirectTo'] = urlJoin(
+    getPagePath(stateId, county),
+    'compare',
+    compareShareId,
+  );
 
   // NOTE: Trailing '/' is significant so we hit the index.html page with correct meta tags and
   // so we don't get redirected and lose the query params.
@@ -86,7 +84,7 @@ export function getComparePageUrl(
 }
 
 export function getCompareShareImageUrl(compareShareId: string): string {
-  return urlJoin(getShareImageBaseUrl(), 'compare', `${compareShareId}.png`);
+  return urlJoin(getShareImageBaseUrl(), 'share', `${compareShareId}.png`);
 }
 
 /**

--- a/src/common/utils/model.ts
+++ b/src/common/utils/model.ts
@@ -6,7 +6,7 @@ import {
   RegionDescriptor,
 } from './RegionDescriptor';
 import { Api } from 'api';
-import { findCountyByFips } from 'common/locations';
+import { County, findCountyByFips } from 'common/locations';
 import moment from 'moment';
 import { RegionSummaryWithTimeseries } from 'api/schema/RegionSummaryWithTimeseries';
 import { assert } from '.';
@@ -92,7 +92,7 @@ export function fetchAllCountyProjections(snapshotUrl: string | null = null) {
   return cachedCountiesProjections[key];
 }
 
-export function useProjections(location: string, county = null) {
+export function useProjections(location: string, county?: County) {
   const [projections, setProjections] = useState<Projections>();
 
   useEffect(() => {

--- a/src/components/Compare/CompareMain.tsx
+++ b/src/components/Compare/CompareMain.tsx
@@ -5,7 +5,7 @@ import React, {
   useRef,
   useEffect,
 } from 'react';
-import { useLocation, useParams } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 import { Modal } from '@material-ui/core';
 import CompareTable from 'components/Compare/CompareTable';
 import ModalCompare from 'components/Compare/ModalCompare';
@@ -25,14 +25,14 @@ import {
   GeoScopeFilter,
 } from 'common/utils/compare';
 import { Metric } from 'common/metric';
-import { getFirebase } from 'common/firebase';
 import { countySummary } from 'common/location_summaries';
 import { findCountyByFips } from 'common/locations';
 import { ScreenshotReady } from 'components/Screenshot';
-
-const firestore = getFirebase().firestore();
-const paramsCollection = firestore.collection('compare-shared-params');
-const nextIdDocRef = paramsCollection.doc('__nextId');
+import {
+  SharedComponent,
+  storeSharedComponentParams,
+  useSharedComponentParams,
+} from 'common/sharing';
 
 // For filters (0, 50, and 99 are numerical values required by MUI Slider component):
 const scopeValueMap = {
@@ -72,8 +72,8 @@ const CompareMain = (props: {
     }
   }, [location.pathname, scrollToCompare]);
 
-  // Store these as state variables so we can replace them with data read
-  // from Firestore when generating compare share images.
+  // Store these as state variables so we can replace them with stored params
+  // when generating compare share images.
   const [stateId, setStateId] = useState(props.stateId);
   const [county, setCounty] = useState(props.county);
   const currentCounty = county && {
@@ -146,72 +146,41 @@ const CompareMain = (props: {
     countyTypeToView,
     viewAllCounties,
     geoScope,
+    stateId,
+    countyId: county?.full_fips_code,
   };
 
-  // createCompareShareId() stores the current share params to Firestore under a
-  // newly-assigned numeric ID and returns it. We cache the result so multiple
-  // calls don't generate extra IDs.
-  let createCompareShareIdPromise: Promise<string> | null = null;
   const createCompareShareId = async () => {
-    if (!createCompareShareIdPromise) {
-      createCompareShareIdPromise = firestore.runTransaction(async txn => {
-        const nextIdDoc = await txn.get(nextIdDocRef);
-        const id = nextIdDoc.data()?.id || 0;
-
-        nextIdDocRef.set({ id: id + 1 });
-
-        const params: firebase.firestore.DocumentData = { ...uiState };
-        if (stateId) {
-          params['stateId'] = stateId;
-        }
-        if (county) {
-          params['countyId'] = county.full_fips_code;
-        }
-        paramsCollection.doc(`${id}`).set(params);
-
-        return `${id}`;
-      });
-    }
-
-    return createCompareShareIdPromise;
+    return storeSharedComponentParams(SharedComponent.Compare, uiState);
   };
 
   const [screenshotReady, setScreenshotReady] = useState(false);
 
-  // Check for a /compare/{compareShareId} in the URL and use it to repopulate the
-  // compare table if it's there.
-  const { compareShareId } = useParams();
+  // Repopulate state from shared parameters if we're being rendered via a
+  // sharing URL.
+  const sharedParams = useSharedComponentParams(SharedComponent.Compare);
   useEffect(() => {
-    async function fetchParamsFromFirestore(id: string) {
-      const doc = await paramsCollection.doc(id).get();
-      const params = doc.data();
-      if (params) {
-        const { stateId, countyId } = params;
-        if (stateId) {
-          setStateId(stateId);
-        }
-        if (countyId) {
-          setCounty(findCountyByFips(countyId));
-        }
-
-        setSorter(params['sorter']);
-        setSortDescending(params['sortDescending']);
-        setSortByPopulation(params['sortByPopulation']);
-        setCountyTypeToView(params['countyTypeToView']);
-        setViewAllCounties(params['viewAllCounties']);
-        setGeoScope(params['geoScope']);
-        setSliderValue(scopeValueMap[params['geoScope'] as GeoScopeFilter]);
-
-        // Now that the UI is populated, we can capture the screenshot.
-        setScreenshotReady(true);
-      } else {
-        console.error('Invalid Sharing ID:', compareShareId);
+    if (sharedParams) {
+      const { stateId, countyId } = sharedParams;
+      if (stateId) {
+        setStateId(stateId);
       }
+      if (countyId) {
+        setCounty(findCountyByFips(countyId));
+      }
+
+      setSorter(sharedParams.sorter);
+      setSortDescending(sharedParams.sortDescending);
+      setSortByPopulation(sharedParams.sortByPopulation);
+      setCountyTypeToView(sharedParams.countyTypeToView);
+      setViewAllCounties(sharedParams.viewAllCounties);
+      setGeoScope(sharedParams.geoScope);
+      setSliderValue(scopeValueMap[sharedParams.geoScope as GeoScopeFilter]);
+
+      // Now that the UI is populated, we can capture the screenshot.
+      setScreenshotReady(true);
     }
-    if (compareShareId) {
-      fetchParamsFromFirestore(compareShareId);
-    }
-  }, [compareShareId]);
+  }, [sharedParams]);
 
   if (locations.length === 0) {
     return null;

--- a/src/components/Explore/Explore.tsx
+++ b/src/components/Explore/Explore.tsx
@@ -1,11 +1,16 @@
-import React, { useState, useMemo, useEffect } from 'react';
+import React, {
+  useState,
+  useMemo,
+  useEffect,
+  useRef,
+  useCallback,
+} from 'react';
 import { some, uniq, max } from 'lodash';
 import Grid from '@material-ui/core/Grid';
 import useMediaQuery from '@material-ui/core/useMediaQuery';
 import { useTheme } from '@material-ui/core/styles';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import { ParentSize } from '@vx/responsive';
-import { Projection } from 'common/models/Projection';
 import { useModelLastUpdatedDate } from 'common/utils/model';
 import { findLocationForFips, Location } from 'common/locations';
 import {
@@ -32,8 +37,15 @@ import {
   getChartSeries,
   getMetricName,
   getSeriesLabel,
+  EXPLORE_CHART_IDS,
 } from './utils';
 import * as Styles from './Explore.style';
+import {
+  SharedComponent,
+  storeSharedComponentParams,
+  useSharedComponentParams,
+} from 'common/sharing';
+import { useLocation, useParams } from 'react-router-dom';
 
 const MARGIN_SINGLE_LOCATION = 20;
 const MARGIN_STATE_CODE = 60;
@@ -63,16 +75,19 @@ function getLabelLength(series: Series, shortLabel: boolean) {
 }
 
 const Explore: React.FunctionComponent<{
-  projection: Projection;
-  chartId?: string;
-}> = ({ projection, chartId }) => {
-  const { locationName, fips } = projection;
+  fips: string;
+}> = ({ fips }) => {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
   const isMobileXs = useMediaQuery(theme.breakpoints.down('xs'));
 
-  const defaultMetric =
-    (chartId && getMetricByChartId(chartId)) || ExploreMetric.CASES;
+  const { sharedComponentId } = useParams();
+  let defaultMetric = ExploreMetric.CASES;
+  // Originally we had share URLs like /explore/cases instead of
+  // /explore/<sharedComponentId> and so this code allows them to keep working.
+  if (sharedComponentId && EXPLORE_CHART_IDS.includes(sharedComponentId)) {
+    defaultMetric = getMetricByChartId(sharedComponentId)!;
+  }
   const [currentMetric, setCurrentMetric] = useState(defaultMetric);
 
   const [normalizeData, setNormalizeData] = useState(false);
@@ -106,6 +121,28 @@ const Explore: React.FunctionComponent<{
     setSelectedLocations(changedLocations);
   };
 
+  const exploreRef = useRef<HTMLDivElement>(null);
+  const scrollToExplore = useCallback(() => {
+    const scrollOffset = 180;
+    return setTimeout(() => {
+      if (exploreRef.current) {
+        window.scrollTo({
+          left: 0,
+          top: exploreRef.current.offsetTop - scrollOffset,
+          behavior: 'smooth',
+        });
+      }
+    }, 200);
+  }, [exploreRef]);
+
+  const location = useLocation();
+  useEffect(() => {
+    if (location.pathname.includes('/explore')) {
+      const timeoutId = scrollToExplore();
+      return () => clearTimeout(timeoutId);
+    }
+  }, [location.pathname, scrollToExplore]);
+
   // Resets the state when navigating locations
   useEffect(() => {
     setSelectedLocations([currentLocation]);
@@ -137,8 +174,30 @@ const Explore: React.FunctionComponent<{
     [hasMultipleLocations, isMobileXs, chartSeries],
   );
 
+  const createSharedComponentId = async () => {
+    return storeSharedComponentParams(SharedComponent.Explore, {
+      currentMetric,
+      normalizeData,
+      selectedFips: selectedLocations.map(
+        location => location.full_fips_code || location.state_fips_code,
+      ),
+    });
+  };
+
+  const sharedParams = useSharedComponentParams(SharedComponent.Explore);
+  useEffect(() => {
+    if (sharedParams) {
+      setCurrentMetric(sharedParams.currentMetric);
+      setNormalizeData(sharedParams.normalizeData);
+      const locations = sharedParams.selectedFips.map((fips: string) =>
+        findLocationForFips(fips),
+      );
+      setSelectedLocations(locations);
+    }
+  }, [sharedParams]);
+
   return (
-    <Styles.Container>
+    <Styles.Container ref={exploreRef}>
       <Grid container spacing={1}>
         <Grid item sm={6} xs={12}>
           <Styles.Heading variant="h4">Trends</Styles.Heading>
@@ -150,12 +209,17 @@ const Explore: React.FunctionComponent<{
         <Grid item sm={6} xs={12}>
           <Styles.ShareBlock>
             <ShareImageButtonGroup
-              imageUrl={getExportImageUrl(fips, currentMetric)}
+              imageUrl={() =>
+                createSharedComponentId().then(id =>
+                  getExportImageUrl(fips, id),
+                )
+              }
               imageFilename={getImageFilename(fips, currentMetric)}
-              url={getChartUrl(fips, currentMetric)}
+              url={() =>
+                createSharedComponentId().then(id => getChartUrl(fips, id))
+              }
               quote={getSocialQuote(fips, currentMetric)}
               hashtags={['COVIDActNow']}
-              disabled={hasMultipleLocations}
             />
           </Styles.ShareBlock>
         </Grid>
@@ -222,7 +286,7 @@ const Explore: React.FunctionComponent<{
                   isMobile={isMobile}
                   width={width}
                   height={400}
-                  tooltipSubtext={`in ${locationName}`}
+                  tooltipSubtext={`in ${getLocationNames(selectedLocations)}`}
                   hasMultipleLocations={hasMultipleLocations}
                   isMobileXs={isMobileXs}
                   marginRight={marginRight}
@@ -237,7 +301,7 @@ const Explore: React.FunctionComponent<{
         <EmptyChart
           height={400}
           metricName={currentMetricName}
-          locationName={locationName}
+          locationName={getLocationNames(selectedLocations)}
         />
       )}
       <DisclaimerWrapper>

--- a/src/components/Explore/MultipleLocationsChart.tsx
+++ b/src/components/Explore/MultipleLocationsChart.tsx
@@ -230,7 +230,7 @@ const MultipleLocationsChart: React.FC<{
           />
         </Group>
       </svg>
-      {width > 0 && <ScreenshotReady />}
+      {width > 0 && seriesList.length > 0 && <ScreenshotReady />}
       {tooltipOpen && tooltipData && (
         <Fragment>
           <MultipleLocationsTooltip

--- a/src/components/Explore/SingleLocationChart.tsx
+++ b/src/components/Explore/SingleLocationChart.tsx
@@ -227,7 +227,7 @@ const SingleLocationChart: React.FC<{
           />
         </Fragment>
       )}
-      {width > 0 && <ScreenshotReady />}
+      {width > 0 && seriesList.length > 0 && <ScreenshotReady />}
     </Styles.PositionRelative>
   );
 };

--- a/src/components/Explore/utils.ts
+++ b/src/components/Explore/utils.ts
@@ -18,9 +18,8 @@ import {
   findLocationForFips,
   getLocationNames as getAllLocations,
   getLocationNameForFips,
-  getLocationUrlForFips,
+  getRelativeUrlForFips,
   isStateFips,
-  findStateByFips,
   Location,
 } from 'common/locations';
 import { share_image_url } from 'assets/data/share_images_url.json';
@@ -290,33 +289,25 @@ export function getImageFilename(fips: string, metric: ExploreMetric) {
   return `${sanitizeLocationName(locationName)}-${chartId}-${downloadDate}.png`;
 }
 
-function getRelativeUrl(fips: string) {
-  if (isStateFips(fips)) {
-    const { state_code } = findStateByFips(fips);
-    return `states/${state_code.toLowerCase()}`;
-  } else {
-    return `counties/${fips}`;
-  }
-}
-
 /**
  * Generates the URL of the export images for the given fips code and chart.
  * It needs to be consistent with the path on the share image generation
  * script in `scripts/generate_share_images/index.ts`
  */
-export function getExportImageUrl(fips: string, metric: ExploreMetric) {
-  const chartId = getChartIdByMetric(metric);
-  const relativeUrl = getRelativeUrl(fips);
-  return urlJoin(share_image_url, relativeUrl, `explore/${chartId}/export.png`);
+export function getExportImageUrl(fips: string, sharedComponentId: string) {
+  return urlJoin(share_image_url, `share/${sharedComponentId}/export.png`);
 }
 
-export function getChartUrl(fips: string, metric: ExploreMetric) {
-  const chartId = getChartIdByMetric(metric);
-  const locationUrl = getLocationUrlForFips(fips);
-  const isState = isStateFips(fips);
-  return isState
-    ? `${locationUrl}explore/${chartId}`
-    : `${locationUrl}/explore/${chartId}`;
+export function getChartUrl(fips: string, sharedComponentId: string) {
+  const redirectTo = urlJoin(
+    getRelativeUrlForFips(fips),
+    'explore',
+    sharedComponentId,
+  );
+  const url = urlJoin(window.location.origin, 'share', sharedComponentId);
+  // NOTE: Trailing '/' is significant so we hit the index.html page with correct meta tags and
+  // so we don't get redirected and lose the query params.
+  return `${url}/?redirectTo=${encodeURIComponent(redirectTo)}`;
 }
 
 export function getSocialQuote(fips: string, metric: ExploreMetric) {

--- a/src/components/LocationPage/ChartsHolder.tsx
+++ b/src/components/LocationPage/ChartsHolder.tsx
@@ -9,7 +9,7 @@ import useMediaQuery from '@material-ui/core/useMediaQuery';
 import { useTheme } from '@material-ui/core/styles';
 import { Metric, ALL_METRICS } from 'common/metric';
 import CompareMain from 'components/Compare/CompareMain';
-import Explore, { EXPLORE_CHART_IDS } from 'components/Explore';
+import Explore from 'components/Explore';
 import { County } from 'common/locations';
 
 // TODO: 180 is rough accounting for the navbar and searchbar;
@@ -48,9 +48,7 @@ const ChartsHolder = (props: {
   useEffect(() => {
     const scrollToChart = () => {
       const timeoutId = setTimeout(() => {
-        if (chartId && EXPLORE_CHART_IDS.includes(chartId)) {
-          scrollTo(exploreChartRef.current);
-        } else if (chartId in metricRefs) {
+        if (chartId in metricRefs) {
           const metricRef = metricRefs[(chartId as unknown) as Metric];
           if (metricRef.current) {
             scrollTo(metricRef.current);
@@ -113,10 +111,7 @@ const ChartsHolder = (props: {
               ))}
             </MainContentInner>
             <MainContentInner ref={exploreChartRef}>
-              <Explore
-                projection={props.projections.primary}
-                chartId={chartId}
-              />
+              <Explore fips={props.projections.primary.fips} />
             </MainContentInner>
           </ChartContentWrapper>
           <div ref={shareBlockRef}>

--- a/src/screens/internal/ShareImage/ChartExportImage.style.ts
+++ b/src/screens/internal/ShareImage/ChartExportImage.style.ts
@@ -44,6 +44,16 @@ export const MetricName = styled.div`
   letter-spacing: -0.01em;
 `;
 
+export const ExploreTitle = styled.div`
+  margin-top: 10px;
+  text-transform: capitalize;
+  font-family: 'Roboto';
+  font-weight: bold;
+  font-size: 24px;
+  line-height: 24px;
+  width: 900px;
+`;
+
 export const LastUpdated = styled.div`
   margin-top: 10px;
   font-family: 'Source Code Pro';
@@ -62,6 +72,11 @@ export const ChartWrapper = styled.div`
   span {
     font-family: 'Roboto' !important;
   }
+`;
+
+export const ExploreChartWrapper = styled(ChartWrapper)`
+  margin-left: 60px;
+  width: 1060px;
 `;
 
 export const LogoHolder = styled.div`

--- a/src/screens/internal/ShareImage/ChartShareImage.style.ts
+++ b/src/screens/internal/ShareImage/ChartShareImage.style.ts
@@ -20,6 +20,15 @@ export const Title = styled.div`
   font-size: 24px;
   line-height: 18px;
   text-transform: capitalize;
+  width: 400px;
+`;
+
+export const ExploreTitle = styled(Title)`
+  font-size: 18px;
+  line-height: 19px;
+  text-transform: capitalize;
+  height: 75px;
+  overflow: hidden;
 `;
 
 export const Subtitle = styled.div`
@@ -34,8 +43,9 @@ export const Subtitle = styled.div`
 `;
 
 export const ChartWrapper = styled.div`
-  margin-left: 60px;
-  margin-top: 25px;
+  position: absolute;
+  left: 60px;
+  top: 88px;
   width: 495px;
   height: 225px;
 
@@ -43,6 +53,11 @@ export const ChartWrapper = styled.div`
   span {
     font-family: 'Roboto' !important;
   }
+`;
+
+export const ExploreChartWrapper = styled(ChartWrapper)`
+  left: 20px;
+  width: 535px;
 `;
 
 export const LogoHolder = styled.div`

--- a/src/screens/internal/ShareImage/ShareImage.tsx
+++ b/src/screens/internal/ShareImage/ShareImage.tsx
@@ -6,6 +6,25 @@ import ChartExportImage from './ChartExportImage';
 import ExploreChartImage from './ExploreChartImage';
 import ExploreChartExportImage from './ExploreChartExportImage';
 import CompareTableImage from './CompareTableImage';
+import { SharedComponent, useSharedComponentParams } from 'common/sharing';
+
+function SharedComponentImage({ exportImage }: { exportImage: boolean }) {
+  const componentParams = useSharedComponentParams(SharedComponent.Any);
+  if (componentParams) {
+    switch (componentParams.component as SharedComponent) {
+      case SharedComponent.Compare:
+        return <CompareTableImage />;
+      case SharedComponent.Explore:
+        return exportImage ? (
+          <ExploreChartExportImage componentParams={componentParams} />
+        ) : (
+          <ExploreChartImage componentParams={componentParams} />
+        );
+    }
+  }
+
+  return <>Could not find / read component sharing params</>;
+}
 
 export default function ShareImage({ match }: RouteComponentProps<{}>) {
   return (
@@ -69,12 +88,15 @@ export default function ShareImage({ match }: RouteComponentProps<{}>) {
         component={ExploreChartExportImage}
       />
 
-      {/* COMPARE TABLES */}
+      {/* SHARED COMPONENTS (Compare, Explore, etc.) */}
       <Route
         exact
-        path={`${match.path}compare/:compareShareId`}
-        component={CompareTableImage}
+        path={`${match.path}share/:sharedComponentId`}
+        component={SharedComponentImage}
       />
+      <Route exact path={`${match.path}share/:sharedComponentId/export`}>
+        <SharedComponentImage exportImage={true} />
+      </Route>
 
       {/* DEFAULT */}
       <Route path="/*">Bad Share Image URL.</Route>


### PR DESCRIPTION
Rework compare sharing to be more generic (reusable for explore).
* Create common helpers for storing / fetching component params to/from Firestore.
* Change shared URLs to /share/xxx since we can redirect to the right URL
  anyway, and this lets us just generate /share/xxx/index.html pages.

Implement (multi-location) Explore Sharing (moves existing sharing to new 'shared component' infrastructure).