### PR TITLE
Fix inconsistent tracking of switch component clicks due to extra event callback.

### DIFF
--- a/src/components/Compare/Filters.tsx
+++ b/src/components/Compare/Filters.tsx
@@ -97,9 +97,8 @@ const Filters = (props: {
     },
   ];
 
-  const switchHandleChange = () => {
+  const switchHandleChange = (newViewAllCounties: boolean) => {
     if (props.isHomepage && props.setViewAllCounties) {
-      const newViewAllCounties = !props.viewAllCounties;
       props.setViewAllCounties(newViewAllCounties);
       trackCompareEvent(
         EventAction.SELECT,
@@ -143,16 +142,11 @@ const Filters = (props: {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('xs'));
 
-  const gridOnClick = (on: boolean) => {
-    props.setViewAllCounties && props.setViewAllCounties(on);
-  };
-
   const switchProps = {
     leftLabel: 'States',
     rightLabel: 'Counties',
-    checkedValue: props.viewAllCounties,
+    checked: props.viewAllCounties,
     onChange: switchHandleChange,
-    gridOnClick,
     isModal: props.isModal,
   };
 

--- a/src/components/SharedComponents/SwitchComponent.stories.mdx
+++ b/src/components/SharedComponents/SwitchComponent.stories.mdx
@@ -1,0 +1,10 @@
+import { Meta, Story } from '@storybook/addon-docs/blocks';
+import SwitchComponent from './SwitchComponent';
+
+<Meta title="Shared Components/Switch Component" argTypes={{ onChange: { action: 'changed' } }} />
+
+export const Template = (args) => <SwitchComponent {...args} />
+
+<Story name="Default" args={{leftLabel: 'Left', rightLabel: 'Right'  }}>
+  {Template.bind({})}
+</Story>

--- a/src/components/SharedComponents/SwitchComponent.style.tsx
+++ b/src/components/SharedComponents/SwitchComponent.style.tsx
@@ -7,24 +7,24 @@ export const SwitchLabel = styled(Grid)`
 `;
 
 export const SwitchGrid = styled(Grid)<{
-  checked: boolean | undefined;
-  isModal?: boolean;
+  $checked: boolean | undefined;
+  $isModal?: boolean;
 }>`
   width: fit-content;
   cursor: pointer;
 
   ${SwitchLabel} {
     &:first-child {
-      color: ${({ checked }) =>
-        checked ? `${COLOR_MAP.GRAY_BODY_COPY}` : 'black'};
-      color: ${({ isModal }) => isModal && 'white'};
-      font-weight: ${({ checked }) => !checked && 'bold'};
+      color: ${({ $checked }) =>
+        $checked ? `${COLOR_MAP.GRAY_BODY_COPY}` : 'black'};
+      color: ${({ $isModal }) => $isModal && 'white'};
+      font-weight: ${({ $checked }) => !$checked && 'bold'};
     }
     &:last-child {
-      color: ${({ checked }) =>
-        !checked ? `${COLOR_MAP.GRAY_BODY_COPY}` : 'black'};
-      color: ${({ isModal }) => isModal && 'white'};
-      font-weight: ${({ checked }) => checked && 'bold'};
+      color: ${({ $checked }) =>
+        !$checked ? `${COLOR_MAP.GRAY_BODY_COPY}` : 'black'};
+      color: ${({ $isModal }) => $isModal && 'white'};
+      font-weight: ${({ $checked }) => $checked && 'bold'};
     }
   }
 `;

--- a/src/components/SharedComponents/SwitchComponent.style.tsx
+++ b/src/components/SharedComponents/SwitchComponent.style.tsx
@@ -7,7 +7,7 @@ export const SwitchLabel = styled(Grid)`
 `;
 
 export const SwitchGrid = styled(Grid)<{
-  viewAllCounties: boolean | undefined;
+  checked: boolean | undefined;
   isModal?: boolean;
 }>`
   width: fit-content;
@@ -15,16 +15,16 @@ export const SwitchGrid = styled(Grid)<{
 
   ${SwitchLabel} {
     &:first-child {
-      color: ${({ viewAllCounties }) =>
-        viewAllCounties ? `${COLOR_MAP.GRAY_BODY_COPY}` : 'black'};
+      color: ${({ checked }) =>
+        checked ? `${COLOR_MAP.GRAY_BODY_COPY}` : 'black'};
       color: ${({ isModal }) => isModal && 'white'};
-      font-weight: ${({ viewAllCounties }) => !viewAllCounties && 'bold'};
+      font-weight: ${({ checked }) => !checked && 'bold'};
     }
     &:last-child {
-      color: ${({ viewAllCounties }) =>
-        !viewAllCounties ? `${COLOR_MAP.GRAY_BODY_COPY}` : 'black'};
+      color: ${({ checked }) =>
+        !checked ? `${COLOR_MAP.GRAY_BODY_COPY}` : 'black'};
       color: ${({ isModal }) => isModal && 'white'};
-      font-weight: ${({ viewAllCounties }) => viewAllCounties && 'bold'};
+      font-weight: ${({ checked }) => checked && 'bold'};
     }
   }
 `;

--- a/src/components/SharedComponents/SwitchComponent.tsx
+++ b/src/components/SharedComponents/SwitchComponent.tsx
@@ -5,40 +5,33 @@ import { SwitchGrid, SwitchLabel } from './SwitchComponent.style';
 const SwitchComponent = (props: {
   leftLabel: string;
   rightLabel: string;
-  checkedValue: boolean | undefined;
-  onChange: any;
-  gridOnClick: any;
+  checked: boolean | undefined;
+  onChange: (newValue: boolean) => void;
   isModal?: boolean;
 }) => {
-  const {
-    leftLabel,
-    rightLabel,
-    checkedValue,
-    onChange,
-    gridOnClick,
-    isModal,
-  } = props;
+  const { leftLabel, rightLabel, checked, onChange, isModal } = props;
+
   return (
     <SwitchGrid
       container
       alignItems="center"
       spacing={1}
-      viewAllCounties={checkedValue}
+      checked={checked}
       isModal={isModal}
     >
-      <SwitchLabel onClick={() => gridOnClick(false)} item>
+      <SwitchLabel onClick={() => onChange(false)} item>
         {leftLabel}
       </SwitchLabel>
       <Grid item>
         <Switch
-          checked={checkedValue}
-          onChange={onChange}
+          checked={checked}
+          onChange={event => onChange(event.target.checked)}
           value="checked"
           size="small"
           disableRipple
         />
       </Grid>
-      <SwitchLabel onClick={() => gridOnClick(true)} item>
+      <SwitchLabel onClick={() => onChange(true)} item>
         {rightLabel}
       </SwitchLabel>
     </SwitchGrid>

--- a/src/components/SharedComponents/SwitchComponent.tsx
+++ b/src/components/SharedComponents/SwitchComponent.tsx
@@ -16,8 +16,8 @@ const SwitchComponent = (props: {
       container
       alignItems="center"
       spacing={1}
-      checked={checked}
-      isModal={isModal}
+      $checked={checked}
+      $isModal={isModal}
     >
       <SwitchLabel onClick={() => onChange(false)} item>
         {leftLabel}

--- a/src/screens/HomePage/HomePage.js
+++ b/src/screens/HomePage/HomePage.js
@@ -79,8 +79,7 @@ export default function HomePage() {
 
   const exploreSectionRef = useRef(null);
 
-  const onClickSwitch = () => {
-    const newShowCounties = !showCounties;
+  const onClickSwitch = newShowCounties => {
     setShowCounties(newShowCounties);
     trackEvent(
       EventCategory.MAP,
@@ -132,9 +131,8 @@ export default function HomePage() {
                   <SwitchComponent
                     leftLabel="States"
                     rightLabel="Counties"
-                    checkedValue={showCounties}
+                    checked={showCounties}
                     onChange={onClickSwitch}
-                    gridOnClick={setShowCounties}
                   />
                 </StyledGridItem>
               </Grid>


### PR DESCRIPTION
SwitchComponent had two separate callbacks (onChange and onGridClick) and we were only tracking analytics events when you hit the onChange handler (concretely, if you hit the actual switch GUI then `onChange` would fire and we'd track it; but if you clicked on the "States" or "Counties" labels, then `onGridClick` would fire instead and we wouldn't track it). 

I reworked it to only have a single event callback and also added it to storybook and did some minor cleanup.