### PR TITLE
Metric explainers CMS config

### DIFF
--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -570,52 +570,44 @@ collections:
           - label: Metadata description
             name: metadataDescription
             widget: text
-      - label: 'Products: Full Pages'
-        name: ProductsFullPages
-        file: src/cms-content/learn/products-full-pages.json
+      - name: Learn-Metric Explainers
+        label: 'Metric Explainers'
+        file: src/cms-content/learn/metric-explainers.json
         fields:
-          - label: Product
-            name: product
+          - label: Page Header
+            name: pageHeader
+            widget: string
+          - label: Page Intro
+            name: pageIntro
+            widget: markdown
+          - label: Sections
+            name: sections
             widget: list
             fields:
-              - {
-                  label: Product name,
-                  name: productName,
-                  widget: string,
-                  hint: 'Product name (ex. API)',
-                }
-              - {
-                  label: Product ID,
-                  name: productId,
-                  widget: string,
-                  hint: 'Must match ID used on products landing page, ie. product name all lowercase, separated by dashes if multi-work (ex. response-simulator)',
-                }
-              - {
-                  label: Product Intro,
-                  name: productIntro,
-                  widget: markdown,
-                  hint: 'Main intro before sections',
-                }
-              - label: Sections
-                name: sections
+              - { label: Section header, name: sectionHeader, widget: string, required: false, hint: 'Use for indiv. metric sections -- metric name ie. Daily New Cases' }
+              - { label: Section subheader, name: sectionSubheader, widget: string, required: false, hint: 'Use for indiv. metric sections -- metric alias ie. Also known as: incidence' }
+              - { label: Section ID, name: sectionId, widget: string, hint: 'Section header, all lowercase, separated by dashes if multi-word' }
+              - { label: Section intro, name: sectionIntro, widget: markdown }
+              - label: Questions
+                name: questions
                 widget: list
                 fields:
-                  - {
-                      label: Section title,
-                      name: sectionTitle,
-                      widget: string,
-                      hint: 'ex: Why our API',
-                    }
-                  - {
-                      label: Section ID,
-                      name: sectionId,
-                      widget: string,
-                      hint: 'Section title all lowercase, separated by dashes if multi-work (ex. why-our-api)',
-                    }
-                  - { label: Section Body, name: sectionBody, widget: markdown }
-              - label: Metadata title
-                name: metadataTitle
-                widget: text
-              - label: Metadata description
-                name: metadataDescription
-                widget: text
+                  - { label: Question, name: question, widget: text }
+                  - { label: Question ID, name: questionId, widget: text }
+                  - { label: Answer, name: answer, widget: markdown }
+          - label: Key metrics section header
+            name: metricsHeader
+            widget: string
+            hint: Should be 'Key metrics'
+          - label: Framework section header
+            name: frameworkHeader
+            widget: text
+          - label: Framework section body
+            name: frameworkBody
+            widget: markdown
+          - label: Metadata title
+            name: metadataTitle
+            widget: text
+          - label: Metadata description
+            name: metadataDescription
+            widget: text

--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -599,9 +599,17 @@ collections:
             name: metricsHeader
             widget: string
             hint: Should be 'Key metrics'
+          - label: Key metrics section ID
+            name: metricsID
+            widget: string
+            hint: Section header, all lowercase, separated by dashed if multi-word
           - label: Framework section header
             name: frameworkHeader
             widget: text
+          - label: Framework section ID
+            name: frameworkID
+            widget: string
+            hint: Section header, all lowercase, separated by dashed if multi-word
           - label: Framework section body
             name: frameworkBody
             widget: markdown

--- a/src/cms-content/learn/index.ts
+++ b/src/cms-content/learn/index.ts
@@ -4,7 +4,6 @@ import glossary from './learn-glossary.json';
 import landing from './learn-landing.json';
 import caseStudies from './learn-case-studies.json';
 import productsLanding from './products-landing.json';
-import productPages from './products-full-pages.json';
 import { sanitizeID, Markdown, TocItem } from '../utils';
 
 /*
@@ -206,35 +205,26 @@ export interface ProductsLandingContent {
 export const productsLandingContent = productsLanding as ProductsLandingContent;
 
 /**
- * Products - full pages:
+ * Metric Explainers:
  **/
 
-export interface BodySection {
-  sectionTitle: string;
+// re-uses Question interface from FAQ
+interface Section {
+  sectionHeader: string;
+  sectionSubheader: string;
   sectionId: string;
-  sectionBody: Markdown;
+  sectionIntro: Markdown;
+  questions: Question[];
 }
 
-export interface ProductPage {
-  productName: string;
-  productId: string;
-  productIntro: Markdown;
-  sections: BodySection[];
+export interface MetricExplainersContent {
+  pageHeader: string;
+  pageIntro: string;
+  sections: Section[];
+  frameworkHeader: string;
+  frameworkBody: Markdown;
   metadataTitle: string;
   metadataDescription: string;
-}
-
-export interface ProductPageContent {
-  product: ProductPage[];
-}
-
-export const productPageContent = productPages as ProductPageContent;
-
-// Used to get full-page product content by product ID
-export function getProductPageContent(
-  productLandingId: string,
-): ProductPage | undefined {
-  return productPages.product.find(item => item.productId === productLandingId);
 }
 
 // TODO (pablo): Should we have a short heading for categories?

--- a/src/cms-content/learn/index.ts
+++ b/src/cms-content/learn/index.ts
@@ -221,6 +221,7 @@ export interface MetricExplainersContent {
   pageHeader: string;
   pageIntro: string;
   sections: Section[];
+  metricsHeader: string;
   frameworkHeader: string;
   frameworkBody: Markdown;
   metadataTitle: string;

--- a/src/cms-content/learn/index.ts
+++ b/src/cms-content/learn/index.ts
@@ -222,7 +222,9 @@ export interface MetricExplainersContent {
   pageIntro: string;
   sections: Section[];
   metricsHeader: string;
+  metricsID: string;
   frameworkHeader: string;
+  frameworkID: string;
   frameworkBody: Markdown;
   metadataTitle: string;
   metadataDescription: string;


### PR DESCRIPTION
- Adds config + types for metric explainers
- Removes config + types for product pages (section nix'ed, no longer needed)