### PR TITLE
use h1 in the location page

### DIFF
--- a/src/assets/theme/index.tsx
+++ b/src/assets/theme/index.tsx
@@ -37,10 +37,12 @@ const fonts: ThemeFonts = {
     margin-bottom: 0.75rem;
   `,
   heading1: css`
-    font-size: 1.8125rem;
-    line-height: 1.25;
+    font-size: 1.875rem;
+    font-weight: 400;
+    line-height: 1.17;
     margin-bottom: 1.25rem;
     margin-top: 1.25rem;
+    letter-spacing: -0.05px;
   `,
   disclaimer: css`
     font-size: 0.875rem;

--- a/src/assets/theme/index.tsx
+++ b/src/assets/theme/index.tsx
@@ -18,6 +18,7 @@ const colors: ThemeColors = {
 };
 
 interface ThemeFonts {
+  heading1: FlattenSimpleInterpolation;
   subtitle1: FlattenSimpleInterpolation;
   disclaimer: FlattenSimpleInterpolation;
   link: FlattenSimpleInterpolation;
@@ -34,6 +35,12 @@ const fonts: ThemeFonts = {
     font-size: 0.875rem;
     line-height: 1.125;
     margin-bottom: 0.75rem;
+  `,
+  heading1: css`
+    font-size: 1.8125rem;
+    line-height: 1.25;
+    margin-bottom: 1.25rem;
+    margin-top: 1.25rem;
   `,
   disclaimer: css`
     font-size: 0.875rem;

--- a/src/components/LocationPage/LocationPageHeader.style.tsx
+++ b/src/components/LocationPage/LocationPageHeader.style.tsx
@@ -1,10 +1,11 @@
 import styled from 'styled-components';
 import Typography from '@material-ui/core/Typography';
 import { Box } from '@material-ui/core';
-import palette from 'assets/theme/palette';
 import { COLORS } from 'common';
 import { COLOR_MAP } from 'common/colors';
 import { Level } from 'common/level';
+import { Heading1 } from 'components/Typography';
+import { materialSMBreakpoint } from 'assets/theme/sizes';
 
 export const ColoredHeaderBanner = styled(Box)`
   display: flex;
@@ -12,7 +13,7 @@ export const ColoredHeaderBanner = styled(Box)`
   height: 400px;
   background-color: ${props => props.bgcolor || COLORS.LIGHTGRAY};
 
-  @media (min-width: 600px) {
+  @media (min-width: ${materialSMBreakpoint}) {
     height: 250px;
   }
 `;
@@ -38,7 +39,7 @@ export const Wrapper = styled(Box)<{
     cursor: pointer;
     margin: -380px 1rem 0 1rem;
 
-    @media (min-width: 600px) {
+    @media (min-width: ${materialSMBreakpoint}) {
       position: relative;
       flex-direction: column;
       margin: ${props.headerTopMargin}px 1rem ${props.headerBottomMargin}px;
@@ -76,18 +77,25 @@ export const HeaderSection = styled(Box)`
     justify-content: space-between;
   }
 
-  @media (min-width: 600px) {
+  @media (min-width: ${materialSMBreakpoint}) {
     flex-direction: row;
     justify-content: space-between;
   }
 `;
 
 export const LocationCopyWrapper = styled(Box)`
-  line-height: 1.4;
-  margin: 1.5rem 1rem;
+  text-align: center;
+  margin: 0.5rem 2.25rem;
 
-  @media (min-width: 600px) {
-    margin: 2.5rem 0.875rem 2.5rem 2.25rem;
+  @media (min-width: ${materialSMBreakpoint}) {
+    text-align: left;
+    margin: 1.25rem 2.25rem;
+  }
+`;
+
+export const LocationName = styled(Heading1)`
+  @media (max-width: ${materialSMBreakpoint}) {
+    font-size: 1.375rem;
   }
 `;
 
@@ -104,7 +112,7 @@ export const FooterContainer = styled(Box)`
     margin-right: 0.75rem;
   }
 
-  @media (min-width: 600px) {
+  @media (min-width: ${materialSMBreakpoint}) {
     width: 100%;
     margin: 1.5rem 0 0.5rem 0.2rem;
     cursor: auto;
@@ -151,7 +159,7 @@ export const ButtonsWrapper = styled(Box)`
   justify-content: center;
   margin-bottom: 1.5rem;
 
-  @media (min-width: 600px) {
+  @media (min-width: ${materialSMBreakpoint}) {
     width: fit-content;
     background-color: unset;
     border-radius: 0;
@@ -204,7 +212,7 @@ export const HeaderButton = styled(Box)`
     }
   }
 
-  @media (min-width: 600px) {
+  @media (min-width: ${materialSMBreakpoint}) {
     font-size: 14px;
     padding: 0.75rem 1.75rem;
     margin: auto;
@@ -221,7 +229,7 @@ export const LastUpdatedDate = styled.span<{
   display: flex;
   margin-left: ${({ isVerifiedState }) => isVerifiedState && '32px'};
 
-  @media (min-width: 600px) {
+  @media (min-width: ${materialSMBreakpoint}) {
     display: inline;
     margin-left: 0;
     margin-bottom: 10px;
@@ -247,7 +255,7 @@ export const SectionHalf = styled(Box)`
     color: ${COLOR_MAP.GRAY_ICON};
   }
 
-  @media (min-width: 600px) {
+  @media (min-width: ${materialSMBreakpoint}) {
     &:first-child {
       flex: 3;
       margin: 2rem 1.5rem 2rem 2.25rem;
@@ -265,7 +273,7 @@ export const SectionColumn = styled(Box)<{ isUpdateCopy?: Boolean }>`
   flex-direction: column;
   margin-left: 1.5rem;
 
-  @media (min-width: 600px) {
+  @media (min-width: ${materialSMBreakpoint}) {
     margin-left: ${({ isUpdateCopy }) => (isUpdateCopy ? '1rem' : '1.5rem')};
   }
 `;
@@ -278,7 +286,7 @@ export const ColumnTitle = styled(Typography)<{ isUpdateCopy?: Boolean }>`
   letter-spacing: 0.02rem;
   margin-bottom: 0.5rem;
 
-  @media (min-width: 600px) {
+  @media (min-width: ${materialSMBreakpoint}) {
     margin-bottom: ${({ isUpdateCopy }) => (isUpdateCopy ? '.5rem' : '.75rem')};
     font-size: 13px;
   }
@@ -300,7 +308,7 @@ export const Copy = styled(Typography)<{ isUpdateCopy?: Boolean }>`
     cursor: pointer;
   }
 
-  @media (min-width: 600px) {
+  @media (min-width: ${materialSMBreakpoint}) {
     font-size: 13px;
     max-width: 440px;
   }
@@ -313,28 +321,8 @@ export const LevelDescription = styled(Typography)`
   font-weight: bold;
   margin-bottom: 0.5rem;
 
-  @media (min-width: 600px) {
+  @media (min-width: ${materialSMBreakpoint}) {
     font-size: 18px;
     margin-bottom: 0.75rem;
   }
-`;
-
-// TODO(michael): This doesn't seem to be used. We should remove it!
-export const Triangle = styled(Box)<{ alarmLevel: number }>`
-  width: 0;
-  height: 0;
-  border-left: 6px solid transparent;
-  border-right: 6px solid transparent;
-  border-bottom: 6px solid black;
-  margin-top: 6px;
-  margin-left: ${({ alarmLevel }) =>
-    alarmLevel === Level.LOW
-      ? '-96px'
-      : alarmLevel === Level.MEDIUM
-      ? '-32px'
-      : alarmLevel === Level.HIGH
-      ? '32px'
-      : alarmLevel === Level.CRITICAL
-      ? '96px'
-      : '0'};
 `;

--- a/src/components/LocationPage/LocationPageHeader.style.tsx
+++ b/src/components/LocationPage/LocationPageHeader.style.tsx
@@ -91,39 +91,6 @@ export const LocationCopyWrapper = styled(Box)`
   }
 `;
 
-export const HeaderTitle = styled(Typography)<{
-  isEmbed?: Boolean;
-}>`
-  color: ${palette.black};
-  font-size: ${props => (props.isEmbed ? '1.8rem' : '22px')};
-  font-weight: normal;
-  line-height: ${props => (props.isEmbed ? '1.5rem' : '2.2rem')};
-  padding: 0;
-  text-align: center;
-
-  a {
-    color: ${palette.black};
-    text-decoration: none;
-  }
-
-  @media (min-width: 600px) {
-    font-size: 30px;
-    text-align: left;
-  }
-`;
-
-export const HeaderSubtitle = styled(Typography)`
-  font-size: 15px;
-  line-height: 1.4;
-  color: ${COLOR_MAP.GRAY_BODY_COPY};
-  margin-top: 1.2rem;
-
-  @media (min-width: 600px) {
-    font-size: 16px;
-    margin-top: 1rem;
-  }
-`;
-
 export const FooterContainer = styled(Box)`
   margin: 0.8rem 0.3rem 0;
 

--- a/src/components/LocationPage/LocationPageHeader.style.tsx
+++ b/src/components/LocationPage/LocationPageHeader.style.tsx
@@ -3,7 +3,6 @@ import Typography from '@material-ui/core/Typography';
 import { Box } from '@material-ui/core';
 import { COLORS } from 'common';
 import { COLOR_MAP } from 'common/colors';
-import { Level } from 'common/level';
 import { Heading1 } from 'components/Typography';
 import { materialSMBreakpoint } from 'assets/theme/sizes';
 

--- a/src/components/LocationPage/LocationPageHeader.tsx
+++ b/src/components/LocationPage/LocationPageHeader.tsx
@@ -17,6 +17,7 @@ import {
   ColumnTitle,
   SectionColumn,
   LevelDescription,
+  LocationName,
 } from 'components/LocationPage/LocationPageHeader.style';
 import { useEmbed } from 'common/utils/hooks';
 import { LOCATION_SUMMARY_LEVELS } from 'common/metrics/location_summary';
@@ -33,7 +34,6 @@ import WarningIcon from '@material-ui/icons/Warning';
 import { Metric } from 'common/metric';
 import { BANNER_COPY } from 'components/Banner/ThirdWaveBanner';
 import { ThermometerImage } from 'components/Thermometer';
-import { Heading1 } from 'components/Typography';
 
 const NewFeatureCopy = (props: {
   locationName: string;
@@ -51,12 +51,14 @@ const LocationPageHeading: React.FC<{ projections: Projections }> = ({
 }) => {
   const { countyName, stateCode, stateName } = projections;
   return countyName ? (
-    <Fragment>
+    <LocationName>
       <strong>{countyName}, </strong>
       {stateCode}
-    </Fragment>
+    </LocationName>
   ) : (
-    <strong>{stateName}</strong>
+    <LocationName>
+      <strong>{stateName}</strong>
+    </LocationName>
   );
 };
 
@@ -113,9 +115,9 @@ const LocationPageHeader = (props: {
         <TopContainer>
           <HeaderSection>
             <LocationCopyWrapper>
-              <Heading1>
+              <LocationName>
                 <LocationPageHeading projections={props.projections} />
-              </Heading1>
+              </LocationName>
             </LocationCopyWrapper>
             <ButtonsWrapper>
               <HeaderButton onClick={props.onHeaderShareClick || noop}>

--- a/src/components/LocationPage/LocationPageHeader.tsx
+++ b/src/components/LocationPage/LocationPageHeader.tsx
@@ -6,7 +6,6 @@ import {
   Wrapper,
   TopContainer,
   FooterContainer,
-  HeaderTitle,
   HeaderSection,
   HeaderSubCopy,
   ButtonsWrapper,
@@ -27,7 +26,6 @@ import { useModelLastUpdatedDate } from 'common/utils/model';
 import { STATES_WITH_DATA_OVERRIDES } from 'common/metrics/hospitalizations';
 import { Projections } from 'common/models/Projections';
 import { formatUtcDate } from 'common/utils';
-import { isNull } from 'util';
 import NotificationsNoneIcon from '@material-ui/icons/NotificationsNone';
 import ShareOutlinedIcon from '@material-ui/icons/ShareOutlined';
 import LocationHeaderStats from 'components/SummaryStats/LocationHeaderStats';
@@ -35,6 +33,7 @@ import WarningIcon from '@material-ui/icons/Warning';
 import { Metric } from 'common/metric';
 import { BANNER_COPY } from 'components/Banner/ThirdWaveBanner';
 import { ThermometerImage } from 'components/Thermometer';
+import { Heading1 } from 'components/Typography';
 
 const NewFeatureCopy = (props: {
   locationName: string;
@@ -47,25 +46,18 @@ const NewFeatureCopy = (props: {
   );
 };
 
-const LocationPageHeading = (props: { projections: Projections }) => {
-  const { isEmbed } = useEmbed();
-
-  const displayName = props.projections.countyName ? (
-    <>
-      <strong>{props.projections.countyName}, </strong>
-      <a
-        href={`${
-          isEmbed ? '/embed' : ''
-        }/us/${props.projections.stateCode.toLowerCase()}`}
-      >
-        {props.projections.stateCode}
-      </a>
-    </>
+const LocationPageHeading: React.FC<{ projections: Projections }> = ({
+  projections,
+}) => {
+  const { countyName, stateCode, stateName } = projections;
+  return countyName ? (
+    <Fragment>
+      <strong>{countyName}, </strong>
+      {stateCode}
+    </Fragment>
   ) : (
-    <strong>{props.projections.stateName}</strong>
+    <strong>{stateName}</strong>
   );
-
-  return <span>{displayName}</span>;
 };
 
 const noop = () => {};
@@ -81,7 +73,7 @@ const LocationPageHeader = (props: {
   onNewUpdateClick: () => void;
 }) => {
   const hasStats = !!Object.values(props.stats).filter(
-    (val: number | null) => !isNull(val),
+    (val: number | null) => val !== null,
   ).length;
 
   //TODO (chelsi): get rid of this use of 'magic' numbers
@@ -121,9 +113,9 @@ const LocationPageHeader = (props: {
         <TopContainer>
           <HeaderSection>
             <LocationCopyWrapper>
-              <HeaderTitle isEmbed={isEmbed}>
+              <Heading1>
                 <LocationPageHeading projections={props.projections} />
-              </HeaderTitle>
+              </Heading1>
             </LocationCopyWrapper>
             <ButtonsWrapper>
               <HeaderButton onClick={props.onHeaderShareClick || noop}>

--- a/src/components/Typography/Typography.stories.mdx
+++ b/src/components/Typography/Typography.stories.mdx
@@ -1,8 +1,0 @@
-import { Meta, Story } from '@storybook/addon-docs/blocks';
-import { Subtitle1 } from './Typography.style';
-
-<Meta title="Building Blocks/Typography" />
-
-<Story name="Subtitle1">
-  <Subtitle1>counties in oklahoma</Subtitle1>
-</Story>

--- a/src/components/Typography/Typography.stories.tsx
+++ b/src/components/Typography/Typography.stories.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { Heading1, Subtitle1 } from './Typography.style';
+
+export default {
+  title: 'Building Blocks/Typography',
+  component: Subtitle1,
+};
+
+export const Heading_1 = () => <Heading1>Learn more about COVID</Heading1>;
+
+export const Subtitle_1 = () => <Subtitle1>counties in oklahoma</Subtitle1>;

--- a/src/components/Typography/Typography.style.ts
+++ b/src/components/Typography/Typography.style.ts
@@ -26,6 +26,12 @@ import Typography from '@material-ui/core/Typography';
  *    at the application level (if we were to implement a dark theme).
  */
 
+export const Heading1 = styled(Typography).attrs(props => ({
+  variant: 'h1',
+}))`
+  ${props => props.theme.fonts.heading1};
+`;
+
 export const Subtitle1 = styled(Typography).attrs(props => ({
   variant: 'body1',
 }))`


### PR DESCRIPTION
The state or county name in the location page looks like a heading, but is a styled div. This makes the page more annoying to navigate for users that need assistive technologies and hurts SEO.

This PR updates the Location page header to use the H1 element. It should be visually identical than the exiting title. I also removed the link on the state code in the header, I don't think that that feature was useful, as it was invisible for users.

### References
- https://web.dev/headings-and-landmarks/

### Notes
- There are other headings to add as well (chart titles should be H2, etc), will work on those on separate PRs