### PR TITLE
adjust ticks on metric charts

### DIFF
--- a/src/components/Charts/Axis.tsx
+++ b/src/components/Charts/Axis.tsx
@@ -18,8 +18,8 @@ export const AxisBottom = (props: SharedAxisProps<Date>) => {
   const dateFormat = isSmallDevice ? 'MMM' : 'MMM DD';
 
   const tickValues = isSmallDevice
-    ? timeMonth.range(dateStart, dateStop, 1)
-    : timeDay.range(dateStart, dateStop, 14);
+    ? timeMonth.range(dateStart, dateStop, 2)
+    : timeDay.range(dateStart, dateStop, 21);
 
   return (
     <Style.Axis>


### PR DESCRIPTION
This PR adjusts the separation between the ticks on the x-axis for metric charts. It's just a stop gap while I work on a more definitive solution.