### PR TITLE
remove case studies categories from the sidebar on case study pages

### DIFF
--- a/src/cms-content/learn/index.ts
+++ b/src/cms-content/learn/index.ts
@@ -1,4 +1,4 @@
-import { chain, keyBy, reject } from 'lodash';
+import { chain, keyBy, reject, omit } from 'lodash';
 import faq from './learn-faq.json';
 import glossary from './learn-glossary.json';
 import landing from './learn-landing.json';
@@ -157,8 +157,7 @@ export function getMoreStudies(caseStudyId: string): CaseStudy[] {
 
 export const caseStudiesContent = caseStudies as CaseStudiesContent;
 
-// TODO (pablo): Should we have a short heading for categories?
-export const learnPages: TocItem[] = [
+export const sidebarItemsLearn: TocItem[] = [
   { label: 'Glossary', to: '/glossary' },
   {
     label: 'FAQ',
@@ -177,6 +176,11 @@ export const learnPages: TocItem[] = [
     })),
   },
 ];
+
+// The hierarchy of sidebarItemsLearn doesn't make sense on the Case Study page
+export const sidebarItemsCaseStudy: TocItem[] = sidebarItemsLearn.map(
+  pageItem => omit(pageItem, 'items'),
+);
 
 /**
  * Products - landing page:

--- a/src/components/PageContent/PageContent.tsx
+++ b/src/components/PageContent/PageContent.tsx
@@ -10,14 +10,14 @@ import {
   DesktopOnly,
 } from './PageContent.style';
 
-const PageContent: React.FC<{ sidebarItems: TocItem[] }> = ({
+const PageContent: React.FC<{ sidebarItems?: TocItem[] }> = ({
   children,
   sidebarItems,
-}) => {
-  return (
-    <Fragment>
-      <PageContainer>
-        <MainContent>{children}</MainContent>
+}) => (
+  <Fragment>
+    <PageContainer>
+      <MainContent>{children}</MainContent>
+      {sidebarItems && sidebarItems.length > 0 && (
         <DesktopOnly>
           <Sidebar>
             <Sticky>
@@ -25,10 +25,10 @@ const PageContent: React.FC<{ sidebarItems: TocItem[] }> = ({
             </Sticky>
           </Sidebar>
         </DesktopOnly>
-      </PageContainer>
-      <ShareBlock />
-    </Fragment>
-  );
-};
+      )}
+    </PageContainer>
+    <ShareBlock />
+  </Fragment>
+);
 
 export default PageContent;

--- a/src/screens/Learn/CaseStudies/CaseStudiesLanding.tsx
+++ b/src/screens/Learn/CaseStudies/CaseStudiesLanding.tsx
@@ -8,7 +8,7 @@ import Breadcrumbs from 'components/Breadcrumbs';
 import PageContent from 'components/PageContent';
 import { MarkdownContent, Heading1, Heading2 } from 'components/Markdown';
 import { formatMetatagDate } from 'common/utils';
-import { caseStudiesContent, learnPages } from 'cms-content/learn';
+import { caseStudiesContent, sidebarItemsLearn } from 'cms-content/learn';
 import CaseStudyCard from './CaseStudyCard';
 import { BreadcrumbsContainer } from '../Learn.style';
 import { CardsContainer } from './CaseStudy.style';
@@ -36,7 +36,7 @@ const Landing: React.FC = () => {
         pageTitle={metadataTitle}
         pageDescription={`${date} ${metadataDescription}`}
       />
-      <PageContent sidebarItems={learnPages}>
+      <PageContent sidebarItems={sidebarItemsLearn}>
         <BreadcrumbsContainer>
           <Breadcrumbs item={{ to: '/learn', label: 'Learn' }} />
         </BreadcrumbsContainer>

--- a/src/screens/Learn/CaseStudies/CaseStudy.tsx
+++ b/src/screens/Learn/CaseStudies/CaseStudy.tsx
@@ -15,7 +15,6 @@ import {
   getCaseStudyCategory,
   getMoreStudies,
   caseStudiesContent,
-  sidebarItemsCaseStudy,
 } from 'cms-content/learn';
 import * as Style from '../Learn.style';
 import {
@@ -48,7 +47,7 @@ const CaseStudy: React.FC = () => {
         pageTitle={`Case Study: ${caseStudy.shortTitle}`}
         pageDescription={`${date} ${metadataDescription}`}
       />
-      <PageContent sidebarItems={sidebarItemsCaseStudy}>
+      <PageContent>
         <Style.BreadcrumbsContainer>
           <Breadcrumbs item={{ to: '/case-studies', label: 'Case Studies' }} />
         </Style.BreadcrumbsContainer>

--- a/src/screens/Learn/CaseStudies/CaseStudy.tsx
+++ b/src/screens/Learn/CaseStudies/CaseStudy.tsx
@@ -14,8 +14,8 @@ import {
   caseStudiesById,
   getCaseStudyCategory,
   getMoreStudies,
-  learnPages,
   caseStudiesContent,
+  sidebarItemsCaseStudy,
 } from 'cms-content/learn';
 import * as Style from '../Learn.style';
 import {
@@ -48,7 +48,7 @@ const CaseStudy: React.FC = () => {
         pageTitle={`Case Study: ${caseStudy.shortTitle}`}
         pageDescription={`${date} ${metadataDescription}`}
       />
-      <PageContent sidebarItems={learnPages}>
+      <PageContent sidebarItems={sidebarItemsCaseStudy}>
         <Style.BreadcrumbsContainer>
           <Breadcrumbs item={{ to: '/case-studies', label: 'Case Studies' }} />
         </Style.BreadcrumbsContainer>

--- a/src/screens/Learn/Faq/Faq.tsx
+++ b/src/screens/Learn/Faq/Faq.tsx
@@ -5,7 +5,7 @@ import AppMetaTags from 'components/AppMetaTags/AppMetaTags';
 import Breadcrumbs from 'components/Breadcrumbs';
 import { MarkdownContent, Heading1 } from 'components/Markdown';
 import PageContent, { MobileOnly } from 'components/PageContent';
-import { faqContent, FaqSection, learnPages } from 'cms-content/learn';
+import { faqContent, FaqSection, sidebarItemsLearn } from 'cms-content/learn';
 import { BreadcrumbsContainer } from '../Learn.style';
 import Section from './Section';
 
@@ -33,7 +33,7 @@ const Faq: React.FC = () => {
         pageTitle={metadataTitle}
         pageDescription={`${date} ${metadataDescription}`}
       />
-      <PageContent sidebarItems={learnPages}>
+      <PageContent sidebarItems={sidebarItemsLearn}>
         <BreadcrumbsContainer>
           <Breadcrumbs item={{ to: '/learn', label: 'Learn' }} />
         </BreadcrumbsContainer>

--- a/src/screens/Learn/Glossary/Glossary.tsx
+++ b/src/screens/Learn/Glossary/Glossary.tsx
@@ -7,7 +7,7 @@ import { StyledAccordion } from 'components/SharedComponents';
 import { trackEvent, EventAction, EventCategory } from 'components/Analytics';
 import { MarkdownContent, Heading1 } from 'components/Markdown';
 import PageContent from 'components/PageContent';
-import { glossaryContent, Term, learnPages } from 'cms-content/learn';
+import { glossaryContent, Term, sidebarItemsLearn } from 'cms-content/learn';
 import Breadcrumbs from 'components/Breadcrumbs';
 import { Anchor } from 'components/TableOfContents';
 import { formatMetatagDate } from 'common/utils';
@@ -53,7 +53,7 @@ const Glossary: React.FC = () => {
         pageTitle={metadataTitle}
         pageDescription={`${date} ${metadataDescription}`}
       />
-      <PageContent sidebarItems={learnPages}>
+      <PageContent sidebarItems={sidebarItemsLearn}>
         <BreadcrumbsContainer>
           <Breadcrumbs item={{ to: '/learn', label: 'Learn' }} />
         </BreadcrumbsContainer>

--- a/src/screens/Learn/Landing/Landing.tsx
+++ b/src/screens/Learn/Landing/Landing.tsx
@@ -7,7 +7,7 @@ import { Anchor } from 'components/TableOfContents';
 import {
   LandingSection,
   landingPageContent,
-  learnPages,
+  sidebarItemsLearn,
 } from 'cms-content/learn';
 import SectionButton, { ButtonTheme } from './SectionButton';
 import { ButtonContainer } from '../Learn.style';
@@ -30,7 +30,7 @@ const Landing: React.FC = () => {
         pageTitle={metadataTitle}
         pageDescription={`${date} ${metadataDescription}`}
       />
-      <PageContent sidebarItems={learnPages}>
+      <PageContent sidebarItems={sidebarItemsLearn}>
         <Heading1>{header}</Heading1>
         <MarkdownContent source={intro} />
         {sections.map((section: LandingSection) => (


### PR DESCRIPTION
The sidebar on the case study page shouldn't have the categories on it, because the page itself doesn't show categories (none of them will be highlighted)

![image](https://user-images.githubusercontent.com/114084/98723057-b23da780-2346-11eb-9c49-7f0ba6847479.png)

A solution is just to not show the categories on the case study page.