### PR TITLE
Mask NYC Boroughs Test Positivity

### DIFF
--- a/src/common/models/Projection.ts
+++ b/src/common/models/Projection.ts
@@ -32,7 +32,7 @@ const DISABLED_CASE_DENSITY: string[] = [];
 
 const DISABLED_INFECTION_RATE = new DisabledFips([]);
 
-const DISABLED_TEST_POSITIVITY = new DisabledFips(['48113', '48215']);
+const DISABLED_TEST_POSITIVITY = new DisabledFips(['48113', '48215', '36061', '36047', '36081', '36005', '36085']);
 
 const DISABLED_ICU = new DisabledFips([]);
 

--- a/src/common/models/Projection.ts
+++ b/src/common/models/Projection.ts
@@ -32,7 +32,15 @@ const DISABLED_CASE_DENSITY: string[] = [];
 
 const DISABLED_INFECTION_RATE = new DisabledFips([]);
 
-const DISABLED_TEST_POSITIVITY = new DisabledFips(['48113', '48215', '36061', '36047', '36081', '36005', '36085']);
+const DISABLED_TEST_POSITIVITY = new DisabledFips([
+  '48113',
+  '48215',
+  '36061',
+  '36047',
+  '36081',
+  '36005',
+  '36085',
+]);
 
 const DISABLED_ICU = new DisabledFips([]);
 


### PR DESCRIPTION
https://trello.com/c/fjjyfcKG/629-new-york-ny-test-positivity-data