### PR TITLE
case studies: ux feedback

### DIFF
--- a/src/components/Markdown/Markdown.style.ts
+++ b/src/components/Markdown/Markdown.style.ts
@@ -17,11 +17,17 @@ export const StylesBody = css`
 `;
 
 export const StylesH2 = css`
-  margin-top: ${theme.spacing(1)}px;
+  color: ${COLOR_MAP.GRAY_BODY_COPY};
+  margin-top: ${theme.spacing(4)}px;
   margin-bottom: ${theme.spacing(3)}px;
-  font-size: 18px;
+  font-size: 22px;
   font-weight: 900;
-  line-height: 29px;
+  line-height: 1.6;
+`;
+
+export const StylesH3 = css`
+  color: ${COLOR_MAP.GRAY_BODY_COPY};
+  font-size: 18px;
 `;
 
 export const StylesBlockQuoteHighlight = css`
@@ -74,6 +80,10 @@ export const StylesMarkdown = css`
   h2 {
     ${StylesH2}
     color: #000;
+  }
+
+  h3 {
+    ${StylesH3}
   }
 
   img {

--- a/src/components/Markdown/Markdown.style.ts
+++ b/src/components/Markdown/Markdown.style.ts
@@ -3,92 +3,124 @@ import { COLOR_MAP } from 'common/colors';
 import ReactMarkdown from 'react-markdown';
 import theme from 'assets/theme';
 
-export const StylesBlockElement = css`
-  margin-bottom: ${theme.spacing(2)}px;
-  &:last-child {
-    margin-bottom: 0;
+const baseCss = css`
+  font-family: ${theme.typography.fontFamily};
+`;
+
+const paragraphCss = css`
+  ${baseCss}
+  color: ${COLOR_MAP.GRAY_BODY_COPY};
+  margin-top: ${theme.spacing(2)}px;
+  font-size: 16px;
+  &:first-of-type {
+    margin-top: 0;
   }
 `;
 
-export const StylesBody = css`
-  color: ${COLOR_MAP.GRAY_BODY_COPY};
-  line-height: 1.6;
-  font-size: 16px;
+const heading1Css = css`
+  ${baseCss}
+  line-height: 1.25;
+  margin-bottom: ${1.5 * theme.spacing(1)}px;
 `;
 
-export const StylesH2 = css`
-  color: ${COLOR_MAP.GRAY_BODY_COPY};
+const heading2Css = css`
+  ${baseCss}
+  font-weight: ${theme.typography.fontWeightMedium};
   margin-top: ${theme.spacing(4)}px;
-  margin-bottom: ${theme.spacing(3)}px;
+  margin-bottom: ${theme.spacing(1)}px;
   font-size: 22px;
-  font-weight: 900;
-  line-height: 1.6;
 `;
 
-export const StylesH3 = css`
-  color: ${COLOR_MAP.GRAY_BODY_COPY};
+const heading3Css = css`
+  ${baseCss}
+  color: #000;
   font-size: 18px;
+  font-weight: ${theme.typography.fontWeightBold};
 `;
 
-export const StylesBlockQuoteHighlight = css`
+const blockquoteCss = css`
   background-color: ${COLOR_MAP.LIGHTGRAY_BG};
   padding: ${theme.spacing(2)}px;
   display: inline-block;
-  margin: 0.5rem 0;
+  margin: ${theme.spacing(1)}px 0;
   width: 100%;
   p {
     color: ${COLOR_MAP.GREEN.BASE};
-    font-size: 1.125rem;
+    font-size: 18px;
     font-weight: 900;
     line-height: 1.6;
     margin: 0;
   }
 `;
 
-export const StylesUl = css`
-  ${StylesBody};
-  ${StylesBlockElement};
+/**
+ * These components should be used to ensure that the styles applied to markdown
+ * blocks is also applied to elements outside markdown blocks.
+ */
 
-  li {
-    ${StylesBlockElement};
-    margin-top: ${theme.spacing(1)}px;
-    margin-bottom: ${theme.spacing(1)}px;
-  }
+export const Paragraph = styled.p`
+  ${paragraphCss}
+`;
+
+export const Heading1 = styled.h1`
+  ${heading1Css}
+`;
+
+export const Heading2 = styled.h2`
+  ${heading2Css}
+`;
+
+export const Heading3 = styled.h3`
+  ${heading3Css}
+`;
+
+export const Blockquote = styled.blockquote`
+  ${blockquoteCss}
 `;
 
 export const StylesMarkdown = css`
-  ${StylesBody};
-
-  /* Inline  */
-  a {
-    color: ${COLOR_MAP.BLUE};
-  }
-
-  /* Block elements */
-  p,
-  ul {
-    ${StylesBody}
-    ${StylesBlockElement}
-  }
-
-  li {
-    ${StylesBlockElement}
-    margin-top: ${theme.spacing(1)}px;
-    margin-bottom: ${theme.spacing(1)}px;
+  h1 {
+    ${heading1Css};
   }
 
   h2 {
-    ${StylesH2}
-    color: #000;
+    ${heading2Css};
   }
 
   h3 {
-    ${StylesH3}
+    ${heading3Css};
+  }
+
+  p {
+    ${paragraphCss};
+  }
+
+  li,
+  ol {
+    ${paragraphCss};
+    margin-top: ${theme.spacing(1)}px;
+    margin-bottom: ${theme.spacing(1)}px;
+    a {
+      color: ${COLOR_MAP.BLUE};
+    }
   }
 
   img {
     max-width: 100%;
   }
+
+  blockquote {
+    ${blockquoteCss};
+  }
+`;
+
+/**
+ * Sometimes, we need to apply markdown styles to a non-markdown component. In
+ * this case, we need to wrap the content with `MarkdownStyleContainer`, which
+ * includes the styles that we need.
+ */
+export const MarkdownStyleContainer = styled.div`
+  ${StylesMarkdown};
 `;
 
 export const MarkdownBody = styled(ReactMarkdown)`

--- a/src/components/Markdown/MarkdownContent.tsx
+++ b/src/components/Markdown/MarkdownContent.tsx
@@ -8,7 +8,7 @@ import { MarkdownBody } from './Markdown.style';
  * Custom renderers for each Markdown node type. Useful to override the
  * attributes or styling of the rendered element.
  *
- * https://github.com/remarkjs/react-markdown#node-types
+ * https://github.com/remarkjs/react-markdown#appendix-b-node-types
  */
 const customRenderers = {
   link: MarkdownLink,

--- a/src/components/Markdown/index.ts
+++ b/src/components/Markdown/index.ts
@@ -4,6 +4,7 @@ import {
   StylesBlockElement,
   StylesBlockQuoteHighlight,
   StylesH2,
+  StylesH3,
   StylesUl,
   StylesMarkdown,
 } from './Markdown.style';
@@ -16,6 +17,7 @@ export {
   StylesBlockElement,
   StylesBlockQuoteHighlight,
   StylesH2,
+  StylesH3,
   StylesUl,
   StylesMarkdown,
 };

--- a/src/components/Markdown/index.ts
+++ b/src/components/Markdown/index.ts
@@ -1,23 +1,21 @@
 import {
   MarkdownBody,
-  StylesBody,
-  StylesBlockElement,
-  StylesBlockQuoteHighlight,
-  StylesH2,
-  StylesH3,
-  StylesUl,
   StylesMarkdown,
+  Heading1,
+  Heading2,
+  Heading3,
+  Paragraph,
+  MarkdownStyleContainer,
 } from './Markdown.style';
 import MarkdownContent from './MarkdownContent';
 
 export {
   MarkdownBody,
   MarkdownContent,
-  StylesBody,
-  StylesBlockElement,
-  StylesBlockQuoteHighlight,
-  StylesH2,
-  StylesH3,
-  StylesUl,
   StylesMarkdown,
+  Heading1,
+  Heading2,
+  Heading3,
+  Paragraph,
+  MarkdownStyleContainer,
 };

--- a/src/screens/Learn/CaseStudies/CaseStudiesLanding.tsx
+++ b/src/screens/Learn/CaseStudies/CaseStudiesLanding.tsx
@@ -4,16 +4,15 @@ import { caseStudiesContent } from 'cms-content/learn';
 import CaseStudyCard from './CaseStudyCard';
 import {
   PageContainer,
-  PageHeader,
   PageContent,
   BreadcrumbsContainer,
-  PageIntroMarkdown,
 } from '../Learn.style';
 import AppMetaTags from 'components/AppMetaTags/AppMetaTags';
 import Breadcrumbs from 'components/Breadcrumbs';
 import { formatMetatagDate } from 'common/utils';
 import Grid from '@material-ui/core/Grid';
-import { CardsContainer, CategoryHeader } from './CaseStudy.style';
+import { CardsContainer } from './CaseStudy.style';
+import { MarkdownContent, Heading1, Heading2 } from 'components/Markdown';
 
 const { header, intro, categories } = caseStudiesContent;
 
@@ -30,17 +29,15 @@ const Landing: React.FC = () => {
       />
       <PageContent>
         <BreadcrumbsContainer>
-          <Breadcrumbs item={{ to: '/case-studies', label: 'Case Studies' }} />
+          <Breadcrumbs item={{ to: '/learn', label: 'Learn' }} />
         </BreadcrumbsContainer>
-        <PageHeader>{header}</PageHeader>
-        <PageIntroMarkdown source={intro} />
+        <Heading1>{header}</Heading1>
+        <MarkdownContent source={intro} />
         {categories.map(category => {
           const caseStudies = category.caseStudies || [];
           return (
             <Fragment key={category.categoryId}>
-              <CategoryHeader id={category.categoryId}>
-                {category.header}
-              </CategoryHeader>
+              <Heading2 id={category.categoryId}>{category.header}</Heading2>
               <CardsContainer>
                 {caseStudies.map(caseStudy => (
                   <Grid

--- a/src/screens/Learn/CaseStudies/CaseStudy.style.ts
+++ b/src/screens/Learn/CaseStudies/CaseStudy.style.ts
@@ -1,85 +1,7 @@
 import styled from 'styled-components';
-import { Link } from 'react-router-dom';
-import { Card, CardContent, Grid } from '@material-ui/core';
-import ArrowForwardIosIcon from '@material-ui/icons/ArrowForwardIos';
-import { COLOR_MAP } from 'common/colors';
-import { COLORS } from 'common';
+import { Grid } from '@material-ui/core';
 import theme from 'assets/theme';
-import { StylesH2, StylesMarkdown, MarkdownContent } from 'components/Markdown';
-
-/*
- TODO (Chelsi): we're almost always removing the underline
- manually. Lets put this styled Link somewhere global ::
-*/
-export const StyledLink = styled(Link)`
-  text-decoration: none;
-`;
-
-export const StyledCard = styled(Card)`
-  box-shadow: none;
-  border: 1px solid ${COLORS.LIGHTGRAY};
-
-  &:hover {
-    border: 1px solid ${COLOR_MAP.GREEN.BASE};
-    /* Highlights the arrow icon on hover */
-    svg {
-      color: ${COLOR_MAP.GREEN.BASE};
-    }
-  }
-`;
-
-export const StyledCardContent = styled(CardContent)`
-  display: flex;
-  padding: ${theme.spacing(2)}px;
-`;
-
-export const CardsContainer = styled(Grid).attrs(props => ({
-  container: true,
-  spacing: 1,
-  alignItems: 'stretch',
-}))`
-  margin-bottom: ${theme.spacing(3)}px;
-  &:last-child {
-    margin-bottom: 0;
-  }
-`;
-
-export const CardLogo = styled.img.attrs(props => ({
-  height: 28,
-}))`
-  margin-bottom: ${1.5 * theme.spacing(1)}px;
-`;
-
-export const CardTitle = styled.h3`
-  font-size: 15px;
-  font-weight: 700;
-  color: #000;
-  margin: 0;
-`;
-
-export const CardBody = styled(MarkdownContent)`
-  p {
-    font-size: 14px;
-    line-height: 1.4;
-  }
-`;
-
-export const IconContainer = styled.div`
-  display: flex;
-  align-items: center;
-  margin-left: ${theme.spacing(2)}px;
-`;
-
-export const CopyContainer = styled.div`
-  flex-direction: column;
-`;
-
-export const ArrowIcon = styled(ArrowForwardIosIcon)`
-  color: ${COLOR_MAP.GRAY_ICON};
-  display: flex;
-  width: ${theme.spacing(2)}px;
-  height: ${theme.spacing(2)}px;
-`;
+import { StylesH2, StylesMarkdown } from 'components/Markdown';
 
 export const Logo = styled.img.attrs(props => ({
   height: '50px',
@@ -104,4 +26,15 @@ export const LearnMoreTitle = styled.h2`
 
 export const LearnMoreBody = styled.div`
   ${StylesMarkdown}
+`;
+
+export const CardsContainer = styled(Grid).attrs(props => ({
+  container: true,
+  spacing: 1,
+  alignItems: 'stretch',
+}))`
+  margin-bottom: ${theme.spacing(3)}px;
+  &:last-child {
+    margin-bottom: 0;
+  }
 `;

--- a/src/screens/Learn/CaseStudies/CaseStudy.style.ts
+++ b/src/screens/Learn/CaseStudies/CaseStudy.style.ts
@@ -1,16 +1,11 @@
 import styled from 'styled-components';
 import { Grid } from '@material-ui/core';
 import theme from 'assets/theme';
-import { StylesH2, StylesMarkdown } from 'components/Markdown';
+import { MarkdownContent } from 'components/Markdown';
 
 export const Logo = styled.img.attrs(props => ({
   height: '50px',
 }))``;
-
-export const CategoryHeader = styled.h2`
-  ${StylesH2};
-  margin-bottom: ${theme.spacing(2)}px;
-`;
 
 /**
  * More studies in the category and additional resources
@@ -20,21 +15,19 @@ export const LearnMoreSection = styled.div`
   margin-top: ${theme.spacing(4)}px;
 `;
 
-export const LearnMoreTitle = styled.h2`
-  ${StylesH2}
-`;
-
-export const LearnMoreBody = styled.div`
-  ${StylesMarkdown}
-`;
-
 export const CardsContainer = styled(Grid).attrs(props => ({
   container: true,
-  spacing: 1,
+  spacing: 2,
   alignItems: 'stretch',
 }))`
   margin-bottom: ${theme.spacing(3)}px;
   &:last-child {
     margin-bottom: 0;
+  }
+`;
+
+export const Author = styled(MarkdownContent)`
+  p {
+    font-size: 14px;
   }
 `;

--- a/src/screens/Learn/CaseStudies/CaseStudy.style.ts
+++ b/src/screens/Learn/CaseStudies/CaseStudy.style.ts
@@ -21,7 +21,6 @@ export const StyledCard = styled(Card)`
 
   &:hover {
     border: 1px solid ${COLOR_MAP.GREEN.BASE};
-
     /* Highlights the arrow icon on hover */
     svg {
       color: ${COLOR_MAP.GREEN.BASE};
@@ -32,11 +31,6 @@ export const StyledCard = styled(Card)`
 export const StyledCardContent = styled(CardContent)`
   display: flex;
   padding: ${theme.spacing(2)}px;
-`;
-
-export const CardsWrapper = styled(Grid)`
-  display: flex;
-  flex-wrap: wrap;
 `;
 
 export const CardsContainer = styled(Grid).attrs(props => ({
@@ -70,17 +64,21 @@ export const CardBody = styled(MarkdownContent)`
   }
 `;
 
-export const CardHalf = styled.div`
-  &:last-child {
-    display: flex;
-    align-items: center;
-    margin-left: 2rem;
-  }
+export const IconContainer = styled.div`
+  display: flex;
+  align-items: center;
+  margin-left: ${theme.spacing(2)}px;
+`;
+
+export const CopyContainer = styled.div`
+  flex-direction: column;
 `;
 
 export const ArrowIcon = styled(ArrowForwardIosIcon)`
   color: ${COLOR_MAP.GRAY_ICON};
   display: flex;
+  width: ${theme.spacing(2)}px;
+  height: ${theme.spacing(2)}px;
 `;
 
 export const Logo = styled.img.attrs(props => ({

--- a/src/screens/Learn/CaseStudies/CaseStudy.tsx
+++ b/src/screens/Learn/CaseStudies/CaseStudy.tsx
@@ -7,14 +7,14 @@ import {
   getMoreStudies,
 } from 'cms-content/learn';
 import * as Style from '../Learn.style';
-import {
-  Logo,
-  LearnMoreSection,
-  LearnMoreTitle,
-  LearnMoreBody,
-} from './CaseStudy.style';
+import { Logo, LearnMoreSection, Author } from './CaseStudy.style';
 import Breadcrumbs from 'components/Breadcrumbs';
-import { BodyCopyMarkdown } from '../Learn.style';
+import {
+  MarkdownContent,
+  Heading1,
+  Heading2,
+  MarkdownStyleContainer,
+} from 'components/Markdown';
 
 const CaseStudy: React.FC = () => {
   let { caseStudyId } = useParams<{ caseStudyId: string }>();
@@ -35,14 +35,14 @@ const CaseStudy: React.FC = () => {
         <Style.BreadcrumbsContainer>
           <Breadcrumbs item={{ to: '/case-studies', label: 'Case Studies' }} />
         </Style.BreadcrumbsContainer>
-        <Style.PageHeader>{header}</Style.PageHeader>
+        <Heading1>{header}</Heading1>
         <Logo src={caseStudy.logoUrl} alt={caseStudy.logoAltText} />
-        <BodyCopyMarkdown source={author} />
-        <BodyCopyMarkdown source={body} />
+        <Author source={author} />
+        <MarkdownContent source={body} />
         {studyCategory && otherCaseStudies.length > 0 && (
           <LearnMoreSection>
-            <LearnMoreTitle>{`More ${studyCategory.header.toLowerCase()} studies`}</LearnMoreTitle>
-            <LearnMoreBody>
+            <Heading2>{`More ${studyCategory.header.toLowerCase()} studies`}</Heading2>
+            <MarkdownStyleContainer>
               <ul>
                 {otherCaseStudies.map(study => (
                   <li key={study.caseStudyId}>
@@ -52,7 +52,7 @@ const CaseStudy: React.FC = () => {
                   </li>
                 ))}
               </ul>
-            </LearnMoreBody>
+            </MarkdownStyleContainer>
           </LearnMoreSection>
         )}
       </Style.PageContent>

--- a/src/screens/Learn/CaseStudies/CaseStudyCard.style.ts
+++ b/src/screens/Learn/CaseStudies/CaseStudyCard.style.ts
@@ -5,7 +5,7 @@ import ArrowForwardIosIcon from '@material-ui/icons/ArrowForwardIos';
 import { COLOR_MAP } from 'common/colors';
 import { COLORS } from 'common';
 import theme from 'assets/theme';
-import { MarkdownContent, StylesH3 } from 'components/Markdown';
+import { MarkdownContent, Heading3 } from 'components/Markdown';
 
 /*
  TODO (Chelsi): we're almost always removing the underline
@@ -39,9 +39,7 @@ export const CardLogo = styled.img.attrs(props => ({
   margin-bottom: ${1.5 * theme.spacing(1)}px;
 `;
 
-export const CardTitle = styled.h3`
-  ${StylesH3}
-`;
+export const CardTitle = Heading3;
 
 export const CardBody = styled(MarkdownContent)``;
 

--- a/src/screens/Learn/CaseStudies/CaseStudyCard.style.ts
+++ b/src/screens/Learn/CaseStudies/CaseStudyCard.style.ts
@@ -1,0 +1,63 @@
+import styled from 'styled-components';
+import { Link } from 'react-router-dom';
+import { Card, CardContent } from '@material-ui/core';
+import ArrowForwardIosIcon from '@material-ui/icons/ArrowForwardIos';
+import { COLOR_MAP } from 'common/colors';
+import { COLORS } from 'common';
+import theme from 'assets/theme';
+import { MarkdownContent, StylesH3 } from 'components/Markdown';
+
+/*
+ TODO (Chelsi): we're almost always removing the underline
+ manually. Lets put this styled Link somewhere global ::
+*/
+export const StyledLink = styled(Link)`
+  text-decoration: none;
+`;
+
+export const StyledCard = styled(Card)`
+  box-shadow: none;
+  border: 1px solid ${COLORS.LIGHTGRAY};
+
+  &:hover {
+    border: 1px solid ${COLOR_MAP.GREEN.BASE};
+    /* Highlights the arrow icon on hover */
+    svg {
+      color: ${COLOR_MAP.GREEN.BASE};
+    }
+  }
+`;
+
+export const StyledCardContent = styled(CardContent)`
+  display: flex;
+  padding: ${theme.spacing(2)}px;
+`;
+
+export const CardLogo = styled.img.attrs(props => ({
+  height: 28,
+}))`
+  margin-bottom: ${1.5 * theme.spacing(1)}px;
+`;
+
+export const CardTitle = styled.h3`
+  ${StylesH3}
+`;
+
+export const CardBody = styled(MarkdownContent)``;
+
+export const IconContainer = styled.div`
+  display: flex;
+  align-items: center;
+  margin-left: ${theme.spacing(2)}px;
+`;
+
+export const CopyContainer = styled.div`
+  flex-direction: column;
+`;
+
+export const ArrowIcon = styled(ArrowForwardIosIcon)`
+  color: ${COLOR_MAP.GRAY_ICON};
+  display: flex;
+  width: ${theme.spacing(2)}px;
+  height: ${theme.spacing(2)}px;
+`;

--- a/src/screens/Learn/CaseStudies/CaseStudyCard.tsx
+++ b/src/screens/Learn/CaseStudies/CaseStudyCard.tsx
@@ -4,10 +4,11 @@ import {
   StyledCard,
   StyledCardContent,
   CardTitle,
-  CardHalf,
   ArrowIcon,
   CardLogo,
   CardBody,
+  CopyContainer,
+  IconContainer,
 } from './CaseStudy.style';
 import { CaseStudy } from 'cms-content/learn';
 
@@ -18,14 +19,14 @@ const CaseStudyCard = (props: { cardContent: CaseStudy; url: string }) => {
     <StyledCard>
       <StyledLink to={`${url}/${caseStudyId}`}>
         <StyledCardContent>
-          <CardHalf>
+          <CopyContainer>
             <CardLogo src={cardContent.logoUrl} alt={cardContent.logoAltText} />
             <CardTitle>{shortTitle}</CardTitle>
             <CardBody source={summary} />
-          </CardHalf>
-          <CardHalf>
+          </CopyContainer>
+          <IconContainer>
             <ArrowIcon />
-          </CardHalf>
+          </IconContainer>
         </StyledCardContent>
       </StyledLink>
     </StyledCard>

--- a/src/screens/Learn/CaseStudies/CaseStudyCard.tsx
+++ b/src/screens/Learn/CaseStudies/CaseStudyCard.tsx
@@ -9,7 +9,7 @@ import {
   CardBody,
   CopyContainer,
   IconContainer,
-} from './CaseStudy.style';
+} from './CaseStudyCard.style';
 import { CaseStudy } from 'cms-content/learn';
 
 const CaseStudyCard = (props: { cardContent: CaseStudy; url: string }) => {

--- a/src/screens/Learn/CaseStudies/CaseStudyCard.tsx
+++ b/src/screens/Learn/CaseStudies/CaseStudyCard.tsx
@@ -3,14 +3,13 @@ import {
   StyledLink,
   StyledCard,
   StyledCardContent,
-  CardTitle,
   ArrowIcon,
   CardLogo,
-  CardBody,
   CopyContainer,
   IconContainer,
 } from './CaseStudyCard.style';
 import { CaseStudy } from 'cms-content/learn';
+import { MarkdownContent, Heading3 } from 'components/Markdown';
 
 const CaseStudyCard = (props: { cardContent: CaseStudy; url: string }) => {
   const { cardContent, url } = props;
@@ -21,8 +20,8 @@ const CaseStudyCard = (props: { cardContent: CaseStudy; url: string }) => {
         <StyledCardContent>
           <CopyContainer>
             <CardLogo src={cardContent.logoUrl} alt={cardContent.logoAltText} />
-            <CardTitle>{shortTitle}</CardTitle>
-            <CardBody source={summary} />
+            <Heading3>{shortTitle}</Heading3>
+            <MarkdownContent source={summary} />
           </CopyContainer>
           <IconContainer>
             <ArrowIcon />

--- a/src/screens/Learn/Faq/Faq.tsx
+++ b/src/screens/Learn/Faq/Faq.tsx
@@ -1,10 +1,8 @@
 import React from 'react';
 import {
   PageContainer,
-  PageHeader,
   PageContent,
   BreadcrumbsContainer,
-  PageIntroMarkdown,
 } from '../Learn.style';
 import Section from './Section';
 import { faqContent, FaqSection } from 'cms-content/learn';
@@ -13,6 +11,7 @@ import AppMetaTags from 'components/AppMetaTags/AppMetaTags';
 import * as Style from './Faq.style';
 import Breadcrumbs from 'components/Breadcrumbs';
 import { formatMetatagDate } from 'common/utils';
+import { MarkdownContent, Heading1 } from 'components/Markdown';
 
 const Faq = () => {
   const {
@@ -42,8 +41,8 @@ const Faq = () => {
         <BreadcrumbsContainer>
           <Breadcrumbs item={{ to: '/learn', label: 'Learn' }} />
         </BreadcrumbsContainer>
-        <PageHeader>{header}</PageHeader>
-        <PageIntroMarkdown source={intro} />
+        <Heading1>{header}</Heading1>
+        <MarkdownContent source={intro} />
         <Style.MobileOnly>
           <TableOfContents items={getSectionItems(sections)} />
         </Style.MobileOnly>

--- a/src/screens/Learn/Faq/Section.tsx
+++ b/src/screens/Learn/Faq/Section.tsx
@@ -1,8 +1,8 @@
 import React, { Fragment } from 'react';
 import { StyledAccordion } from 'components/SharedComponents';
-import { SectionHeader } from '../Learn.style';
 import { FaqSection, Question } from 'cms-content/learn';
 import { Anchor } from 'components/TableOfContents';
+import { Heading2 } from 'components/Markdown';
 
 const Section = (props: { content: FaqSection }) => {
   const { content } = props;
@@ -10,10 +10,10 @@ const Section = (props: { content: FaqSection }) => {
 
   return (
     <Fragment>
-      <SectionHeader>
+      <Heading2>
         <Anchor id={content.sectionId} />
         {sectionTitle}
-      </SectionHeader>
+      </Heading2>
       {questions.map((item: Question, i: number) => (
         <StyledAccordion
           key={`accordion-question-${i}`}

--- a/src/screens/Learn/Glossary/Glossary.tsx
+++ b/src/screens/Learn/Glossary/Glossary.tsx
@@ -3,10 +3,8 @@ import { useLocation } from 'react-router-dom';
 import { sortBy, without } from 'lodash';
 import {
   PageContainer,
-  PageHeader,
   PageContent,
   BreadcrumbsContainer,
-  PageIntroMarkdown,
 } from '../Learn.style';
 import AppMetaTags from 'components/AppMetaTags/AppMetaTags';
 import { StyledAccordion } from 'components/SharedComponents';
@@ -15,6 +13,7 @@ import Breadcrumbs from 'components/Breadcrumbs';
 import { Anchor } from 'components/TableOfContents';
 import { formatMetatagDate } from 'common/utils';
 import { trackEvent, EventAction, EventCategory } from 'components/Analytics';
+import { MarkdownContent, Heading1 } from 'components/Markdown';
 
 const Glossary = () => {
   const {
@@ -61,8 +60,8 @@ const Glossary = () => {
         <BreadcrumbsContainer>
           <Breadcrumbs item={{ to: '/learn', label: 'Learn' }} />
         </BreadcrumbsContainer>
-        <PageHeader>{header}</PageHeader>
-        <PageIntroMarkdown source={intro} />
+        <Heading1>{header}</Heading1>
+        <MarkdownContent source={intro} />
         {terms.map((item: Term) => (
           <Fragment key={item.termId}>
             <Anchor id={item.termId} />

--- a/src/screens/Learn/Landing/Landing.tsx
+++ b/src/screens/Learn/Landing/Landing.tsx
@@ -1,19 +1,12 @@
 import React, { Fragment } from 'react';
-import {
-  PageContainer,
-  PageContent,
-  PageHeader,
-  SectionHeader,
-  BodyCopyMarkdown,
-  PageIntroMarkdown,
-  ButtonContainer,
-} from '../Learn.style';
+import { PageContainer, PageContent, ButtonContainer } from '../Learn.style';
 import AppMetaTags from 'components/AppMetaTags/AppMetaTags';
 import SectionButton, { ButtonTheme } from './SectionButton';
 // import TableOfContents, { Item } from 'components/TableOfContents';
 import { Anchor } from 'components/TableOfContents';
 import { formatMetatagDate } from 'common/utils';
 import { LandingSection, landingPageContent } from 'cms-content/learn';
+import { Heading1, Heading2, MarkdownContent } from 'components/Markdown';
 
 /*
   Commenting out all things related to the table of contents, since we only have 2 items as of now.
@@ -45,16 +38,16 @@ const Landing = () => {
         pageDescription={`${date} ${metadataDescription}`}
       />
       <PageContent>
-        <PageHeader>{header}</PageHeader>
-        <PageIntroMarkdown source={intro} />
+        <Heading1>{header}</Heading1>
+        <MarkdownContent source={intro} />
         {/* <TableOfContents items={getSectionItems(sections)} /> */}
         {sections.map((section: LandingSection) => (
           <Fragment key={section.sectionId}>
-            <SectionHeader>
+            <Heading2>
               <Anchor id={section.sectionId} />
               {section.sectionTitle}
-            </SectionHeader>
-            <BodyCopyMarkdown source={section.description} />
+            </Heading2>
+            <MarkdownContent source={section.description} />
             <ButtonContainer>
               <SectionButton
                 cta={section.buttonCta}

--- a/src/screens/Learn/Landing/SectionButton.style.tsx
+++ b/src/screens/Learn/Landing/SectionButton.style.tsx
@@ -13,8 +13,7 @@ const SharedButtonStyles = css`
   text-transform: none;
   text-decoration: none;
   color: inherit;
-  padding-left: ${1.5 * theme.spacing(1)}px;
-  padding-right: ${1.5 * theme.spacing(1)}px;
+  padding: ${0.5 * theme.spacing(1)}px ${theme.spacing(2)};
 `;
 
 export const GreenButton = styled(MuiButton)`

--- a/src/screens/Learn/Learn.style.tsx
+++ b/src/screens/Learn/Learn.style.tsx
@@ -1,9 +1,4 @@
 import styled from 'styled-components';
-import {
-  MarkdownContent,
-  StylesH2,
-  StylesBlockQuoteHighlight,
-} from 'components/Markdown';
 import theme from 'assets/theme';
 import { mobileBreakpoint } from 'assets/theme/sizes';
 
@@ -27,15 +22,6 @@ export const PageContent = styled.main`
   padding: 0 1.25rem;
 `;
 
-export const PageHeader = styled.h1`
-  margin: ${theme.spacing(1)}px 0 ${theme.spacing(3)}px 0;
-  line-height: 125%;
-`;
-
-export const SectionHeader = styled.h2`
-  ${StylesH2}
-`;
-
 export const BreadcrumbsContainer = styled.div`
   margin-bottom: ${theme.spacing(2)}px;
 `;
@@ -43,19 +29,4 @@ export const BreadcrumbsContainer = styled.div`
 export const ButtonContainer = styled.div`
   margin-top: ${theme.spacing(2)}px;
   margin-bottom: ${theme.spacing(3)}px;
-`;
-/*
-  Markdown styles used throughout Learn
-*/
-
-export const PageIntroMarkdown = styled(MarkdownContent)`
-  p::last-child {
-    margin-bottom: ${theme.spacing(4)}px;
-  }
-`;
-
-export const BodyCopyMarkdown = styled(MarkdownContent)`
-  blockquote {
-    ${StylesBlockQuoteHighlight}
-  }
 `;


### PR DESCRIPTION
This PR updates and centralize the styles for Learn pages, mostly on typography and spacing around elements.

## Typography

On Learn pages, we have paragraphs and headings both inside and outside markdown blocks. We need headings and spacing to be consistent in both cases. For example, the [Case Studies landing page](https://covid-projections-git-pablo-case-studies-ux-feedback.covidactnow.vercel.app/case-studies) uses `h2` elements for category names, but in the [California Department of Public Health](https://covid-projections-git-pablo-case-studies-ux-feedback.covidactnow.vercel.app/case-studies/cdph-calcat) case study, the `h2` level is part of the markdown content added via the CMS.

One solution to keep both consistent is to export the headings from the `Markdown` component and use them directly in the different pages. The corresponding css styles are also used to style the markdown block, keeping both in sync.

Note that I renamed the css styles to use lowercase ([`blockquoteCss`](https://github.com/covid-projections/covid-projections/pull/1840/files#diff-cd4f7ea90f8a6e457c4d21791fe0538c46773f5184c1c00189b3cdcea0257f72R41)), to signify that they are just string templates and not proper components (as opposed to [`Blockquote`](https://github.com/covid-projections/covid-projections/pull/1840/files#diff-cd4f7ea90f8a6e457c4d21791fe0538c46773f5184c1c00189b3cdcea0257f72R77), which is a component). 


## Other Changes
- Updated the styles following [Josh's feedback](https://www.dropbox.com/scl/fi/k8i2ghrsnpo3ujudb9ptw/Case-Studies.paper?dl=0&rlkey=j9arieg6ytdw6inhigymd7090#:uid=843721934345494409872287&h2=Feedback-and-Bugs) 
- Adjusts the padding on the Buttons for the Learn landing page