### PR TITLE
SEO: Add a new map image to link to from our 'image' meta tag.

### DIFF
--- a/firebase/functions/src/dynamic_web_content.ts
+++ b/firebase/functions/src/dynamic_web_content.ts
@@ -30,9 +30,12 @@ shareRouter.get(/\/(.*)\.png/, (req, res) => {
 
   // Extract the share image path via the 0th regex capture group.
   let sharePath = req.params[0];
-  if (sharePath.endsWith('-image-covid-us-map-cases')) {
+  if (sharePath === 'home') {
     // home.png is generated from the root /internal/share-image/ URL.
     sharePath = '';
+  } else if (sharePath.endsWith('-image-covid-us-map-cases')) {
+    // This is used for the 'image' meta tag which is generated from /internal/share-image/map/
+    sharePath = 'map';
   }
 
   const baseUrl =

--- a/public/index.html
+++ b/public/index.html
@@ -28,6 +28,7 @@
   <link data-react-helmet="true" rel="canonical" href="https://covidactnow.org/" />
   <meta data-react-helmet="true" name="description"
     content="America’s COVID warning system. All 50 states. 3,000+ counties." />
+  <meta data-react-helmet="true" name="image" content="" />
 
   <!-- Facebook Open Graph meta tags (site-wide) -->
   <meta property="og:type" content="website" />

--- a/scripts/generate_index_pages.ts
+++ b/scripts/generate_index_pages.ts
@@ -8,7 +8,6 @@
 
 import fs from 'fs-extra';
 import path from 'path';
-import moment from 'moment';
 import _ from 'lodash';
 import urlJoin from 'url-join';
 import US_STATE_DATASET from '../src/components/MapSelectors/datasets/us_states_dataset_01_02_2020.json';
@@ -124,11 +123,9 @@ async function main() {
   console.log('Building index.html pages...');
 
   const builder = await IndexPageBuilder.initialize();
-  const date = moment().format('YYYY-MM-DD');
-  const mapFilename = `${date}-image-covid-us-map-cases.png`;
   await builder.writeTemplatedPage(
     '/index.html',
-    homePageTags(builder.fullImageUrl(mapFilename)),
+    homePageTags(builder.fullImageUrl('home.png')),
   );
 
   // Make sure we have at least SHARED_COMPONENT_IDS_TO_GENERATE index.html

--- a/src/common/urls.ts
+++ b/src/common/urls.ts
@@ -4,6 +4,7 @@ import { County } from './locations';
 import urlJoin from 'url-join';
 import * as QueryString from 'query-string';
 import { getLocationUrlForFips } from 'common/locations';
+import moment from 'moment';
 
 /**
  * We append a short unique string corresponding to the currently published
@@ -49,6 +50,14 @@ function getShareImageBaseUrl(stateId?: string, county?: County): string {
   } else {
     return imageBaseUrl;
   }
+}
+
+export function getMapImageUrl(): string {
+  const date = moment().format('YYYY-MM-DD');
+  return urlJoin(
+    getShareImageBaseUrl(),
+    `${date}-image-covid-us-map-cases.png`,
+  );
 }
 
 // TODO(michael): Move existing code over to use this method.

--- a/src/components/AppMetaTags/AppMetaTags.js
+++ b/src/components/AppMetaTags/AppMetaTags.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Helmet } from 'react-helmet';
+import { getMapImageUrl } from 'common/urls';
 
 /**
  * public/index.html contains meta tags for the home page. Every non-home page
@@ -17,7 +18,7 @@ export default function AppMetaTags({
   let fullPageTitle = pageTitle
     ? [pageTitle, 'Covid Act Now'].join(' - ')
     : 'Covid Act Now';
-  let fullCanonicalUrl = new URL(canonicalUrl, 'http://covidactnow.org/').href;
+  let fullCanonicalUrl = new URL(canonicalUrl, 'https://covidactnow.org/').href;
 
   return (
     <Helmet>
@@ -25,6 +26,7 @@ export default function AppMetaTags({
       <title>{fullPageTitle}</title>
       <link rel="canonical" href={fullCanonicalUrl} />
       <meta name="description" content={pageDescription} />
+      {canonicalUrl === '/' && <meta name="image" content={getMapImageUrl()} />}
     </Helmet>
   );
 }

--- a/src/components/SocialLocationPreview/SocialLocationPreview.tsx
+++ b/src/components/SocialLocationPreview/SocialLocationPreview.tsx
@@ -53,6 +53,7 @@ const SocialLocationPreview = (props: {
               hideInstructions={true}
               setMapOption={function () {}}
               setMobileMenuOpen={function () {}}
+              showCounties={true}
             />
           </MapWrapper>
           {isEmbed ? (

--- a/src/components/SocialLocationPreview/SocialLocationPreview.tsx
+++ b/src/components/SocialLocationPreview/SocialLocationPreview.tsx
@@ -53,7 +53,6 @@ const SocialLocationPreview = (props: {
               hideInstructions={true}
               setMapOption={function () {}}
               setMobileMenuOpen={function () {}}
-              showCounties={true}
             />
           </MapWrapper>
           {isEmbed ? (

--- a/src/screens/internal/ShareImage/ChartShareImage.tsx
+++ b/src/screens/internal/ShareImage/ChartShareImage.tsx
@@ -9,7 +9,7 @@ import {
   Subtitle,
   Title,
 } from './ChartShareImage.style';
-import { ScreenshotWrapper } from './ShareImage.style';
+import { DarkScreenshotWrapper } from './ShareImage.style';
 import LogoDark from 'assets/images/logoDark';
 import { chartDarkMode } from 'assets/theme/palette';
 import { Projections } from 'common/models/Projections';
@@ -44,7 +44,7 @@ export default function ChartShareImage() {
   const chartHeight = 225;
 
   return (
-    <ScreenshotWrapper className={SCREENSHOT_CLASS}>
+    <DarkScreenshotWrapper className={SCREENSHOT_CLASS}>
       <Wrapper>
         <Headers>
           <Title>{getMetricNameExtended(metric)}</Title>
@@ -68,6 +68,6 @@ export default function ChartShareImage() {
           </ChartWrapper>
         </ThemeProvider>
       </Wrapper>
-    </ScreenshotWrapper>
+    </DarkScreenshotWrapper>
   );
 }

--- a/src/screens/internal/ShareImage/ExploreChartImage.tsx
+++ b/src/screens/internal/ShareImage/ExploreChartImage.tsx
@@ -5,7 +5,7 @@ import { ParentSize } from '@vx/responsive';
 import LogoDark from 'assets/images/logoDark';
 import { chartDarkMode } from 'assets/theme/palette';
 import { findLocationForFips } from 'common/locations';
-import { ScreenshotWrapper } from './ShareImage.style';
+import { DarkScreenshotWrapper } from './ShareImage.style';
 import { ExploreChart } from 'components/Explore';
 import {
   ExploreChartWrapper,
@@ -41,7 +41,7 @@ const ExploreChartImage = ({ componentParams }: { componentParams: any }) => {
   }, [selectedLocations, currentMetric, normalizeData]);
 
   return (
-    <ScreenshotWrapper className={SCREENSHOT_CLASS}>
+    <DarkScreenshotWrapper className={SCREENSHOT_CLASS}>
       <Wrapper>
         <Headers>
           <ExploreTitle>
@@ -75,7 +75,7 @@ const ExploreChartImage = ({ componentParams }: { componentParams: any }) => {
           </ExploreChartWrapper>
         </ThemeProvider>
       </Wrapper>
-    </ScreenshotWrapper>
+    </DarkScreenshotWrapper>
   );
 };
 

--- a/src/screens/internal/ShareImage/ShareCardImage.tsx
+++ b/src/screens/internal/ShareImage/ShareCardImage.tsx
@@ -19,7 +19,7 @@ import { ScreenshotReady, SCREENSHOT_CLASS } from 'components/Screenshot';
  * Screen that just shows the appropriate share card so that we can take a
  * screenshot that we then use as our OpenGraph image.
  */
-const ShareCardImage = ({ mapImage }: { mapImage: boolean }) => {
+const ShareCardImage = () => {
   const { stateId, countyFipsId } = useParams();
   const isHomePage = !stateId && !countyFipsId;
   return (

--- a/src/screens/internal/ShareImage/ShareCardImage.tsx
+++ b/src/screens/internal/ShareImage/ShareCardImage.tsx
@@ -8,7 +8,7 @@ import {
   TitleWrapper,
   LastUpdatedWrapper,
 } from './ShareCardImage.style';
-import { ScreenshotWrapper } from './ShareImage.style';
+import { DarkScreenshotWrapper } from './ShareImage.style';
 import { formatLocalDate } from 'common/utils';
 import { findCountyByFips } from 'common/locations';
 import { ScreenshotReady, SCREENSHOT_CLASS } from 'components/Screenshot';
@@ -19,16 +19,16 @@ import { ScreenshotReady, SCREENSHOT_CLASS } from 'components/Screenshot';
  * Screen that just shows the appropriate share card so that we can take a
  * screenshot that we then use as our OpenGraph image.
  */
-const ShareCardImage = () => {
+const ShareCardImage = ({ mapImage }: { mapImage: boolean }) => {
   const { stateId, countyFipsId } = useParams();
   const isHomePage = !stateId && !countyFipsId;
   return (
-    <ScreenshotWrapper className={SCREENSHOT_CLASS}>
+    <DarkScreenshotWrapper className={SCREENSHOT_CLASS}>
       <Header isHomePage={isHomePage} />
       <ShareCardWrapper isHomePage={isHomePage}>
         <ShareCard stateId={stateId} countyFipsId={countyFipsId} />
       </ShareCardWrapper>
-    </ScreenshotWrapper>
+    </DarkScreenshotWrapper>
   );
 };
 

--- a/src/screens/internal/ShareImage/ShareImage.style.ts
+++ b/src/screens/internal/ShareImage/ShareImage.style.ts
@@ -4,7 +4,11 @@ export const ScreenshotWrapper = styled.div`
   margin: 100px auto;
   width: 1200px;
   height: 630px;
+  overflow: hidden;
+  background-color: white;
+`;
+
+export const DarkScreenshotWrapper = styled(ScreenshotWrapper)`
   background-color: black;
   color: white;
-  overflow: hidden;
 `;

--- a/src/screens/internal/ShareImage/ShareImage.tsx
+++ b/src/screens/internal/ShareImage/ShareImage.tsx
@@ -7,6 +7,7 @@ import ExploreChartImage from './ExploreChartImage';
 import ExploreChartExportImage from './ExploreChartExportImage';
 import CompareTableImage from './CompareTableImage';
 import { SharedComponent, useSharedComponentParams } from 'common/sharing';
+import { USMapImage } from './USMapImage';
 
 function SharedComponentImage({ exportImage }: { exportImage: boolean }) {
   const componentParams = useSharedComponentParams(SharedComponent.Any);
@@ -31,6 +32,11 @@ export default function ShareImage({ match }: RouteComponentProps<{}>) {
     <Switch>
       {/* HOME PAGE SHARE CARD */}
       <Route exact path={`${match.path}`} component={ShareCardImage} />
+
+      {/* HOME PAGE MAP IMAGE (used in meta name="image" tag) */}
+      <Route exact path={`${match.path}map/`}>
+        <USMapImage />
+      </Route>
 
       {/* LOCATION PAGES SHARE CARD */}
       <Route

--- a/src/screens/internal/ShareImage/USMapImage.style.ts
+++ b/src/screens/internal/ShareImage/USMapImage.style.ts
@@ -1,0 +1,13 @@
+import styled from 'styled-components';
+
+export const USMapWrapper = styled.div`
+  margin: auto;
+  width: 515px;
+  transform: scale(2);
+  transform-origin: top center;
+
+  /* HACK to remove box-shadow from SocialLocationPreview component. */
+  div:first-child {
+    box-shadow: none;
+  }
+`;

--- a/src/screens/internal/ShareImage/USMapImage.tsx
+++ b/src/screens/internal/ShareImage/USMapImage.tsx
@@ -1,0 +1,15 @@
+import { SCREENSHOT_CLASS } from 'components/Screenshot';
+import SocialLocationPreview from 'components/SocialLocationPreview/SocialLocationPreview';
+import React from 'react';
+import { ScreenshotWrapper } from './ShareImage.style';
+import { USMapWrapper } from './USMapImage.style';
+
+export const USMapImage = () => {
+  return (
+    <ScreenshotWrapper className={SCREENSHOT_CLASS}>
+      <USMapWrapper>
+        <SocialLocationPreview />
+      </USMapWrapper>
+    </ScreenshotWrapper>
+  );
+};


### PR DESCRIPTION
https://trello.com/c/4d3VBDOm/598-update-covidactnoworg-snapshot

1. Create a new map image for SEO (separate from the homepage share image) that doesn't have the big black background and header, etc.
1. Revert the homepage share URL back to 'home.png' (instead of [date]-image-covid-us-map-cases.png)
1. Point [date]-image-covid-us-map-cases.png at the new map image and insert it into our `<meta name="image">` tag on the homepage.

The image is generated from https://covid-projections-git-mikelehen-map-seo.covidactnow.now.sh/internal/share-image/map/

![image](https://user-images.githubusercontent.com/206364/100578575-6f148b80-3297-11eb-93a8-772f18250681.png)

The image isn't really great, but hopefully it's good enough for now.  It might also be nice if we had a dedicated URL for the county-colored homepage (https://covidactnow.org/us-county/ or whatever) and generated the appropriate county-colored image into the `<meta name="image">` tag on that page).