### PR TITLE
fix the size of the status labels on embed

### DIFF
--- a/src/components/SignalStatus/SignalStatus.style.tsx
+++ b/src/components/SignalStatus/SignalStatus.style.tsx
@@ -12,14 +12,13 @@ export const SignalStatusWrapper = styled(Box)<{
       monospace;
     font-weight: bold;
     font-size: ${props.isEmbed ? '13px' : '0.875rem'};
-    width: 4.5rem;
+    width: 5rem;
     margin-left: 1rem;
     line-height: 1.25rem;
     display: flex;
     align-items: center;
 
     svg {
-      width: 1rem;
       margin-right: 0.25rem;
     }
   `

--- a/src/components/SignalStatus/SignalStatus.style.tsx
+++ b/src/components/SignalStatus/SignalStatus.style.tsx
@@ -12,7 +12,7 @@ export const SignalStatusWrapper = styled(Box)<{
       monospace;
     font-weight: bold;
     font-size: ${props.isEmbed ? '13px' : '0.875rem'};
-    width: 5rem;
+    width: 5.5rem;
     margin-left: 1rem;
     line-height: 1.25rem;
     display: flex;


### PR DESCRIPTION
[Trello](https://trello.com/c/4LNZymF4/555-embed-icon-for-daily-new-cases-is-smaller-than-the-rest) - This PR adjusts the space shared by the warning icon and the word "Critical" to make sure that they fit in the embed. 

- [Standalone](https://covid-projections-git-pablo-fix-embed-icon.covidactnow.vercel.app/embed/us/indiana-in)
- [Location Page](https://covid-projections-git-pablo-fix-embed-icon.covidactnow.vercel.app/us/indiana-in)

Before
![image](https://user-images.githubusercontent.com/114084/98591010-7b06c200-2284-11eb-8785-5ace4bab5788.png)


After
![image](https://user-images.githubusercontent.com/114084/98590991-73471d80-2284-11eb-844d-fb4030471b67.png)
