### PR TITLE
analytics: tracking social sharing for explore and compare

### DIFF
--- a/src/components/Compare/CompareTable.tsx
+++ b/src/components/Compare/CompareTable.tsx
@@ -231,6 +231,9 @@ const CompareTable = (props: {
                     `Facebook: ${trackLabel}`,
                   )
                 }
+                onShareOnTwitter={() =>
+                  trackCompareEvent(EventAction.SHARE, `Twitter: ${trackLabel}`)
+                }
               />
             </Header>
             {props.stateName && (

--- a/src/components/Compare/CompareTable.tsx
+++ b/src/components/Compare/CompareTable.tsx
@@ -28,6 +28,10 @@ import { getComparePageUrl, getCompareShareImageUrl } from 'common/urls';
 import { EventAction } from 'components/Analytics';
 import { MoreInfoButton } from 'components/SharedComponents';
 
+function trackShare(label: string) {
+  trackCompareEvent(EventAction.SHARE, label);
+}
+
 const CompareTable = (props: {
   stateName?: string;
   county?: any | null;
@@ -225,15 +229,9 @@ const CompareTable = (props: {
                 onSaveImage={() =>
                   trackCompareEvent(EventAction.SAVE_IMAGE, trackLabel)
                 }
-                onShareOnFacebook={() =>
-                  trackCompareEvent(
-                    EventAction.SHARE,
-                    `Facebook: ${trackLabel}`,
-                  )
-                }
-                onShareOnTwitter={() =>
-                  trackCompareEvent(EventAction.SHARE, `Twitter: ${trackLabel}`)
-                }
+                onShareOnFacebook={() => trackShare(`Facebook: ${trackLabel}`)}
+                onShareOnTwitter={() => trackShare(`Twitter: ${trackLabel}`)}
+                onShareOnLinkedin={() => trackShare(`Linkedin: ${trackLabel}`)}
               />
             </Header>
             {props.stateName && (

--- a/src/components/Compare/CompareTable.tsx
+++ b/src/components/Compare/CompareTable.tsx
@@ -225,6 +225,12 @@ const CompareTable = (props: {
                 onSaveImage={() =>
                   trackCompareEvent(EventAction.SAVE_IMAGE, trackLabel)
                 }
+                onShareOnFacebook={() =>
+                  trackCompareEvent(
+                    EventAction.SHARE,
+                    `Facebook: ${trackLabel}`,
+                  )
+                }
               />
             </Header>
             {props.stateName && (

--- a/src/components/Explore/Explore.tsx
+++ b/src/components/Explore/Explore.tsx
@@ -61,6 +61,10 @@ function trackExploreEvent(action: EventAction, label: string, value?: number) {
   trackEvent(EventCategory.EXPLORE, action, label, value);
 }
 
+function trackShare(label: string, value?: number) {
+  trackExploreEvent(EventAction.SHARE, label, value);
+}
+
 function getNoDataCopy(metricName: string, locationNames: string) {
   return (
     <p>
@@ -285,6 +289,7 @@ const Explore: React.FunctionComponent<{
   const trackingLabel = hasMultipleLocations
     ? `Multiple Locations`
     : 'Single Location';
+  const numLocations = selectedLocations.length;
 
   return (
     <Styles.Container ref={exploreRef}>
@@ -320,18 +325,13 @@ const Explore: React.FunctionComponent<{
                 );
               }}
               onShareOnFacebook={() =>
-                trackExploreEvent(
-                  EventAction.SHARE,
-                  `Facebook: ${trackingLabel}`,
-                  selectedLocations.length,
-                )
+                trackShare(`Facebook: ${trackingLabel}`, numLocations)
               }
               onShareOnTwitter={() =>
-                trackExploreEvent(
-                  EventAction.SHARE,
-                  `Twitter: ${trackingLabel}`,
-                  selectedLocations.length,
-                )
+                trackShare(`Twitter: ${trackingLabel}`, numLocations)
+              }
+              onShareOnLinkedin={() =>
+                trackShare(`Linkedin: ${trackingLabel}`, numLocations)
               }
             />
           </Styles.ShareBlock>

--- a/src/components/Explore/Explore.tsx
+++ b/src/components/Explore/Explore.tsx
@@ -326,6 +326,13 @@ const Explore: React.FunctionComponent<{
                   selectedLocations.length,
                 )
               }
+              onShareOnTwitter={() =>
+                trackExploreEvent(
+                  EventAction.SHARE,
+                  `Twitter: ${trackingLabel}`,
+                  selectedLocations.length,
+                )
+              }
             />
           </Styles.ShareBlock>
         </Grid>

--- a/src/components/Explore/Explore.tsx
+++ b/src/components/Explore/Explore.tsx
@@ -319,6 +319,13 @@ const Explore: React.FunctionComponent<{
                   selectedLocations.length,
                 );
               }}
+              onShareOnFacebook={() =>
+                trackExploreEvent(
+                  EventAction.SHARE,
+                  `Facebook: ${trackingLabel}`,
+                  selectedLocations.length,
+                )
+              }
             />
           </Styles.ShareBlock>
         </Grid>

--- a/src/components/ShareButtons/FacebookShareButton.tsx
+++ b/src/components/ShareButtons/FacebookShareButton.tsx
@@ -24,11 +24,13 @@ export const FacebookShareButton: React.FC<{
   url: string;
   quote: string;
   socialIconSize: number;
-}> = ({ url, quote, socialIconSize }) => (
+  onClickShare: () => void;
+}> = ({ url, quote, socialIconSize, onClickShare }) => (
   <SocialShareButton
     variant="contained"
     color={COLOR_FACEBOOK}
     disableElevation
+    onClick={onClickShare}
   >
     <FacebookShareButtonInner
       url={url}

--- a/src/components/ShareButtons/FacebookShareButton.tsx
+++ b/src/components/ShareButtons/FacebookShareButton.tsx
@@ -29,7 +29,6 @@ export const FacebookShareButton: React.FC<{
   <SocialShareButton
     variant="contained"
     color={COLOR_FACEBOOK}
-    disableElevation
     onClick={onClickShare}
   >
     <FacebookShareButtonInner

--- a/src/components/ShareButtons/LinkedinShareButton.tsx
+++ b/src/components/ShareButtons/LinkedinShareButton.tsx
@@ -8,11 +8,12 @@ export const LinkedinShareButton: React.FC<{
   url: string;
   quote: string;
   socialIconSize: number;
-}> = ({ url, quote, socialIconSize }) => (
+  onClickShare: () => void;
+}> = ({ url, quote, socialIconSize, onClickShare }) => (
   <SocialShareButton
     variant="contained"
     color={COLOR_LINKEDIN}
-    disableElevation
+    onClick={onClickShare}
   >
     <ReactShare.LinkedinShareButton url={url} title={quote}>
       <ReactShare.LinkedinIcon

--- a/src/components/ShareButtons/ShareButtonGroup.tsx
+++ b/src/components/ShareButtons/ShareButtonGroup.tsx
@@ -20,6 +20,7 @@ const ShareImageButtons: React.FC<{
   onCopyLink?: () => void;
   onShareOnFacebook: () => void;
   onShareOnTwitter: () => void;
+  onShareOnLinkedin: () => void;
 }> = ({
   imageUrl,
   imageFilename,
@@ -29,6 +30,7 @@ const ShareImageButtons: React.FC<{
   disabled = false,
   onShareOnFacebook,
   onShareOnTwitter,
+  onShareOnLinkedin,
   onSaveImage = () => {},
   onCopyLink = () => {},
 }) => {
@@ -101,7 +103,10 @@ const ShareImageButtons: React.FC<{
               {...socialSharingProps}
               hashtags={hashtags}
             />
-            <LinkedinShareButton {...socialSharingProps} />
+            <LinkedinShareButton
+              onClickShare={onShareOnLinkedin}
+              {...socialSharingProps}
+            />
             <CopyLinkButton
               url={socialSharingProps.url}
               onCopyLink={onCopyLink}

--- a/src/components/ShareButtons/ShareButtonGroup.tsx
+++ b/src/components/ShareButtons/ShareButtonGroup.tsx
@@ -19,6 +19,7 @@ const ShareImageButtons: React.FC<{
   onSaveImage?: () => void;
   onCopyLink?: () => void;
   onShareOnFacebook: () => void;
+  onShareOnTwitter: () => void;
 }> = ({
   imageUrl,
   imageFilename,
@@ -27,6 +28,7 @@ const ShareImageButtons: React.FC<{
   hashtags,
   disabled = false,
   onShareOnFacebook,
+  onShareOnTwitter,
   onSaveImage = () => {},
   onCopyLink = () => {},
 }) => {
@@ -80,20 +82,11 @@ const ShareImageButtons: React.FC<{
               );
               onSaveImage();
             }}
-            disableRipple
-            disableFocusRipple
-            disableTouchRipple
             disabled={disabled}
           >
             Save
           </ShareButton>
-          <ShareButton
-            onClick={toggleSocialButtons}
-            disableRipple
-            disableFocusRipple
-            disableTouchRipple
-            disabled={disabled}
-          >
+          <ShareButton onClick={toggleSocialButtons} disabled={disabled}>
             Share
           </ShareButton>
         </ButtonGroup>
@@ -103,7 +96,11 @@ const ShareImageButtons: React.FC<{
               onClickShare={onShareOnFacebook}
               {...socialSharingProps}
             />
-            <TwitterShareButton {...socialSharingProps} hashtags={hashtags} />
+            <TwitterShareButton
+              onClickShare={onShareOnTwitter}
+              {...socialSharingProps}
+              hashtags={hashtags}
+            />
             <LinkedinShareButton {...socialSharingProps} />
             <CopyLinkButton
               url={socialSharingProps.url}

--- a/src/components/ShareButtons/ShareButtonGroup.tsx
+++ b/src/components/ShareButtons/ShareButtonGroup.tsx
@@ -18,6 +18,7 @@ const ShareImageButtons: React.FC<{
   disabled?: boolean;
   onSaveImage?: () => void;
   onCopyLink?: () => void;
+  onShareOnFacebook: () => void;
 }> = ({
   imageUrl,
   imageFilename,
@@ -25,6 +26,7 @@ const ShareImageButtons: React.FC<{
   quote,
   hashtags,
   disabled = false,
+  onShareOnFacebook,
   onSaveImage = () => {},
   onCopyLink = () => {},
 }) => {
@@ -97,7 +99,10 @@ const ShareImageButtons: React.FC<{
         </ButtonGroup>
         {socialSharingProps && (
           <SocialButtonsContainer onClick={() => hideSocialButtons(1500)}>
-            <FacebookShareButton {...socialSharingProps} />
+            <FacebookShareButton
+              onClickShare={onShareOnFacebook}
+              {...socialSharingProps}
+            />
             <TwitterShareButton {...socialSharingProps} hashtags={hashtags} />
             <LinkedinShareButton {...socialSharingProps} />
             <CopyLinkButton

--- a/src/components/ShareButtons/ShareButtons.style.tsx
+++ b/src/components/ShareButtons/ShareButtons.style.tsx
@@ -4,7 +4,11 @@ import theme from 'assets/theme';
 import palette from 'assets/theme/palette';
 import { StyledShareButtonStyles } from 'components/ShareBlock/ShareBlock.style';
 
-export const ShareButton = styled(Button)`
+export const ShareButton = styled(Button).attrs(props => ({
+  disableRipple: true,
+  disableFocusRipple: true,
+  disableTouchRipple: true,
+}))`
   border-color: ${palette.lightGray};
   color: ${palette.lightBlue};
   text-transform: none;

--- a/src/components/ShareButtons/ShareButtons.style.tsx
+++ b/src/components/ShareButtons/ShareButtons.style.tsx
@@ -33,7 +33,9 @@ export const SocialButtonsContainer = styled.div`
   width: fit-content;
 `;
 
-export const SocialButton = styled(Button)`
+export const SocialButton = styled(Button).attrs(props => ({
+  disableElevation: true,
+}))`
   width: 60px;
   height: 42px;
   text-transform: none;

--- a/src/components/ShareButtons/TwitterShareButton.tsx
+++ b/src/components/ShareButtons/TwitterShareButton.tsx
@@ -20,8 +20,14 @@ export const TwitterShareButton: React.FC<{
   quote: string;
   hashtags?: string[];
   socialIconSize: number;
-}> = ({ url, quote, hashtags, socialIconSize }) => (
-  <SocialShareButton variant="contained" color={COLOR_TWITTER} disableElevation>
+  onClickShare: () => void;
+}> = ({ url, quote, hashtags, socialIconSize, onClickShare }) => (
+  <SocialShareButton
+    variant="contained"
+    color={COLOR_TWITTER}
+    disableElevation
+    onClick={onClickShare}
+  >
     <TwitterShareButtonInner
       url={url}
       quote={quote}

--- a/src/components/ShareButtons/TwitterShareButton.tsx
+++ b/src/components/ShareButtons/TwitterShareButton.tsx
@@ -25,7 +25,6 @@ export const TwitterShareButton: React.FC<{
   <SocialShareButton
     variant="contained"
     color={COLOR_TWITTER}
-    disableElevation
     onClick={onClickShare}
   >
     <TwitterShareButtonInner


### PR DESCRIPTION
Adding tracking for when users click "share" on Facebook, Twitter, and Linkedin for Compare and Explore. The metric charts use an old component and need to migrate that first. 