### PR TITLE
recommend: use a custom link for markdown content

### DIFF
--- a/src/components/Markdown/Markdown.style.ts
+++ b/src/components/Markdown/Markdown.style.ts
@@ -7,3 +7,8 @@ export const MarkdownBody = styled(ReactMarkdown)`
     color: ${COLOR_MAP.BLUE};
   }
 `;
+
+export const MarkdownLink = styled.a.attrs(props => ({
+  rel: 'noopener noreferrer',
+  target: '_blank',
+}))``;

--- a/src/components/Markdown/MarkdownContent.tsx
+++ b/src/components/Markdown/MarkdownContent.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import ReactMarkdown, { ReactMarkdownProps } from 'react-markdown';
+import { MarkdownLink } from './Markdown.style';
+
+/**
+ * Custom renderers for each Markdown node type. Useful to override the
+ * attributes or styling of the rendered element.
+ *
+ * https://github.com/remarkjs/react-markdown#node-types
+ */
+const customRenderers = {
+  link: MarkdownLink,
+};
+
+const MarkdownContent: React.FC<ReactMarkdownProps> = props => {
+  return <ReactMarkdown renderers={customRenderers} {...props} />;
+};
+
+export default MarkdownContent;

--- a/src/components/Markdown/index.ts
+++ b/src/components/Markdown/index.ts
@@ -1,3 +1,4 @@
 import { MarkdownBody } from './Markdown.style';
+import MarkdownContent from './MarkdownContent';
 
-export { MarkdownBody };
+export { MarkdownBody, MarkdownContent };

--- a/src/components/Recommend/RecommendModal.style.ts
+++ b/src/components/Recommend/RecommendModal.style.ts
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 import MuiTab from '@material-ui/core/Tab';
 import MuiTabs from '@material-ui/core/Tabs';
-import { MarkdownBody } from 'components/Markdown';
+import { MarkdownContent } from 'components/Markdown';
 import theme from 'assets/theme';
 import { COLOR_MAP } from 'common/colors';
 import { COLORS } from 'common';
@@ -39,7 +39,7 @@ export const SourceTitle = styled.h2`
   text-align: left;
 `;
 
-export const SourceIntro = styled(MarkdownBody)`
+export const SourceIntro = styled(MarkdownContent)`
   font-family: Roboto;
   font-size: 15px;
   font-style: normal;
@@ -92,7 +92,7 @@ export const Tabs = styled(MuiTabs)`
   }
 `;
 
-export const LevelDescription = styled(MarkdownBody)`
+export const LevelDescription = styled(MarkdownContent)`
   padding: ${theme.spacing(3)}px;
   height: 450px;
   overflow-y: auto;


### PR DESCRIPTION
This attaches `rel="noopener noreferrer"` to links in markdown content