### PR TITLE
learn: add learn on the footer

### DIFF
--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -30,11 +30,12 @@ const Footer = ({ children }: { children: React.ReactNode }) => {
             <Logo />
             <StyledFooterBodyNav>
               <Link to="/">Map</Link>
-              <Link to="/about">About</Link>
+              <Link to="/learn">Learn</Link>
               <Link to="/resources">Resources</Link>
               <ExternalLink href="https://blog.covidactnow.org">
                 Blog
               </ExternalLink>
+              <Link to="/about">About</Link>
               <Link to="/contact">Contact Us</Link>
             </StyledFooterBodyNav>
             <StyledFooterDivider />


### PR DESCRIPTION
This PR adds a link to the Learn page on the footer, and re-arranges the items to match the top navigation bar.