### PR TITLE
Adding geolocation to explore

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@types/d3-shape": "^1.3.2",
     "@types/d3-time": "^1.0.10",
     "@types/react-router-hash-link": "^1.2.1",
+    "@types/topojson": "^3.2.2",
     "@types/typeform__embed": "^0.22.2",
     "@types/uuid": "^8.3.0",
     "@vx/axis": "^0.0.196",
@@ -36,6 +37,7 @@
     "csv-parse": "^4.8.8",
     "d3-array": "^2.4.0",
     "d3-color": "^2.0.0",
+    "d3-geo": "^2.0.1",
     "d3-scale-chromatic": "^2.0.0",
     "d3-time": "^1.1.0",
     "downshift": "^5.0.5",
@@ -65,6 +67,7 @@
     "sharp": "^0.25.2",
     "styled-components": "^5.0.1",
     "tar": "^6.0.1",
+    "topojson-client": "^3.1.0",
     "uuid": "^8.3.0"
   },
   "scripts": {

--- a/src/common/utils/geolocation.ts
+++ b/src/common/utils/geolocation.ts
@@ -1,0 +1,33 @@
+import { feature } from 'topojson-client';
+import { Topology, GeometryCollection } from 'topojson-specification';
+import STATES_JSON from 'components/Map/data/states-10m.json';
+import { geoContains } from 'd3-geo';
+
+export function getCurrentLocation(onLocation: PositionCallback) {
+  navigator.geolocation.getCurrentPosition(position => {
+    onLocation(position);
+  });
+}
+
+const states = feature(
+  (STATES_JSON as unknown) as Topology,
+  STATES_JSON.objects.states as GeometryCollection,
+);
+
+interface GeolocationPosition {
+  latitude: number;
+  longitude: number;
+}
+
+export function getState(position: GeolocationPosition) {
+  const point: [number, number] = [position.longitude, position.latitude];
+  const state = states.features.find(stateFeature => {
+    // tslint:disable-next-line
+    if (stateFeature.geometry) {
+      const cont = geoContains(stateFeature.geometry, point);
+      if (cont) {
+        console.log(cont, stateFeature);
+      }
+    }
+  });
+}

--- a/src/components/Explore/Explore.style.ts
+++ b/src/components/Explore/Explore.style.ts
@@ -9,6 +9,7 @@ import colorPalette from 'assets/theme/palette';
 import { charts } from 'components/Charts/Charts.style';
 import { COLOR_MAP } from 'common/colors';
 import { brightenColor } from './utils';
+import MuiMyLocationIcon from '@material-ui/icons/MyLocation';
 
 /** Gets the chart palette based on the current theme. */
 function palette(props: any) {
@@ -319,4 +320,8 @@ export const NormalizeSubLabel = styled.div`
   color: ${COLOR_MAP.GRAY_BODY_COPY};
   margin-left: 2rem;
   transform: translateY(-0.75rem);
+`;
+
+export const MyLocationIcon = styled(MuiMyLocationIcon)`
+  color: #bdbdbd;
 `;

--- a/src/components/Explore/Explore.tsx
+++ b/src/components/Explore/Explore.tsx
@@ -11,6 +11,8 @@ import Grid from '@material-ui/core/Grid';
 import useMediaQuery from '@material-ui/core/useMediaQuery';
 import { useTheme } from '@material-ui/core/styles';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
+import { IconButton } from '@material-ui/core';
+import Tooltip from '@material-ui/core/Tooltip';
 import { ParentSize } from '@vx/responsive';
 import { useModelLastUpdatedDate } from 'common/utils/model';
 import { findLocationForFips, Location } from 'common/locations';
@@ -52,6 +54,7 @@ import { findFipsByUrlParams } from 'common/locations';
 import { ScreenshotReady } from 'components/Screenshot';
 import { EventCategory, EventAction, trackEvent } from 'components/Analytics';
 import { IndigenousDataCheckbox } from 'components/IndigenousPopulationsFeature';
+import { getCurrentLocation, getState } from 'common/utils/geolocation';
 
 const MARGIN_SINGLE_LOCATION = 20;
 const MARGIN_STATE_CODE = 60;
@@ -286,6 +289,15 @@ const Explore: React.FunctionComponent<{
     }
   }, [sharedParams]);
 
+  const onClickGeolocation = () => {
+    console.log('geolocating...');
+    getCurrentLocation(position => {
+      console.log(position);
+      console.log(getState({ latitude: 0, longitude: 0 }));
+      // update the state
+    });
+  };
+
   const trackingLabel = hasMultipleLocations
     ? `Multiple Locations`
     : 'Single Location';
@@ -351,13 +363,20 @@ const Explore: React.FunctionComponent<{
           Compare states or counties
         </Styles.TableAutocompleteHeader>
         <Grid container spacing={1}>
-          <Grid key="location-selector" item sm={9} xs={12}>
+          <Grid key="location-selector" item sm={8} xs={12}>
             <LocationSelector
               locations={autocompleteLocations}
               selectedLocations={selectedLocations}
               onChangeSelectedLocations={onChangeSelectedLocations}
               {...modalNormalizeCheckboxProps}
             />
+          </Grid>
+          <Grid key="geolocation">
+            <Tooltip title="Compare your current location" placement="top">
+              <IconButton onClick={onClickGeolocation}>
+                <Styles.MyLocationIcon />
+              </IconButton>
+            </Tooltip>
           </Grid>
           {!hasMultipleLocations && (
             <Grid key="legend" item sm={3} xs={12}>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2767,6 +2767,48 @@
     "@types/react-native" "*"
     csstype "^2.2.0"
 
+"@types/topojson-client@*":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/topojson-client/-/topojson-client-3.0.0.tgz#2517fae5abbdd3052eb191747c7d0bc268d69918"
+  integrity sha512-HZH6E8XMhjkDEkkpe3HuIg95COuvjdnyy0EKrh8rAi1f6o/V6P3ly1kGyU2E8bpAffXDd2r+Rk5ceMX4XkqHnA==
+  dependencies:
+    "@types/geojson" "*"
+    "@types/topojson-specification" "*"
+
+"@types/topojson-server@*":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/topojson-server/-/topojson-server-3.0.0.tgz#b668fc808831763320db8f3b339ee168c2e2e5dc"
+  integrity sha512-OdIgHf+9hbEOdrZEoIaE6staRbCyssznjtggIySUqvWOk9xWK0lodLnn7ks3l8H+wgMTgelEXqyBmAtlyn0fvA==
+  dependencies:
+    "@types/geojson" "*"
+    "@types/topojson-specification" "*"
+
+"@types/topojson-simplify@*":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/topojson-simplify/-/topojson-simplify-3.0.0.tgz#54ad7e2f172c662c07ad390e5cf965c147093e65"
+  integrity sha512-hfrvjZ/KbdAFBgJzdPfkixHgMNbhRvvFSCIOga1rAeluksFV9sSTWx+N4vZymqcfz1J+yMZfP2SCRt+/DHsJCQ==
+  dependencies:
+    "@types/geojson" "*"
+    "@types/topojson-specification" "*"
+
+"@types/topojson-specification@*":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@types/topojson-specification/-/topojson-specification-1.0.1.tgz#a80cb294290b79f2d674d3f5938c544ed2bd9d80"
+  integrity sha512-ZZYZUgkmUls9Uhxx2WZNt9f/h2+H3abUUjOVmq+AaaDFckC5oAwd+MDp95kBirk+XCXrYj0hfpI6DSUiJMrpYQ==
+  dependencies:
+    "@types/geojson" "*"
+
+"@types/topojson@^3.2.2":
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/@types/topojson/-/topojson-3.2.2.tgz#96136313ba6a1df3df8931b722400828e027ee94"
+  integrity sha512-CwIJKe3YmNZ4oMcjJ//+8IXe6YA+znX6DXe0alCEoMoiWEM97QfjuP9BhPdvSU4pa0ZgghYJYtKcTprZhJm7Kw==
+  dependencies:
+    "@types/geojson" "*"
+    "@types/topojson-client" "*"
+    "@types/topojson-server" "*"
+    "@types/topojson-simplify" "*"
+    "@types/topojson-specification" "*"
+
 "@types/typeform__embed@^0.22.2":
   version "0.22.2"
   resolved "https://registry.yarnpkg.com/@types/typeform__embed/-/typeform__embed-0.22.2.tgz#306fab7a3167b7f454c5d266ffb6ddbdafabe7e6"
@@ -5707,6 +5749,11 @@ d3-array@1, d3-array@^1.2.0:
   resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-1.2.4.tgz#635ce4d5eea759f6f605863dbcfc30edc737f71f"
   integrity sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw==
 
+d3-array@>=2.5:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-2.8.0.tgz#f76e10ad47f1f4f75f33db5fc322eb9ffde5ef23"
+  integrity sha512-6V272gsOeg7+9pTW1jSYOR1QE37g95I3my1hBmY+vOUNHRrk9yt4OTz/gK7PMkVAVDrYYq4mq3grTiZ8iJdNIw==
+
 d3-array@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-2.4.0.tgz#87f8b9ad11088769c82b5ea846bcb1cc9393f242"
@@ -5738,6 +5785,13 @@ d3-geo@^1.11.6:
   integrity sha512-XG4d1c/UJSEX9NfU02KwBL6BYPj8YKHxgBEw5om2ZnTRSbIcego6dhHwcxuSR3clxh0EpE38os1DVPOmnYtTPg==
   dependencies:
     d3-array "1"
+
+d3-geo@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/d3-geo/-/d3-geo-2.0.1.tgz#2437fdfed3fe3aba2812bd8f30609cac83a7ee39"
+  integrity sha512-M6yzGbFRfxzNrVhxDJXzJqSLQ90q1cCyb3EWFZ1LF4eWOBYxFypw7I/NFVBNXKNqxv1bqLathhYvdJ6DC+th3A==
+  dependencies:
+    d3-array ">=2.5"
 
 d3-interpolate@1:
   version "1.4.0"
@@ -15684,7 +15738,7 @@ toidentifier@1.0.0:
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.0.tgz#7e1be3470f1e77948bc43d94a3c8f4d7752ba553"
   integrity sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==
 
-topojson-client@^3.0.0:
+topojson-client@^3.0.0, topojson-client@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/topojson-client/-/topojson-client-3.1.0.tgz#22e8b1ed08a2b922feeb4af6f53b6ef09a467b99"
   integrity sha512-605uxS6bcYxGXw9qi62XyrV6Q3xwbndjachmNxu8HWTtVPxZfEJN9fd/SZS1Q54Sn2y0TMyMxFj/cJINqGHrKw==


### PR DESCRIPTION
🚧  _work in progress_

[Trello Card](https://trello.com/c/7rfWXRqB/494-geo-locate-user-and-use-the-location-to-pre-populate-explore-chart-on-homepage) 

## Idea

```ts
const [coordinates] = useGeolocation();

useEffect(() => {
  if (coordinates) {
    // find state, add to explore
  } else {
    // user didn't authorize, couldn't find the state (show alert, disable geolocation button)
  }
}, [coordinates])

```



## Note to self
- `geoContains` from `d3-geo` doesn't work with coordinates from our states dataset (two theories, spherical vs. planar coordinates, or clockwise vs. counterclockwise coordinates on the corresponding polygons). A workaround is to work with projected coordinates and use `contains` from `d3-polygon` , using any projection should work.
- Enable sensors on Chrome Developer Tools and select a US location during development, see [Override Geolocation in Chrome DevTools](https://developers.google.com/web/tools/chrome-devtools/device-mode/geolocation)