### PR TITLE
handle internal and external links on markdown content

### DIFF
--- a/src/components/Markdown/MarkdownContent.tsx
+++ b/src/components/Markdown/MarkdownContent.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactMarkdown, { ReactMarkdownProps } from 'react-markdown';
-import { MarkdownLink } from './Markdown.style';
+import MarkdownLink from './MarkdownLink';
 
 /**
  * Custom renderers for each Markdown node type. Useful to override the

--- a/src/components/Markdown/MarkdownLink.tsx
+++ b/src/components/Markdown/MarkdownLink.tsx
@@ -1,5 +1,6 @@
 import React, { Fragment } from 'react';
 import { HashLink } from 'react-router-hash-link';
+import { scrollWithOffset } from 'components/TableOfContents';
 
 function isValidURL(href: string): boolean {
   let isValid = false;
@@ -36,7 +37,9 @@ const MarkdownLink: React.FC<{
   }
 
   return isInternalLink(href) ? (
-    <HashLink to={href}>{children}</HashLink>
+    <HashLink to={href} scroll={element => scrollWithOffset(element, -80)}>
+      {children}
+    </HashLink>
   ) : (
     <a href={href} target="_blank" rel="noopener noreferrer">
       {children}

--- a/src/components/Markdown/MarkdownLink.tsx
+++ b/src/components/Markdown/MarkdownLink.tsx
@@ -24,7 +24,8 @@ function isInternalLink(href: string) {
 /**
  * Custom hyperlink for Markdown content. If the link is external, open it on
  * a new tab. If the link is internal, use the HashLink component to render
- * it in the current page.
+ * it in the current page. If the link is invalid, we just render the text of
+ * the link.
  */
 const MarkdownLink: React.FC<{
   href: string;

--- a/src/components/Markdown/MarkdownLink.tsx
+++ b/src/components/Markdown/MarkdownLink.tsx
@@ -1,0 +1,46 @@
+import React, { Fragment } from 'react';
+import { HashLink } from 'react-router-hash-link';
+
+function isValidURL(href: string): boolean {
+  let isValid = false;
+  try {
+    new URL(href);
+    isValid = true;
+  } catch {
+    isValid = false;
+  }
+  return isValid;
+}
+
+/**
+ * If the href parameter doesn't have a hostname, then the href parameter
+ * corresponds to an internal URL such as `/faq` or `/glossary#superspreader`
+ */
+function isInternalLink(href: string) {
+  const url = new URL(href);
+  return url.hostname.length === 0;
+}
+
+/**
+ * Custom hyperlink for Markdown content. If the link is external, open it on
+ * a new tab. If the link is internal, use the HashLink component to render
+ * it in the current page.
+ */
+const MarkdownLink: React.FC<{
+  href: string;
+  children: React.ReactNode;
+}> = ({ href, children }) => {
+  if (!isValidURL(href)) {
+    return <Fragment>{children}</Fragment>;
+  }
+
+  return isInternalLink(href) ? (
+    <HashLink to={href}>{children}</HashLink>
+  ) : (
+    <a href={href} target="_blank" rel="noopener noreferrer">
+      {children}
+    </a>
+  );
+};
+
+export default MarkdownLink;

--- a/src/components/SharedComponents/Accordion.tsx
+++ b/src/components/SharedComponents/Accordion.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { AccordionDetails } from '@material-ui/core';
+import { AccordionDetails, AccordionProps } from '@material-ui/core';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import {
   StyledMuiAccordion,
@@ -7,14 +7,18 @@ import {
   MarkdownBody,
 } from './Accordion.style';
 
-const StyledAccordion = (props: {
+export interface StyledAccordionProps extends Omit<AccordionProps, 'children'> {
   summaryText: string;
   detailText: string;
-}) => {
-  const { summaryText, detailText } = props;
+}
 
+const StyledAccordion: React.FC<StyledAccordionProps> = ({
+  summaryText,
+  detailText,
+  ...otherProps
+}) => {
   return (
-    <StyledMuiAccordion>
+    <StyledMuiAccordion {...otherProps}>
       <StyledAccordionSummary expandIcon={<ExpandMoreIcon />}>
         {summaryText}
       </StyledAccordionSummary>

--- a/src/screens/Learn/Glossary/Glossary.tsx
+++ b/src/screens/Learn/Glossary/Glossary.tsx
@@ -1,4 +1,6 @@
-import React, { Fragment } from 'react';
+import React, { Fragment, useState } from 'react';
+import { useLocation } from 'react-router-dom';
+import { sortBy, without } from 'lodash';
 import {
   PageContainer,
   PageHeader,
@@ -23,6 +25,24 @@ export const breadcrumbItems: BreadcrumbItem[] = [
 ];
 
 const Glossary = () => {
+  const [expandedItems, setExpandedItems] = useState<string[]>([]);
+  const { hash } = useLocation();
+
+  function onChangeExpandedTerm(termId: string, expanded: boolean) {
+    const newExpandedItems = expanded
+      ? [...expandedItems, termId]
+      : without(expandedItems, termId);
+    setExpandedItems(sortBy(newExpandedItems));
+  }
+
+  function isExpanded(termId: string) {
+    // Always expand the term in the URL hash
+    return (
+      expandedItems.includes(termId) ||
+      (hash.length > 0 && `#${termId}` === hash)
+    );
+  }
+
   return (
     <PageContainer>
       <AppMetaTags
@@ -42,6 +62,10 @@ const Glossary = () => {
             <StyledAccordion
               summaryText={item.term}
               detailText={item.definition}
+              expanded={isExpanded(item.termId)}
+              onChange={(event: {}, expanded) =>
+                onChangeExpandedTerm(item.termId, expanded)
+              }
             />
           </Fragment>
         ))}


### PR DESCRIPTION
The markdown component has a custom renderer for links. This PR differentiates internal and external links by parsing the `href` parameter as a [URL](https://developer.mozilla.org/en-US/docs/Web/API/URL) and checking if the link includes a hostname.

Internal links use the `HashLink` component, which scrolls to the specific link (let's say `/glossary#superspreader`, external links will open on a new tab (and have `rel="noopened noreferrer"`)