### PR TITLE
explore: update the interpolation method for line series

### DIFF
--- a/src/components/Explore/SeriesChart.tsx
+++ b/src/components/Explore/SeriesChart.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent } from 'react';
-import { curveCardinal } from '@vx/curve';
+import { curveMonotoneX } from '@vx/curve';
 import { LinePath } from '@vx/shape';
 import * as Styles from './Explore.style';
 import { SeriesType, SeriesParams } from './interfaces';
@@ -21,7 +21,7 @@ const ChartSeries: FunctionComponent<{
     case SeriesType.LINE:
       return (
         <Styles.MainSeriesLine {...params}>
-          <LinePath data={data} x={x} y={y} curve={curveCardinal} />
+          <LinePath data={data} x={x} y={y} curve={curveMonotoneX} />
         </Styles.MainSeriesLine>
       );
     case SeriesType.BAR:


### PR DESCRIPTION
[Trello card](https://trello.com/c/ReNU4QcC/521-removing-overshoot-artifact-from-explore-moving-averages) - This PR replaces the interpolation method used for the Explore charts to avoid artifacts. The new interpolation is [d3-shape#curveMonotoneX](https://github.com/d3/d3-shape#curveMonotoneX)

> “a smooth curve with continuous first-order derivatives that passes through any given set of data points without spurious oscillations. Local extrema can occur only at grid points where they are given by the data, but not in between two adjacent grid points.”

_Before_
![image](https://user-images.githubusercontent.com/114084/96655371-265dd000-12f2-11eb-8af3-7d069e95feb9.png)

_After_
![image](https://user-images.githubusercontent.com/114084/96655352-1d6cfe80-12f2-11eb-9b02-cd8e9c8dd324.png)

