### PR TITLE
implement error boundary

### DIFF
--- a/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import * as Sentry from '@sentry/react';
+import FallbackAlert from './FallbackAlert';
+
+const ErrorBoundary: React.FC = ({ children }) => (
+  <Sentry.ErrorBoundary fallback={FallbackAlert}>
+    {children}
+  </Sentry.ErrorBoundary>
+);
+
+export default ErrorBoundary;

--- a/src/components/ErrorBoundary/FallbackAlert.tsx
+++ b/src/components/ErrorBoundary/FallbackAlert.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { Alert, AlertTitle } from '@material-ui/lab';
+
+const FallbackAlert: React.FC = () => (
+  <Alert severity="error">
+    <AlertTitle>Error</AlertTitle>
+    An error occurred while rendering this component. We were notified about it
+    and will fix it soon.
+  </Alert>
+);
+
+export default FallbackAlert;

--- a/src/components/ErrorBoundary/index.ts
+++ b/src/components/ErrorBoundary/index.ts
@@ -1,0 +1,5 @@
+import ErrorBoundary from './ErrorBoundary';
+import FallbackAlert from './FallbackAlert';
+
+export default ErrorBoundary;
+export { FallbackAlert };

--- a/src/components/Markdown/MarkdownContent.tsx
+++ b/src/components/Markdown/MarkdownContent.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactMarkdown, { ReactMarkdownProps } from 'react-markdown';
 import MarkdownLink from './MarkdownLink';
+import ErrorBoundary from 'components/ErrorBoundary';
 
 /**
  * Custom renderers for each Markdown node type. Useful to override the
@@ -13,7 +14,11 @@ const customRenderers = {
 };
 
 const MarkdownContent: React.FC<ReactMarkdownProps> = props => {
-  return <ReactMarkdown renderers={customRenderers} {...props} />;
+  return (
+    <ErrorBoundary>
+      <ReactMarkdown renderers={customRenderers} {...props} />
+    </ErrorBoundary>
+  );
 };
 
 export default MarkdownContent;

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,12 @@ import ReactDOM from 'react-dom';
 import './index.css';
 import App from './App';
 import * as serviceWorker from './serviceWorker';
+import * as Sentry from '@sentry/react';
+
+Sentry.init({
+  dsn:
+    'https://4e1fa0b7df4d490488847bcc7966712b@o378922.ingest.sentry.io/5444052',
+});
 
 ReactDOM.render(<App />, document.getElementById('root'));
 


### PR DESCRIPTION
An error boundary prevents the entire app from crashing when a component crashes. One potential problem with the CMS is that CMS users could put an invalid URL in the link, which would crash the app.

This PR uses the ErrorBoundary component provided by Sentry to wrap the markdown component. If the markdown component crashes for any reason, the error boundary will capture the error and render the fallback UI. It will also send the error report to Sentry

![image](https://user-images.githubusercontent.com/114084/97345457-54d63080-1847-11eb-9529-9d5234b54de1.png)

## How to Test

In local development, errors are shown with an overlay by Create React App, which hides the Error boundary. To test the error boundary, we need to use the production build

- Throw an error from the Markdown component (add `new URL('~~~')` somewhere in the component)
- Build the app locally (`yarn build`)
- Run the server using the build `serve -s build -l 4000` (I'm using https://www.npmjs.com/package/serve)
- The fallback component should render instead of the component, and the app shouldn't crash