### PR TITLE
Use latest setup-node action to fix broken CI.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
 
-      - uses: actions/setup-node@v1.1.0
+      - uses: actions/setup-node@v1
         with:
           node-version: '10.x'
 


### PR DESCRIPTION
MY [PR](https://github.com/covid-projections/covid-projections/pull/1912/checks?check_run_id=1409629678) failed with:
![image](https://user-images.githubusercontent.com/206364/99327578-17a20480-282f-11eb-9392-cd96ee7d7822.png)

Looks like github made a [breaking change](https://github.blog/changelog/2020-11-09-github-actions-removing-set-env-and-add-path-commands-on-november-16/).

This seems to fix it!