### PR TITLE
update the cap for the case incidence chart

### DIFF
--- a/src/components/Charts/ChartCaseDensity.tsx
+++ b/src/components/Charts/ChartCaseDensity.tsx
@@ -51,7 +51,7 @@ const ChartCaseDensity: FunctionComponent<{
 }> = ({
   columnData,
   zones,
-  capY = 100,
+  capY = 500,
   width,
   height,
   marginTop = 5,


### PR DESCRIPTION
Update the cap on the daily new cases chart. I moved the cap to 500 to account for counties in North Dakota that are unfortunately over 250 / 100k.

See [Wells County, ND](https://covid-projections-git-pablo-update-case-density-cap.covidactnow.vercel.app/us/north_dakota-nd/county/wells_county?s=1231303) for an example 