### PR TITLE
Recommends: fix yellow

### DIFF
--- a/src/common/utils/recommend.ts
+++ b/src/common/utils/recommend.ts
@@ -90,16 +90,16 @@ export function getFedLevel(projection: Projection): FedLevel | null {
     return null;
   }
 
-  if (weeklyCasesPer100k > 100 && positiveTestRate > 0.1) {
+  const redPosTest = positiveTestRate > 0.1;
+  const redCases = weeklyCasesPer100k > 100;
+  const yellowTestPos = 0.05 < positiveTestRate && positiveTestRate <= 0.1;
+  const yellowCases = 10 < weeklyCasesPer100k && weeklyCasesPer100k <= 100;
+
+  if (redPosTest && redCases) {
     return FedLevel.RED;
-  } else if (weeklyCasesPer100k > 100 || positiveTestRate > 0.1) {
+  } else if ((redPosTest || redCases) && (yellowTestPos || yellowCases)) {
     return FedLevel.YELLOW;
-  } else if (
-    10 < weeklyCasesPer100k &&
-    weeklyCasesPer100k < 100 &&
-    0.05 <= positiveTestRate &&
-    positiveTestRate <= 0.1
-  ) {
+  } else if (yellowTestPos && yellowCases) {
     return FedLevel.YELLOW;
   } else {
     return FedLevel.GREEN;

--- a/src/common/utils/recommend.ts
+++ b/src/common/utils/recommend.ts
@@ -95,8 +95,10 @@ export function getFedLevel(projection: Projection): FedLevel | null {
   } else if (weeklyCasesPer100k > 100 || positiveTestRate > 0.1) {
     return FedLevel.YELLOW;
   } else if (
-    (10 < weeklyCasesPer100k && weeklyCasesPer100k < 100) ||
-    (0.05 <= positiveTestRate && positiveTestRate <= 0.1)
+    10 < weeklyCasesPer100k &&
+    weeklyCasesPer100k < 100 &&
+    0.05 <= positiveTestRate &&
+    positiveTestRate <= 0.1
   ) {
     return FedLevel.YELLOW;
   } else {

--- a/src/common/utils/recommend.ts
+++ b/src/common/utils/recommend.ts
@@ -92,6 +92,8 @@ export function getFedLevel(projection: Projection): FedLevel | null {
 
   if (weeklyCasesPer100k > 100 && positiveTestRate > 0.1) {
     return FedLevel.RED;
+  } else if (weeklyCasesPer100k > 100 || positiveTestRate > 0.1) {
+    return FedLevel.YELLOW;
   } else if (
     (10 < weeklyCasesPer100k && weeklyCasesPer100k < 100) ||
     (0.05 <= positiveTestRate && positiveTestRate <= 0.1)


### PR DESCRIPTION
Fed task force's yellow zone is defined as:

```
Both:
- New cases between 10-100 per 100,000 population
- Diagnostic test positivity result between 5-10%

Or one of those two conditions and one condition qualifying as being in the “Red Zone”.
```

We weren't calculating this correctly:
- We were calculating the first half with `||` instead of `&&`
- We weren't capturing the second half/the 'Or...'

For reference (from the fed doc):

![Screen Shot 2020-10-15 at 11 52 06 PM](https://user-images.githubusercontent.com/44076375/97195655-fa26d100-1781-11eb-864b-eb58281b4bc9.png)

To test:
Vermont, Maine = Fed green zone
Minnesota, Oregon = Fed yellow zone
South Dakota, Utah = Fed red zone