### PR TITLE
analytics: set title case for events

### DIFF
--- a/src/components/Analytics/PageviewTracker.tsx
+++ b/src/components/Analytics/PageviewTracker.tsx
@@ -8,7 +8,7 @@ import { defaultTracker, legacyTracker } from './utils';
  * Initialize Google Analytics
  */
 function initializeGA() {
-  const options = { titleCase: false, debug: false };
+  const options = { debug: false };
   ReactGA.initialize(defaultTracker.trackingId, options);
   ReactGA.addTrackers([
     {


### PR DESCRIPTION
Discussed with Gaia - we are going to use Title Case for events from now on, it will help us to tell apart "old" events from the current implementation.