### PR TITLE
Fix horizontal scrollbar on iPhone

### DIFF
--- a/src/components/Banner/Banner.style.ts
+++ b/src/components/Banner/Banner.style.ts
@@ -17,7 +17,7 @@ export const MainContainerStyles = css`
   font-family: Roboto;
   font-style: normal;
   font-weight: 500;
-  line-height: 140%;
+  line-height: 1.4;
   color: #fff;
 
   font-size: 16px;

--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -7,7 +7,7 @@ const Banner: React.FC<{
   renderButton?: () => React.ReactElement;
 }> = ({ message, renderButton }) => {
   return (
-    <Styles.MainContainer container spacing={1} role="banner">
+    <Styles.MainContainer container role="banner">
       <Grid item sm md lg>
         {message}
       </Grid>

--- a/src/components/MapSelectors/GlobalSelector.style.js
+++ b/src/components/MapSelectors/GlobalSelector.style.js
@@ -70,12 +70,20 @@ export const StyledInputWrapper = styled.div`
 `;
 
 export const StyledInput = styled.input`
-  border-radius: ${props => (props.isOpen ? '4px 4px 0 0' : '4px')};
-  font-size: 16px;
+  font-size: 1rem;
   line-height: 1.5rem;
   border: none;
   width: 100%;
   padding: 0 1rem 0 0;
+
+  // When the font-size of an input element is smaller than 16px, Safari will
+  // zoom in when the user enters the input, and won't zoom out when the user
+  // leaves the input area. The fix is increasing the font size from 14px to 16px
+  // and scaling the input element by 14/16 = 0.875.
+  // https://trello.com/c/Kpu34lhS/603-horizontal-scrollbar-on-iphone-after-using-search-box
+  transform: scale(0.875);
+  transform-origin: left top;
+  margin-top: 0.25rem;
 
   &:focus {
     outline: none;

--- a/src/components/MapSelectors/GlobalSelector.style.js
+++ b/src/components/MapSelectors/GlobalSelector.style.js
@@ -50,15 +50,11 @@ export const StyledInputWrapper = styled.div`
   display: flex;
   align-items: center;
   background: white;
-  border-top: 1px solid ${BORDER_COLOR};
-  border-left: 1px solid ${BORDER_COLOR};
-  border-right: 1px solid ${BORDER_COLOR};
-  border-bottom: 1px solid ${BORDER_COLOR};
+  border: solid 1px ${BORDER_COLOR};
   border-radius: ${props => (props.isOpen ? '4px 4px 0 0' : '4px')};
   position: ${props => (props.isOpen ? 'absolute' : 'relative')};
   left: 0;
   right: 0;
-  position: ${props => (props.isOpen ? 'absolute' : 'relative')};
   box-sizing: border-box;
   height: 3.5rem;
   width: 100%;

--- a/src/components/MapSelectors/GlobalSelector.style.js
+++ b/src/components/MapSelectors/GlobalSelector.style.js
@@ -71,7 +71,7 @@ export const StyledInputWrapper = styled.div`
 
 export const StyledInput = styled.input`
   border-radius: ${props => (props.isOpen ? '4px 4px 0 0' : '4px')};
-  font-size: 14px;
+  font-size: 16px;
   line-height: 1.5rem;
   border: none;
   width: 100%;


### PR DESCRIPTION
[Trello](https://trello.com/c/Kpu34lhS/603-horizontal-scrollbar-on-iphone-after-using-search-box) - Horizontal scrollbar on iPhone after using search box

This is a bug in Safari, if the font size on an input element is smaller than 16px, Safari will zoom in when the user focus the input element, but it won't zoom out once the user leaves the input area. The font size of our search input element is 14px 

The best fix I could find is to increase the font-size to 16px (1rem) and scale the input element so the text _looks_ 14px, so by a factor of (14 / 16 = 0.875). I adjusted the spacing around too so it matches (and remove the border radius, which is not necessary since borders are not visible).

## Testing
- Open the page with Safari on iPhone
- Click on the search box, the browser should not zoom-in
- Test in production, the browser will zoom-in
