### PR TITLE
add google ads tracking

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -88,6 +88,22 @@
     fbq('init', '692591964861759');
     fbq('track', 'PageView');
   </script>
+
+  <!-- Global site tag (gtag.js) - Google Ads: 527465415 -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=AW-527465415"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag() { dataLayer.push(arguments); }
+    gtag('js', new Date());
+    gtag('config', 'AW-527465415');
+  </script>
+
+  <!-- Event snippet for Website traffic conversion page -->
+  <script>
+    gtag('event', 'conversion', { 'send_to': 'AW-527465415/lRyqCM2a9-kBEMf3wfsB' });
+  </script>
+
+
   <noscript>
     <img height="1" width="1" src="https://www.facebook.com/tr?id=692591964861759&ev=PageView
       &noscript=1" />


### PR DESCRIPTION
[Trello Card](https://trello.com/c/hVhZfGvt/591-add-google-ads-tags-to-the-website) - Add Google Ads tracking to the website

I thought that this script was already included when initializing Google Analytics in [PageviewTracker.tsx](https://github.com/covid-projections/covid-projections/blob/develop/src/components/Analytics/PageviewTracker.tsx), but I inspected the network requests and it seems that is not the case. 🤷‍♂️ 