### PR TITLE
Disable sentry

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,13 +4,6 @@ import './index.css';
 import App from './App';
 import * as serviceWorker from './serviceWorker';
 
-import * as Sentry from '@sentry/react';
-
-Sentry.init({
-  dsn:
-    'https://4e1fa0b7df4d490488847bcc7966712b@o378922.ingest.sentry.io/5444052',
-});
-
 ReactDOM.render(<App />, document.getElementById('root'));
 
 // If you want your app to work offline and load faster, you can change


### PR DESCRIPTION
Disabling sentry until we fix some of the more common sentry errors.  (we're hitting our quota and unable to receive new events)