### PR TITLE
explainers: thermometer component

### DIFF
--- a/src/common/metric.tsx
+++ b/src/common/metric.tsx
@@ -64,7 +64,7 @@ const metricDefinitions: { [metric in Metric]: MetricDefinition } = {
   [Metric.CASE_DENSITY]: CaseDensity.CaseIncidenceMetric,
 };
 
-function getMetricDefinition(metric: Metric) {
+export function getMetricDefinition(metric: Metric) {
   if (!(metric in metricDefinitions)) {
     fail('unknown metric');
   }

--- a/src/common/metrics/case_density.tsx
+++ b/src/common/metrics/case_density.tsx
@@ -9,11 +9,13 @@ import {
   formatEstimate,
 } from 'common/utils';
 import ExternalLink from 'components/ExternalLink';
+import Thermometer from 'components/Thermometer';
 import { MetricDefinition } from './interfaces';
 
 export const CaseIncidenceMetric: MetricDefinition = {
   renderStatus,
   renderDisclaimer,
+  renderThermometer,
   metricName: 'Daily new cases',
   extendedMetricName: 'Daily new cases per 100k population',
   metricNameForCompare: `Daily new cases per 100k`,
@@ -135,4 +137,44 @@ function renderDisclaimer(): React.ReactElement {
       .
     </Fragment>
   );
+}
+
+function renderThermometer(): React.ReactElement {
+  const levelInfo = CASE_DENSITY_LEVEL_INFO_MAP;
+  const levelCritical = levelInfo[Level.CRITICAL];
+  const levelHigh = levelInfo[Level.HIGH];
+  const levelMedium = levelInfo[Level.MEDIUM];
+  const levelLow = levelInfo[Level.LOW];
+
+  const items = [
+    {
+      title: `Over ${levelHigh.upperLimit}`,
+      description: levelCritical.detail(),
+      color: levelCritical.color,
+      roundTop: true,
+      roundBottom: false,
+    },
+    {
+      title: `${levelMedium.upperLimit} - ${levelHigh.upperLimit}`,
+      description: levelHigh.detail(),
+      color: levelHigh.color,
+      roundTop: false,
+      roundBottom: false,
+    },
+    {
+      title: `${levelLow.upperLimit} - ${levelMedium.upperLimit}`,
+      description: levelMedium.detail(),
+      color: levelMedium.color,
+      roundTop: false,
+      roundBottom: false,
+    },
+    {
+      title: `Under ${levelLow.upperLimit}`,
+      description: levelLow.detail(),
+      color: levelLow.color,
+      roundTop: false,
+      roundBottom: true,
+    },
+  ];
+  return <Thermometer items={items} />;
 }

--- a/src/common/metrics/case_growth.tsx
+++ b/src/common/metrics/case_growth.tsx
@@ -7,12 +7,14 @@ import { formatDecimal } from 'common/utils';
 import { Projections } from 'common/models/Projections';
 import { MetricDefinition } from './interfaces';
 import ExternalLink from 'components/ExternalLink';
+import Thermometer from 'components/Thermometer';
 
 const METRIC_NAME = 'Infection rate';
 
 export const CaseGrowthMetric: MetricDefinition = {
   renderStatus,
   renderDisclaimer,
+  renderThermometer,
   metricName: METRIC_NAME,
   extendedMetricName: METRIC_NAME,
   metricNameForCompare: METRIC_NAME,
@@ -118,4 +120,44 @@ function renderDisclaimer(): React.ReactElement {
       .
     </Fragment>
   );
+}
+
+function renderThermometer(): React.ReactElement {
+  const levelInfo = CASE_GROWTH_RATE_LEVEL_INFO_MAP;
+  const levelCritical = levelInfo[Level.CRITICAL];
+  const levelHigh = levelInfo[Level.HIGH];
+  const levelMedium = levelInfo[Level.MEDIUM];
+  const levelLow = levelInfo[Level.LOW];
+
+  const items = [
+    {
+      title: `Over ${levelHigh.upperLimit}`,
+      description: levelCritical.detail(),
+      color: levelCritical.color,
+      roundTop: true,
+      roundBottom: false,
+    },
+    {
+      title: `${levelMedium.upperLimit} - ${levelHigh.upperLimit}`,
+      description: levelHigh.detail(),
+      color: levelHigh.color,
+      roundTop: false,
+      roundBottom: false,
+    },
+    {
+      title: `${levelLow.upperLimit} - ${levelMedium.upperLimit}`,
+      description: levelMedium.detail(),
+      color: levelMedium.color,
+      roundTop: false,
+      roundBottom: false,
+    },
+    {
+      title: `Under ${levelLow.upperLimit}`,
+      description: levelLow.detail(),
+      color: levelLow.color,
+      roundTop: false,
+      roundBottom: true,
+    },
+  ];
+  return <Thermometer items={items} />;
 }

--- a/src/common/metrics/contact_tracing.tsx
+++ b/src/common/metrics/contact_tracing.tsx
@@ -8,12 +8,14 @@ import { Projections } from 'common/models/Projections';
 import { TRACERS_NEEDED_PER_CASE } from 'common/models/Projection';
 import { MetricDefinition } from './interfaces';
 import ExternalLink from 'components/ExternalLink';
+import Thermometer from 'components/Thermometer';
 
 const METRIC_NAME = 'Tracers hired';
 
 export const ContactTracingMetric: MetricDefinition = {
   renderStatus,
   renderDisclaimer,
+  renderThermometer,
   metricName: METRIC_NAME,
   extendedMetricName: METRIC_NAME,
   metricNameForCompare: METRIC_NAME,
@@ -159,4 +161,43 @@ function renderDisclaimer(): React.ReactElement {
       assess contact tracing capacity.
     </Fragment>
   );
+}
+
+function renderThermometer(): React.ReactElement {
+  const levelInfo = CONTACT_TRACING_LEVEL_INFO_MAP;
+  const levelCritical = levelInfo[Level.CRITICAL];
+  const levelHigh = levelInfo[Level.HIGH];
+  const levelMedium = levelInfo[Level.MEDIUM];
+  const levelLow = levelInfo[Level.LOW];
+
+  const format = (value: number) => formatPercent(value, 0);
+
+  const items = [
+    {
+      title: `Over ${format(levelHigh.upperLimit)}`,
+      description: levelCritical.detail(),
+      color: levelCritical.color,
+      roundTop: true,
+      roundBottom: false,
+    },
+    {
+      title: `${format(levelMedium.upperLimit)} - ${format(
+        levelHigh.upperLimit,
+      )}`,
+      description: levelHigh.detail(),
+      color: levelHigh.color,
+      roundTop: false,
+      roundBottom: false,
+    },
+    {
+      title: `${format(levelLow.upperLimit)} - ${format(
+        levelMedium.upperLimit,
+      )}`,
+      description: levelMedium.detail(),
+      color: levelMedium.color,
+      roundTop: false,
+      roundBottom: true,
+    },
+  ];
+  return <Thermometer items={items} />;
 }

--- a/src/common/metrics/hospitalizations.tsx
+++ b/src/common/metrics/hospitalizations.tsx
@@ -8,12 +8,14 @@ import { Projections } from 'common/models/Projections';
 import { NonCovidPatientsMethod } from 'common/models/ICUHeadroom';
 import { MetricDefinition } from './interfaces';
 import ExternalLink from '../../components/ExternalLink';
+import Thermometer from 'components/Thermometer';
 
 const METRIC_NAME = 'ICU headroom used';
 
 export const ICUHeadroomMetric: MetricDefinition = {
   renderStatus,
   renderDisclaimer,
+  renderThermometer,
   metricName: METRIC_NAME,
   extendedMetricName: METRIC_NAME,
   metricNameForCompare: METRIC_NAME,
@@ -158,4 +160,50 @@ function renderDisclaimer(): React.ReactElement {
       .
     </Fragment>
   );
+}
+
+function renderThermometer(): React.ReactElement {
+  const levelInfo = HOSPITAL_USAGE_LEVEL_INFO_MAP;
+  const levelCritical = levelInfo[Level.CRITICAL];
+  const levelHigh = levelInfo[Level.HIGH];
+  const levelMedium = levelInfo[Level.MEDIUM];
+  const levelLow = levelInfo[Level.LOW];
+
+  const format = (value: number) => formatPercent(value, 0);
+
+  const items = [
+    {
+      title: `Over ${format(levelHigh.upperLimit)}`,
+      description: levelCritical.detail(),
+      color: levelCritical.color,
+      roundTop: true,
+      roundBottom: false,
+    },
+    {
+      title: `${format(levelMedium.upperLimit)} - ${format(
+        levelHigh.upperLimit,
+      )}`,
+      description: levelHigh.detail(),
+      color: levelHigh.color,
+      roundTop: false,
+      roundBottom: false,
+    },
+    {
+      title: `${format(levelLow.upperLimit)} - ${format(
+        levelMedium.upperLimit,
+      )}`,
+      description: levelMedium.detail(),
+      color: levelMedium.color,
+      roundTop: false,
+      roundBottom: false,
+    },
+    {
+      title: `Under ${format(levelLow.upperLimit)}`,
+      description: levelLow.detail(),
+      color: levelLow.color,
+      roundTop: false,
+      roundBottom: true,
+    },
+  ];
+  return <Thermometer items={items} />;
 }

--- a/src/common/metrics/interfaces.ts
+++ b/src/common/metrics/interfaces.ts
@@ -7,4 +7,5 @@ export interface MetricDefinition {
   metricName: string;
   extendedMetricName: string;
   metricNameForCompare: string;
+  renderThermometer: () => React.ReactElement;
 }

--- a/src/common/metrics/positive_rate.tsx
+++ b/src/common/metrics/positive_rate.tsx
@@ -7,12 +7,14 @@ import { formatPercent } from 'common/utils';
 import { Projections } from 'common/models/Projections';
 import { MetricDefinition } from './interfaces';
 import ExternalLink from 'components/ExternalLink';
+import Thermometer from 'components/Thermometer';
 
 const METRIC_NAME = 'Positive test rate';
 
 export const PositiveTestRateMetric: MetricDefinition = {
   renderStatus,
   renderDisclaimer,
+  renderThermometer,
   metricName: METRIC_NAME,
   extendedMetricName: METRIC_NAME,
   metricNameForCompare: METRIC_NAME,
@@ -160,4 +162,50 @@ function renderDisclaimer(projections: Projections): React.ReactElement {
       .
     </Fragment>
   );
+}
+
+function renderThermometer(): React.ReactElement {
+  const levelInfo = POSITIVE_TESTS_LEVEL_INFO_MAP;
+  const levelCritical = levelInfo[Level.CRITICAL];
+  const levelHigh = levelInfo[Level.HIGH];
+  const levelMedium = levelInfo[Level.MEDIUM];
+  const levelLow = levelInfo[Level.LOW];
+
+  const format = (value: number) => formatPercent(value, 0);
+
+  const items = [
+    {
+      title: `Over ${format(levelHigh.upperLimit)}`,
+      description: levelCritical.detail(),
+      color: levelCritical.color,
+      roundTop: true,
+      roundBottom: false,
+    },
+    {
+      title: `${format(levelMedium.upperLimit)} - ${format(
+        levelHigh.upperLimit,
+      )}`,
+      description: levelHigh.detail(),
+      color: levelHigh.color,
+      roundTop: false,
+      roundBottom: false,
+    },
+    {
+      title: `${format(levelLow.upperLimit)} - ${format(
+        levelMedium.upperLimit,
+      )}`,
+      description: levelMedium.detail(),
+      color: levelMedium.color,
+      roundTop: false,
+      roundBottom: false,
+    },
+    {
+      title: `Under ${format(levelLow.upperLimit)}`,
+      description: levelLow.detail(),
+      color: levelLow.color,
+      roundTop: false,
+      roundBottom: true,
+    },
+  ];
+  return <Thermometer items={items} />;
 }

--- a/src/components/Thermometer/Thermometer.style.ts
+++ b/src/components/Thermometer/Thermometer.style.ts
@@ -5,6 +5,11 @@ import { COLOR_MAP } from 'common/colors';
 const barWidth = theme.spacing(2);
 const barRadius = barWidth / 2;
 
+export const ThermometerBox = styled.div`
+  padding: ${theme.spacing(2)}px;
+  background-color: ${COLOR_MAP.LIGHTGRAY_BG};
+`;
+
 export const LevelContainer = styled.div`
   display: flex;
   height: 100%;

--- a/src/components/Thermometer/Thermometer.style.ts
+++ b/src/components/Thermometer/Thermometer.style.ts
@@ -1,0 +1,52 @@
+import styled, { css } from 'styled-components';
+import theme from 'assets/theme';
+import { COLOR_MAP } from 'common/colors';
+
+const barWidth = theme.spacing(2);
+const barRadius = barWidth / 2;
+
+export const LevelContainer = styled.div`
+  display: flex;
+  height: 100%;
+`;
+
+const roundTop = css<{ $roundTop: boolean }>`
+  border-top-left-radius: ${props => (props.$roundTop ? barRadius : 0)}px;
+  border-top-right-radius: ${props => (props.$roundTop ? barRadius : 0)}px;
+`;
+
+const roundBottom = css<{ $roundBottom: boolean }>`
+  border-bottom-left-radius: ${props => (props.$roundBottom ? barRadius : 0)}px;
+  border-bottom-right-radius: ${props =>
+    props.$roundBottom ? barRadius : 0}px;
+`;
+
+export const LevelColor = styled.div<{
+  $color: string;
+  $roundTop: boolean;
+  $roundBottom: boolean;
+}>`
+  background-color: ${props => props.$color};
+  ${roundTop};
+  ${roundBottom};
+
+  flex: 0 0 auto;
+  width: ${barWidth}px;
+  margin-right: ${theme.spacing(2)}px;
+`;
+
+export const LevelCopy = styled.div`
+  flex: 1 1 auto;
+  font-size: 0.875rem; // 14px
+`;
+
+export const LevelTitle = styled.div`
+  font-weight: ${theme.typography.fontWeightBold};
+  color: black;
+`;
+
+export const LevelDescription = styled.div`
+  color: ${COLOR_MAP.GRAY_BODY_COPY};
+  line-height: 1.4;
+  margin-bottom: 4px;
+`;

--- a/src/components/Thermometer/Thermometer.style.ts
+++ b/src/components/Thermometer/Thermometer.style.ts
@@ -43,6 +43,9 @@ export const LevelColor = styled.div<{
 export const LevelCopy = styled.div`
   flex: 1 1 auto;
   font-size: 0.875rem; // 14px
+  line-height: 1.3;
+
+  padding: ${theme.spacing(1) / 2}px 0;
 `;
 
 export const LevelTitle = styled.div`
@@ -52,6 +55,4 @@ export const LevelTitle = styled.div`
 
 export const LevelDescription = styled.div`
   color: ${COLOR_MAP.GRAY_BODY_COPY};
-  line-height: 1.4;
-  margin-bottom: 4px;
 `;

--- a/src/components/Thermometer/Thermometer.tsx
+++ b/src/components/Thermometer/Thermometer.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import {
+  LevelContainer,
+  LevelColor,
+  LevelCopy,
+  LevelTitle,
+  LevelDescription,
+} from './Thermometer.style';
+
+interface ThermometerLevelInfo {
+  title: string;
+  description: string;
+  color: string;
+  roundTop: boolean;
+  roundBottom: boolean;
+}
+
+const Thermometer: React.FC<{ items: ThermometerLevelInfo[] }> = ({
+  items,
+}) => (
+  <div>
+    {items.map(item => (
+      <LevelContainer key={item.color}>
+        <LevelColor
+          $color={item.color}
+          $roundTop={item.roundTop}
+          $roundBottom={item.roundBottom}
+        />
+        <LevelCopy>
+          <LevelTitle>{item.title}</LevelTitle>
+          <LevelDescription>{item.description}</LevelDescription>
+        </LevelCopy>
+      </LevelContainer>
+    ))}
+  </div>
+);
+
+export default Thermometer;

--- a/src/components/Thermometer/index.ts
+++ b/src/components/Thermometer/index.ts
@@ -1,0 +1,3 @@
+import Thermometer from './Thermometer';
+
+export default Thermometer;

--- a/src/components/Thermometer/index.ts
+++ b/src/components/Thermometer/index.ts
@@ -1,3 +1,5 @@
 import Thermometer from './Thermometer';
+import { ThermometerBox } from './Thermometer.style';
 
 export default Thermometer;
+export { ThermometerBox };

--- a/src/screens/Contact/Contact.tsx
+++ b/src/screens/Contact/Contact.tsx
@@ -4,6 +4,7 @@ import { Heading1, Heading2, MarkdownContent } from 'components/Markdown';
 import { Anchor } from 'components/TableOfContents';
 import PageContent from 'components/PageContent';
 import { contactUsContent, sidebarItems } from 'cms-content/contact';
+import { getMetricDefinition, Metric } from 'common/metric';
 
 const {
   header,
@@ -22,6 +23,7 @@ const ContactUsPage: React.FC = () => (
     />
     <PageContent sidebarItems={sidebarItems}>
       <Heading1>{header}</Heading1>
+      {getMetricDefinition(Metric.CONTACT_TRACING).renderThermometer()}
       {intro && intro.length && <MarkdownContent source={intro} />}
       {sections.map(({ sectionId, header, body }) => (
         <Fragment key={sectionId}>

--- a/src/screens/Contact/Contact.tsx
+++ b/src/screens/Contact/Contact.tsx
@@ -4,8 +4,6 @@ import { Heading1, Heading2, MarkdownContent } from 'components/Markdown';
 import { Anchor } from 'components/TableOfContents';
 import PageContent from 'components/PageContent';
 import { contactUsContent, sidebarItems } from 'cms-content/contact';
-import { getMetricDefinition, Metric } from 'common/metric';
-import { ThermometerBox } from 'components/Thermometer';
 
 const {
   header,
@@ -24,9 +22,6 @@ const ContactUsPage: React.FC = () => (
     />
     <PageContent sidebarItems={sidebarItems}>
       <Heading1>{header}</Heading1>
-      <ThermometerBox>
-        {getMetricDefinition(Metric.CONTACT_TRACING).renderThermometer()}
-      </ThermometerBox>
       {intro && intro.length && <MarkdownContent source={intro} />}
       {sections.map(({ sectionId, header, body }) => (
         <Fragment key={sectionId}>

--- a/src/screens/Contact/Contact.tsx
+++ b/src/screens/Contact/Contact.tsx
@@ -5,6 +5,7 @@ import { Anchor } from 'components/TableOfContents';
 import PageContent from 'components/PageContent';
 import { contactUsContent, sidebarItems } from 'cms-content/contact';
 import { getMetricDefinition, Metric } from 'common/metric';
+import { ThermometerBox } from 'components/Thermometer';
 
 const {
   header,
@@ -23,7 +24,9 @@ const ContactUsPage: React.FC = () => (
     />
     <PageContent sidebarItems={sidebarItems}>
       <Heading1>{header}</Heading1>
-      {getMetricDefinition(Metric.CONTACT_TRACING).renderThermometer()}
+      <ThermometerBox>
+        {getMetricDefinition(Metric.CONTACT_TRACING).renderThermometer()}
+      </ThermometerBox>
       {intro && intro.length && <MarkdownContent source={intro} />}
       {sections.map(({ sectionId, header, body }) => (
         <Fragment key={sectionId}>


### PR DESCRIPTION
Implement the thermometer component for the metric explainers. See [Figma](https://www.figma.com/file/ak4c25AkVqwVcg2GzjQ3JB/CMS-(Learn%2C-products%2C-about%2C-contact)?node-id=565%3A5215).

Since we need one per metric, I added the `renderThermometer` function to the `MetricDefinition` interface for each metric. The content of the function is a bit repetitive, but that allows handling the differences between the metrics without much hassle
- Contract tracing doesn't have a Low level
- Number formatting for the limits between each level don't match exactly the number formatting function for the metric (we need fewer decimal points)

### Notes
- The grey box is exported as a separate component to make the thermometer component more reusable and less context-dependent.
- This component is not rendered on any page yet, I added it to the Contact page, use [this commit](b6977d059b1be66ba974c8eb689209fd680c34dd) for testing.
- The description for each level will be wrapped if it doesn't fit in the container (see below for a screenshot on mobile)

<img src="https://user-images.githubusercontent.com/114084/99340572-21326900-283d-11eb-99f9-a895640679cf.png" width="375px" />


