### PR TITLE
homepage: adjusts the margins of the explore chart

### DIFF
--- a/src/components/Explore/Explore.style.ts
+++ b/src/components/Explore/Explore.style.ts
@@ -131,9 +131,11 @@ export const LegendItemLabel = styled.span`
 export const ChartContainer = styled.div<{ adjustContainerWidth?: boolean }>`
   margin-top: ${theme.spacing(4)}px;
   margin-bottom: ${theme.spacing(3)}px;
-  margin-left: ${({ adjustContainerWidth }) => adjustContainerWidth && '-1rem'};
-  margin-right: ${({ adjustContainerWidth }) =>
-    adjustContainerWidth && '-3rem'};
+
+  // We add negative margins on mobile to make more space for the chart to
+  // counteract the margins of the main container element in the page
+  margin-left: ${-1 * theme.spacing(2)}px;
+  margin-right: ${-1 * theme.spacing(2)}px;
 
   @media (min-width: 600px) {
     margin-left: 0;

--- a/src/components/Explore/Explore.style.ts
+++ b/src/components/Explore/Explore.style.ts
@@ -128,7 +128,7 @@ export const LegendItemLabel = styled.span`
 
 // CHARTS
 
-export const ChartContainer = styled.div<{ adjustContainerWidth?: boolean }>`
+export const ChartContainer = styled.div`
   margin-top: ${theme.spacing(4)}px;
   margin-bottom: ${theme.spacing(3)}px;
 

--- a/src/components/Explore/Explore.tsx
+++ b/src/components/Explore/Explore.tsx
@@ -377,7 +377,7 @@ const Explore: React.FunctionComponent<{
         {getSubtitle(currentMetricName, normalizeData, selectedLocations)}
       </Styles.Subtitle>
       {selectedLocations.length > 0 && hasData && (
-        <Styles.ChartContainer adjustContainerWidth={hasMultipleLocations}>
+        <Styles.ChartContainer>
           {/**
            * The width is set to zero while the parent div is rendering, the
            * placeholder div below prevents the page from jumping.

--- a/src/components/Explore/Explore.tsx
+++ b/src/components/Explore/Explore.tsx
@@ -83,7 +83,7 @@ function getMarginRight(
   // states are selected, we only need space for the state code, if at least
   // one county is selected, we need more space.
   return showLabels
-    ? maxLabelLength > 2
+    ? maxLabelLength > 4
       ? MARGIN_COUNTY
       : MARGIN_STATE_CODE
     : MARGIN_SINGLE_LOCATION;


### PR DESCRIPTION
The chart container for the Explore chart was adding negative margins to counteract the margins of the main container on each page. The negative margins were bigger than the main container margins, making the chart container to be wider than the viewport.

This PR uses the same margin as the main container, ensuring that the Home Page won't show the horizontal scrolling control. I also changed the number of characters to use the "narrow" margin to 4, to accommodate for the Native American abbreviation "NAMC" to be shown with narrow margins (more space for the chart)