### PR TITLE
fix vertical alignment of the team member description

### DIFF
--- a/src/screens/About/Team/ActiveMember.tsx
+++ b/src/screens/About/Team/ActiveMember.tsx
@@ -4,14 +4,17 @@ import { Paragraph } from 'components/Markdown';
 import ExternalLink from 'components/ExternalLink';
 import { UserProfile } from 'cms-content/team';
 
-const ActiveMember = (props: {
+const ActiveMember: React.FC<{
   teamMember: UserProfile;
   includeTitle: boolean;
-}) => {
-  const { teamMember, includeTitle } = props;
-
+}> = ({ teamMember, includeTitle }) => {
   return (
-    <TeamMemberWrapper item sm={6} xs={12}>
+    <TeamMemberWrapper
+      item
+      sm={6}
+      xs={12}
+      alignItems={includeTitle ? 'flex-start' : 'center'}
+    >
       <Headshot src={teamMember.profileImgUrl} />
       <ExternalLink href={teamMember.profileUrl}>
         <DescriptionWrapper>

--- a/src/screens/About/Team/ActiveMember.tsx
+++ b/src/screens/About/Team/ActiveMember.tsx
@@ -15,7 +15,10 @@ const ActiveMember: React.FC<{
       xs={12}
       alignItems={includeTitle ? 'flex-start' : 'center'}
     >
-      <Headshot src={teamMember.profileImgUrl} />
+      <Headshot
+        src={teamMember.profileImgUrl}
+        alt={`headshot of ${teamMember.fullName}`}
+      />
       <ExternalLink href={teamMember.profileUrl}>
         <DescriptionWrapper>
           <strong>{teamMember.fullName}</strong>

--- a/src/screens/About/Team/Team.style.tsx
+++ b/src/screens/About/Team/Team.style.tsx
@@ -18,7 +18,7 @@ export const TeamMemberWrapper = styled(Grid)`
     color: black;
     text-decoration: none;
     height: fit-content;
-    margin: auto 0;
+    margin: 0;
     &:hover {
       color: ${COLOR_MAP.BLUE};
     }


### PR DESCRIPTION
- center-align profile picture and name for team members without a title or description
- add alt-text for profile pictures 