### PR TITLE
explore: fix homepage sharing url and image name

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -50,7 +50,11 @@ export default function App() {
                 path="/compare/:sharedComponentId?"
                 component={HomePage}
               />
-
+              <Route
+                exact
+                path="/explore/:sharedComponentId?"
+                component={HomePage}
+              />
               <Route
                 exact
                 path="/alert_unsubscribe"

--- a/src/common/locations.ts
+++ b/src/common/locations.ts
@@ -254,3 +254,20 @@ export function locationNameFromUrlParams(stateId?: string, countyId?: string) {
     ? `${countyOption.county}, ${state?.state}`
     : `${state?.state}`;
 }
+
+export function findFipsByUrlParams(
+  stateUrlName?: string,
+  countyUrlName?: string,
+) {
+  if (!stateUrlName) {
+    return undefined;
+  } else {
+    const state = getStateByUrlName(stateUrlName);
+    const countyOption =
+      countyUrlName && getCountyByUrlName(state?.state_code, countyUrlName);
+
+    return countyOption && state
+      ? countyOption.full_fips_code
+      : state && state.state_fips_code;
+  }
+}

--- a/src/components/Explore/Explore.tsx
+++ b/src/components/Explore/Explore.tsx
@@ -256,18 +256,9 @@ const Explore: React.FunctionComponent<{
           <Styles.ShareBlock>
             <ShareImageButtonGroup
               disabled={selectedLocations.length === 0 || !hasData}
-              imageUrl={() =>
-                createSharedComponentId().then(id => getExportImageUrl(id))
-              }
-              imageFilename={getImageFilename(
-                initialFipsList[0],
-                currentMetric,
-              )}
-              url={() =>
-                createSharedComponentId().then(id =>
-                  getChartUrl(initialFipsList[0], id),
-                )
-              }
+              imageUrl={() => createSharedComponentId().then(getExportImageUrl)}
+              imageFilename={getImageFilename(selectedLocations, currentMetric)}
+              url={() => createSharedComponentId().then(getChartUrl)}
               quote={getSocialQuote(selectedLocations, currentMetric)}
               hashtags={['COVIDActNow']}
               onSaveImage={() => {

--- a/src/components/Explore/utils.ts
+++ b/src/components/Explore/utils.ts
@@ -24,6 +24,7 @@ import {
   isState,
   isCounty,
   belongsToState,
+  getRelativeUrlForFips,
 } from 'common/locations';
 import { share_image_url } from 'assets/data/share_images_url.json';
 import { SeriesType, Series } from './interfaces';
@@ -317,10 +318,9 @@ export function getExportImageUrl(sharedComponentId: string) {
   return urlJoin(share_image_url, `share/${sharedComponentId}/export.png`);
 }
 
-export function getChartUrl(sharedComponentId: string) {
-  const pathname = window.location.pathname;
+export function getChartUrl(sharedComponentId: string, locationFips?: string) {
   const redirectTo = urlJoin(
-    pathname.includes('us/') ? pathname : '/',
+    locationFips ? getRelativeUrlForFips(locationFips) : '/',
     'explore',
     sharedComponentId,
   );


### PR DESCRIPTION
Fixes some issues when sharing the Explore chart from the homepage.

- When the user copies the link, the copied link will redirect the user to either the location or the home page, depending on the original location of the user. The link correctly updates the Explore chart and scrolls to the corresponding location on the page.
- When the user saves an image, the image filename will include the names of the locations currently selected, not the initial location (up to 2 locations, beyond that it will be named `multiple-locations-{METRIC}-{YYYY-MM-DD}.png`)