### PR TITLE
Specify image sizes so maybe Facebook will render a preview?

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -38,6 +38,8 @@
   <!-- NOTE: These are replaced at build time by scripts/generate_index_pages.ts -->
   <meta property="og:url" content="https://covidactnow.org" />
   <meta property="og:image:url" content="https://covidactnow.org/covidactnow.png?fbrefresh=v3" />
+  <meta property="og:image:width" content="1200" />
+  <meta property="og:image:height" content="630" />
   <meta property="og:title" content="America’s COVID warning system." />
   <meta property="og:description"
     content="Covid Act Now has real-time COVID data and risk level for your community. See how your community is doing at covidactnow.org." />


### PR DESCRIPTION
Add og:image:{width,height} tags to hopefully help Facebook render previews.

I noticed the [docs](https://developers.facebook.com/docs/sharing/webmasters/images/) say:

> Use og:image:width and og:image:height Open Graph tags: Using these tags will specify the image dimensions to the crawler so that it can render the image immediately without having to asynchronously download and process it.

