### PR TITLE
Dialog fix

### DIFF
--- a/src/components/Dialog/Dialog.style.ts
+++ b/src/components/Dialog/Dialog.style.ts
@@ -9,9 +9,8 @@ export const DialogTitle = styled(MuiDialogTitle)`
 `;
 
 export const ButtonContainer = styled.div`
-  position: absolute;
-  top: ${({ theme }) => theme.spacing(1)}px;
-  right: ${({ theme }) => theme.spacing(1)}px;
+  display: flex;
+  justify-content: flex-end;
 `;
 
 export const StyledPaper = styled(Paper)`


### PR DESCRIPTION
A recent edit threw off the dialog spacing:

<img width="378" alt="Screen Shot 2020-11-30 at 9 13 00 PM" src="https://user-images.githubusercontent.com/44076375/100688704-f540d880-3350-11eb-9b95-3c074432fb8b.png">