### PR TITLE
restore the donation banner

### DIFF
--- a/src/components/Analytics/PageviewTracker.tsx
+++ b/src/components/Analytics/PageviewTracker.tsx
@@ -17,6 +17,7 @@ function initializeGA() {
       ...options,
     },
   ]);
+  ReactGA.plugin.require('linkid');
 }
 
 /**

--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -7,7 +7,7 @@ const Banner: React.FC<{
   renderButton?: () => React.ReactElement;
 }> = ({ message, renderButton }) => {
   return (
-    <Styles.FeatureBannerContainer container spacing={1}>
+    <Styles.MainContainer container spacing={1}>
       <Grid item sm md lg>
         {message}
       </Grid>
@@ -16,7 +16,7 @@ const Banner: React.FC<{
           {renderButton()}
         </Styles.ButtonContainer>
       )}
-    </Styles.FeatureBannerContainer>
+    </Styles.MainContainer>
   );
 };
 

--- a/src/components/Banner/DonationBanner.tsx
+++ b/src/components/Banner/DonationBanner.tsx
@@ -2,9 +2,18 @@ import React from 'react';
 import Banner from './Banner';
 import { SurveyButton } from './Banner.style';
 import { Link } from 'react-router-dom';
+import { EventAction, EventCategory, trackEvent } from 'components/Analytics';
+
+const trackClick = () => {
+  trackEvent(
+    EventCategory.DONATE,
+    EventAction.CLICK_LINK,
+    'Banner Doante Button',
+  );
+};
 
 const renderDonationButton = () => (
-  <Link to="/donate" id="donate-homepage-banner">
+  <Link to="/donate" id="donate-homepage-banner" onClick={trackClick}>
     <SurveyButton
       variant="contained"
       color="primary"

--- a/src/components/Banner/DonationBanner.tsx
+++ b/src/components/Banner/DonationBanner.tsx
@@ -4,7 +4,7 @@ import { SurveyButton } from './Banner.style';
 import { Link } from 'react-router-dom';
 
 const renderDonationButton = () => (
-  <Link to="/donate">
+  <Link to="/donate" id="donate-homepage-banner">
     <SurveyButton
       variant="contained"
       color="primary"

--- a/src/screens/HomePage/HomePage.js
+++ b/src/screens/HomePage/HomePage.js
@@ -22,7 +22,7 @@ import {
 } from './HomePage.style';
 import { SelectorWrapper } from 'components/Header/HomePageHeader.style';
 import CompareMain from 'components/Compare/CompareMain';
-import { FeatureBanner } from 'components/Banner';
+import { DonationBanner } from 'components/Banner';
 import Explore from 'components/Explore';
 import { getRandomStateFipsList } from './utils';
 
@@ -67,19 +67,6 @@ export default function HomePage() {
 
   const exploreSectionRef = useRef(null);
 
-  // TODO (Chelsi): stop repeating this so much. Put somewhere central.
-  const scrollToExploreSection = () => {
-    return setTimeout(() => {
-      if (exploreSectionRef.current) {
-        window.scrollTo({
-          left: 0,
-          top: exploreSectionRef.current.offsetTop - 75,
-          behavior: 'smooth',
-        });
-      }
-    }, 250);
-  };
-
   return (
     <>
       <EnsureSharingIdInUrl />
@@ -89,7 +76,7 @@ export default function HomePage() {
         pageDescription="Real-time modeling and metrics to understand where we stand against COVID. 50 states. 3,000+ counties. Click the map to dive in"
       />
       <BannerContainer>
-        <FeatureBanner scrollTo={scrollToExploreSection} />
+        <DonationBanner />
       </BannerContainer>
       <HomePageHeader
         indicatorsLinkOnClick={() => scrollTo(indicatorsRef.current)}


### PR DESCRIPTION
I added a plugin to track attribution. Ideally, it should be able to tell us which link started the navigation to an internal page when we have more than one link towards a page (for donation, for example). I'm still investigating how to access this in GA.