### PR TITLE
remove invalid prop for IconButton

### DIFF
--- a/src/components/AppBar/NavBar.style.ts
+++ b/src/components/AppBar/NavBar.style.ts
@@ -122,7 +122,6 @@ export const DesktopOnly = styled.div`
 
 export const IconButton = styled(MuiIconButton).attrs(props => ({
   disableRipple: true,
-  disableElevation: true,
   disableFocusRipple: true,
 }))`
   &:focus {


### PR DESCRIPTION
I attached an invalid prop for the IconButton component (this only throws a warning in development). https://material-ui.com/api/icon-button/