### PR TITLE
Only send first 500 emails.

### DIFF
--- a/scripts/alert_emails/send_emails.ts
+++ b/scripts/alert_emails/send_emails.ts
@@ -112,7 +112,8 @@ async function setLastSnapshotNumber(
     ),
   );
 
-  const emailBatches = _.chunk(emailFipsTuples, BATCH_SIZE);
+  // HACK: Only do first 50 batches for now, while we are validating the migration to AWS.
+  const emailBatches = _.chunk(emailFipsTuples, BATCH_SIZE).slice(0, 50);
   for (const batch of emailBatches) {
     await Promise.all(
       batch.map(([email, fips]) => sendAlertEmail(email, fips)),

--- a/scripts/alert_emails/send_emails.ts
+++ b/scripts/alert_emails/send_emails.ts
@@ -112,8 +112,8 @@ async function setLastSnapshotNumber(
     ),
   );
 
-  // HACK: Only do first 50 batches for now, while we are validating the migration to AWS.
-  const emailBatches = _.chunk(emailFipsTuples, BATCH_SIZE).slice(0, 50);
+  // HACK: Only do first 25 batches for now (to send 500 emails), while we are validating the migration to AWS.
+  const emailBatches = _.chunk(emailFipsTuples, BATCH_SIZE).slice(0, 25);
   for (const batch of emailBatches) {
     await Promise.all(
       batch.map(([email, fips]) => sendAlertEmail(email, fips)),


### PR DESCRIPTION
Temporarily hack email sending script to only send 50 batches (500 emails) to make sure AWS is behaving well.