### PR TITLE
Add HHS data announcement and reenable ND test positivity.

### DIFF
--- a/src/common/models/Projection.ts
+++ b/src/common/models/Projection.ts
@@ -53,7 +53,6 @@ const DISABLED_TEST_POSITIVITY = new DisabledFips([
   '48113',
   '48215',
   '48201', // https://trello.com/c/tgxn6Wjp/
-  '38', // TODO(https://trello.com/c/6ZPv7k9T/) Reenable North Dakota once we improve calculation.
 
   /^29...$/, // TODO(https://trello.com/c/9BiL64Y6/493): Missouri data is always 100%. :|
 ]);

--- a/src/components/LocationPage/LocationPageHeader.tsx
+++ b/src/components/LocationPage/LocationPageHeader.tsx
@@ -187,13 +187,24 @@ const LocationPageHeader = (props: {
             </SectionHalf>
             <SectionHalf>
               <InfoOutlinedIcon />
-              <SectionColumn isUpdateCopy>
-                <ColumnTitle isUpdateCopy>New feature</ColumnTitle>
-                <NewFeatureCopy
-                  locationName={locationName}
-                  onNewUpdateClick={props.onNewUpdateClick}
-                />
-              </SectionColumn>
+              {props.projections.isCounty ? (
+                <SectionColumn isUpdateCopy>
+                  <ColumnTitle isUpdateCopy>New feature</ColumnTitle>
+                  <NewFeatureCopy
+                    locationName={locationName}
+                    onNewUpdateClick={props.onNewUpdateClick}
+                  />
+                </SectionColumn>
+              ) : (
+                <SectionColumn isUpdateCopy>
+                  <ColumnTitle isUpdateCopy>Update</ColumnTitle>
+                  <Copy isUpdateCopy={true}>
+                    As of October 14th, we have switched to using data from the
+                    U.S. Department of Health & Human Services to calculate
+                    Positive Test Rate for most states.
+                  </Copy>
+                </SectionColumn>
+              )}
             </SectionHalf>
           </HeaderSection>
           <LocationHeaderStats


### PR DESCRIPTION
@ghop02 Can you merge this after merging the new snapshot, before merging to master?