### PR TITLE
cms setup: team directory

### DIFF
--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -47,6 +47,66 @@ collections:
                   - { label: 'Alt text', name: 'altText', widget: 'string' }
                   - { label: 'Image', name: 'image', widget: 'image' }
                   - { label: 'Url', name: 'url', widget: 'string' }
+
+  - name: team
+    label: Team Directory
+    description: Team directory
+    files:
+      - name: team
+        label: Team Structure
+        file: 'src/cms-content/team/core-team.json'
+        fields:
+          - label: Teams
+            name: teams
+            widget: list
+            hint: 'Product Management, etc'
+            fields:
+              - label: Team Name
+                name: teamName
+                widget: string
+                hint: 'Product Management, Engineering, etc.'
+              - label: Team ID
+                name: teamId
+                widget: string
+                hint: 'ID for the URL (all lowercase, no spaces)'
+              - label: 'Team members'
+                name: teamMembers
+                widget: list
+                fields:
+                  - label: Full name
+                    name: fullName
+                    widget: string
+                    hint: Name of the team member, as it will appear in the page
+                  - label: Description
+                    name: description
+                    widget: text
+                    hint: Short description of the titles and role of the team member
+                  - label: Profile picture
+                    name: profileImg
+                    widget: image
+                    hint: Square image, at least 128x128
+                  - label: Profile URL
+                    name: profileUrl
+                    widget: string
+                    hint: Link to the LinkedIn profile of the team member
+      - name: alumni
+        label: Alumni
+        file: 'src/cms-content/team/alumni.json'
+        fields:
+          - label: 'Alumni'
+            name: alumni
+            widget: list
+            hint: 'Former team members and collaborators'
+            fields:
+              - label: Full name
+                name: fullName
+                widget: string
+                hint: 'Name of the team member, as it will appear in the page'
+              - label: Profile URL
+                name: profileUrl
+                widget: string
+                hint: Link to the public profile of the person
+
   - name: contact
     label: Contact Us
     format: json

--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -4,7 +4,7 @@
 backend:
   name: github
   repo: covid-projections/covid-projections
-  branch: cms-content-entry
+  branch: pablo/cms-about-page-structure
   base_url: https://api.netlify.com
 
 media_folder: 'public/images_cms'
@@ -457,16 +457,15 @@ collections:
                   label: Product ID,
                   name: productId,
                   widget: string,
-                  hint: 'Must match ID used on products landing page, ie. product name all lowercase, separated by dashes if multi-work (ex. response-simulator)'
+                  hint: 'Must match ID used on products landing page, ie. product name all lowercase, separated by dashes if multi-work (ex. response-simulator)',
                 }
               - {
                   label: Product Intro,
                   name: productIntro,
                   widget: markdown,
-                  hint: 'Main intro before sections'
+                  hint: 'Main intro before sections',
                 }
-              -
-                label: Sections
+              - label: Sections
                 name: sections
                 widget: list
                 fields:
@@ -474,19 +473,15 @@ collections:
                       label: Section title,
                       name: sectionTitle,
                       widget: string,
-                      hint: 'ex: Why our API'
+                      hint: 'ex: Why our API',
                     }
                   - {
                       label: Section ID,
                       name: sectionId,
                       widget: string,
-                      hint: 'Section title all lowercase, separated by dashes if multi-work (ex. why-our-api)'
+                      hint: 'Section title all lowercase, separated by dashes if multi-work (ex. why-our-api)',
                     }
-                  - {
-                      label: Section Body,
-                      name: sectionBody,
-                      widget: markdown,
-                    }
+                  - { label: Section Body, name: sectionBody, widget: markdown }
               - label: Metadata title
                 name: metadataTitle
                 widget: text


### PR DESCRIPTION
Most of the About page is a listing of current and former team members. This PR creates the setup for the team directory. I will add the new sections for the updated About page to the existing `about` collection and wait until we have all the updated content ready to implement the new page.