### PR TITLE
fix Mariana Islands svg props

### DIFF
--- a/src/components/StateSvg/NorthernMarianaIslands.js
+++ b/src/components/StateSvg/NorthernMarianaIslands.js
@@ -2,8 +2,8 @@ import React from 'react';
 
 const MarianaIslands = () => (
   <svg
-    stroke-linecap="round"
-    stroke-linejoin="round"
+    strokeLinecap="round"
+    strokeLinejoin="round"
     baseProfile="tiny"
     version="1.2"
     viewBox="0 0 800 4365"


### PR DESCRIPTION
Fixes the names of the props for the SVG of Mariana Islands (react doesn't like the dashes in multi-word properties, unless it's for aria labels or data attributes)