### PR TITLE
Don't round cases/day to zero in explanatory text.

### DIFF
--- a/src/common/metrics/case_density.tsx
+++ b/src/common/metrics/case_density.tsx
@@ -80,6 +80,11 @@ function renderStatus(projections: Projections): React.ReactElement {
 
   const ESTIMATED_INFECTIONS_FACTOR = 5;
   const newCasesPerDay = currentDailyAverageCases;
+  // Try not to round cases/day to zero (since it will probably be >0 per 100k).
+  const newCasesPerDayText =
+    newCasesPerDay >= 0.1 && newCasesPerDay < 1
+      ? formatDecimal(newCasesPerDay, 1)
+      : formatInteger(newCasesPerDay);
   const newCasesPerYear = 365 * newCasesPerDay;
   const estimatedNewInfectionsPerYear =
     ESTIMATED_INFECTIONS_FACTOR * newCasesPerYear;
@@ -90,10 +95,9 @@ function renderStatus(projections: Projections): React.ReactElement {
 
   return (
     <Fragment>
-      Over the last week, {locationName} has averaged{' '}
-      {formatInteger(newCasesPerDay)} new confirmed cases per day (
-      <b>{formatDecimal(currentCaseDensity, 1)}</b> for every 100,000
-      residents). Over the next year, this translates to around{' '}
+      Over the last week, {locationName} has averaged {newCasesPerDayText} new
+      confirmed cases per day (<b>{formatDecimal(currentCaseDensity, 1)}</b> for
+      every 100,000 residents). Over the next year, this translates to around{' '}
       {formatEstimate(newCasesPerYear)} cases and an{' '}
       <ExternalLink href="https://www.globalhealthnow.org/2020-06/us-cases-10x-higher-reported">
         estimated


### PR DESCRIPTION
https://trello.com/c/d08xcPc3/389-dont-round-cases-day-in-explanatory-text-to-0

Avoid rounding down to zero, leading to confusing explanatory text, e.g.:
![image](https://user-images.githubusercontent.com/206364/95119735-493c9180-0701-11eb-9e4c-b1262c9c261a.png)
