### PR TITLE
fix some explore search quirks

### DIFF
--- a/src/components/AutocompleteLocations/AutocompleteLocations.tsx
+++ b/src/components/AutocompleteLocations/AutocompleteLocations.tsx
@@ -1,8 +1,13 @@
 import React from 'react';
 import Autocomplete from '@material-ui/lab/Autocomplete';
+import { createFilterOptions } from '@material-ui/lab/useAutocomplete';
 import TextField from '@material-ui/core/TextField';
 import { Location } from 'common/locations';
-import { createFilterOptions } from '@material-ui/lab/useAutocomplete';
+/**
+ * `createFilterOptions` creates a configuration object that defines how the
+ * user input will be matched against the options in the Autocomplete
+ * component. See material-ui/lab/useAutocomplete.js for additional options.
+ */
 
 function getLocationLabel(location: Location) {
   return location.county
@@ -24,19 +29,21 @@ const AutocompleteLocations: React.FC<{
     event: React.ChangeEvent<{}>,
     newLocations: Location[],
   ) => void;
-}> = ({ locations, onChangeLocations, selectedLocations }) => (
-  <Autocomplete
-    multiple
-    options={locations}
-    getOptionLabel={getLocationLabel}
-    onChange={onChangeLocations}
-    getOptionSelected={getOptionSelected}
-    value={selectedLocations}
-    filterOptions={createFilterOptions({ matchFrom: 'start', trim: true })}
-    renderInput={params => (
-      <TextField variant="outlined" {...params} placeholder="+ Add" />
-    )}
-  />
-);
+}> = ({ locations, onChangeLocations, selectedLocations }) => {
+  return (
+    <Autocomplete
+      multiple
+      options={locations}
+      getOptionLabel={getLocationLabel}
+      onChange={onChangeLocations}
+      getOptionSelected={getOptionSelected}
+      value={selectedLocations}
+      filterOptions={createFilterOptions({ matchFrom: 'start', trim: true })}
+      renderInput={params => (
+        <TextField variant="outlined" {...params} placeholder="+ Add" />
+      )}
+    />
+  );
+};
 
 export default AutocompleteLocations;

--- a/src/components/AutocompleteLocations/AutocompleteLocations.tsx
+++ b/src/components/AutocompleteLocations/AutocompleteLocations.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import Autocomplete from '@material-ui/lab/Autocomplete';
 import TextField from '@material-ui/core/TextField';
 import { Location } from 'common/locations';
+import { createFilterOptions } from '@material-ui/lab/useAutocomplete';
 
 function getLocationLabel(location: Location) {
   return location.county
@@ -31,6 +32,7 @@ const AutocompleteLocations: React.FC<{
     onChange={onChangeLocations}
     getOptionSelected={getOptionSelected}
     value={selectedLocations}
+    filterOptions={createFilterOptions({ matchFrom: 'start' })}
     renderInput={params => (
       <TextField variant="outlined" {...params} placeholder="+ Add" />
     )}

--- a/src/components/AutocompleteLocations/AutocompleteLocations.tsx
+++ b/src/components/AutocompleteLocations/AutocompleteLocations.tsx
@@ -6,7 +6,15 @@ import { Location } from 'common/locations';
 /**
  * `createFilterOptions` creates a configuration object that defines how the
  * user input will be matched against the options in the Autocomplete
- * component. See material-ui/lab/useAutocomplete.js for additional options.
+ * component.
+ *
+ * The input of the user will be compared with the output of `getOptionLabel`
+ * applied to each location. The option `matchFrom: 'start'` means that the
+ * beginning of the option label needs to match with the user input. For
+ * example, if the user types "king", "King County, TX" and "Kingfisher County, OR"
+ * will be a match (among others), but not "Rockingham County, NC".
+ *
+ * See material-ui/lab/useAutocomplete.js for additional options.
  */
 
 function getLocationLabel(location: Location) {
@@ -37,7 +45,7 @@ const AutocompleteLocations: React.FC<{
     onChange={onChangeLocations}
     getOptionSelected={getOptionSelected}
     value={selectedLocations}
-    filterOptions={createFilterOptions({ matchFrom: 'start', trim: true })}
+    filterOptions={createFilterOptions({ matchFrom: 'start' })}
     renderInput={params => (
       <TextField variant="outlined" {...params} placeholder="+ Add" />
     )}

--- a/src/components/AutocompleteLocations/AutocompleteLocations.tsx
+++ b/src/components/AutocompleteLocations/AutocompleteLocations.tsx
@@ -29,21 +29,19 @@ const AutocompleteLocations: React.FC<{
     event: React.ChangeEvent<{}>,
     newLocations: Location[],
   ) => void;
-}> = ({ locations, onChangeLocations, selectedLocations }) => {
-  return (
-    <Autocomplete
-      multiple
-      options={locations}
-      getOptionLabel={getLocationLabel}
-      onChange={onChangeLocations}
-      getOptionSelected={getOptionSelected}
-      value={selectedLocations}
-      filterOptions={createFilterOptions({ matchFrom: 'start', trim: true })}
-      renderInput={params => (
-        <TextField variant="outlined" {...params} placeholder="+ Add" />
-      )}
-    />
-  );
-};
+}> = ({ locations, onChangeLocations, selectedLocations }) => (
+  <Autocomplete
+    multiple
+    options={locations}
+    getOptionLabel={getLocationLabel}
+    onChange={onChangeLocations}
+    getOptionSelected={getOptionSelected}
+    value={selectedLocations}
+    filterOptions={createFilterOptions({ matchFrom: 'start', trim: true })}
+    renderInput={params => (
+      <TextField variant="outlined" {...params} placeholder="+ Add" />
+    )}
+  />
+);
 
 export default AutocompleteLocations;

--- a/src/components/AutocompleteLocations/AutocompleteLocations.tsx
+++ b/src/components/AutocompleteLocations/AutocompleteLocations.tsx
@@ -32,7 +32,7 @@ const AutocompleteLocations: React.FC<{
     onChange={onChangeLocations}
     getOptionSelected={getOptionSelected}
     value={selectedLocations}
-    filterOptions={createFilterOptions({ matchFrom: 'start' })}
+    filterOptions={createFilterOptions({ matchFrom: 'start', trim: true })}
     renderInput={params => (
       <TextField variant="outlined" {...params} placeholder="+ Add" />
     )}

--- a/src/components/Explore/utils.ts
+++ b/src/components/Explore/utils.ts
@@ -8,6 +8,7 @@ import {
   range,
   words,
   partition,
+  sortBy,
 } from 'lodash';
 import { color } from 'd3-color';
 import { schemeCategory10 } from 'd3-scale-chromatic';
@@ -446,10 +447,30 @@ export function getAutocompleteLocations(locationFips: string) {
     belongsToState(county, currentLocation.state_fips_code),
   );
 
+  const sortedStates = sortBy(states, location => location.state);
+  const sortedStateCounties = sortBy(
+    stateCounties,
+    location => location.county,
+  );
+  const sortedOtherCounties = sortBy(
+    otherCounties,
+    location => location.county,
+  );
+
   // TODO(michael): Where should aggregations go in the list?
   return isStateFips(locationFips)
-    ? [...AGGREGATED_LOCATIONS, ...states, ...stateCounties, ...otherCounties]
-    : [...AGGREGATED_LOCATIONS, ...stateCounties, ...states, ...otherCounties];
+    ? [
+        ...AGGREGATED_LOCATIONS,
+        ...sortedStates,
+        ...sortedStateCounties,
+        ...sortedOtherCounties,
+      ]
+    : [
+        ...AGGREGATED_LOCATIONS,
+        ...sortedStateCounties,
+        ...sortedStates,
+        ...sortedOtherCounties,
+      ];
 }
 
 /**


### PR DESCRIPTION
[Trello](https://trello.com/c/fKbc9J9l/543-explore-search-has-sorting-quirks-for-states-and-especially-counties) - Explore search has sorting quirks for states and especially counties

This PR fixes the quirks, in particular:
- Sort the locations alphabetically, preserving the order of each group (i.e., aggregated, states, state counties, other counties),  (`Alabama` shows before `Alaska`)
- Only match strings from the start of the string (`king` will match `Kings County, TX` and `Kingfisher County, OR` but not `Hocking County, OH`)

The filter options are not super well documented, but the source code is fairly straightforward, see [material-ui/src/useAutocomplete/useAutocomplete.js](https://github.com/mui-org/material-ui/blob/4d50a9ed6a7c2007b9e5061d0842f38df191cfb2/packages/material-ui/src/useAutocomplete/useAutocomplete.js) 