### PR TITLE
Adds timestamp to glossary+FAQ

### DIFF
--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -360,6 +360,12 @@ collections:
           - label: Intro
             name: intro
             widget: markdown
+          - label: Last updated date
+            name: lastUpdatedDate
+            widget: datetime
+            date_format: 'MMMM Do YYYY'
+            time_format: false
+            hint: To be updated whenever an update to this file is going to be deployed
           - label: Terms
             name: terms
             widget: list
@@ -398,6 +404,12 @@ collections:
           - label: Intro
             name: intro
             widget: markdown
+          - label: Last updated date
+            name: lastUpdatedDate
+            widget: datetime
+            date_format: 'MMMM Do YYYY'
+            time_format: false
+            hint: To be updated whenever an update to this file is going to be deployed
           - label: Sections
             name: sections
             widget: list

--- a/src/cms-content/learn/index.ts
+++ b/src/cms-content/learn/index.ts
@@ -5,7 +5,6 @@ import landing from './learn-landing.json';
 import caseStudies from './learn-case-studies.json';
 import productsLanding from './products-landing.json';
 import { sanitizeID, Markdown, TocItem } from '../utils';
-import moment from 'moment';
 
 /*
   Learn Landing page:
@@ -28,10 +27,6 @@ export interface LandingContent {
 }
 
 export const landingPageContent = landing as LandingContent;
-
-const formatLastUpdatedDate = (date: string) => {
-  return moment(date).format('L');
-};
 
 /*
   FAQ:
@@ -65,7 +60,6 @@ const sanitizeSection = (section: FaqSection): FaqSection => ({
 const sanitizeFaq = (faq: FaqContent): FaqContent => ({
   ...faq,
   sections: faq.sections.map(sanitizeSection),
-  lastUpdatedDate: formatLastUpdatedDate(faq.lastUpdatedDate),
 });
 
 export const faqContent = sanitizeFaq(faq) as FaqContent;
@@ -99,7 +93,6 @@ const sanitizeTerm = (term: Term): Term => ({
 const sanitizeGlossary = (glossary: GlossaryContent): GlossaryContent => ({
   ...glossary,
   terms: glossary.terms.map(sanitizeTerm),
-  lastUpdatedDate: formatLastUpdatedDate(glossary.lastUpdatedDate),
 });
 
 export const glossaryContent = sanitizeGlossary(glossary) as GlossaryContent;

--- a/src/cms-content/learn/index.ts
+++ b/src/cms-content/learn/index.ts
@@ -5,6 +5,7 @@ import landing from './learn-landing.json';
 import caseStudies from './learn-case-studies.json';
 import productsLanding from './products-landing.json';
 import { sanitizeID, Markdown, TocItem } from '../utils';
+import moment from 'moment';
 
 /*
   Learn Landing page:
@@ -28,6 +29,10 @@ export interface LandingContent {
 
 export const landingPageContent = landing as LandingContent;
 
+const formatLastUpdatedDate = (date: string) => {
+  return moment(date).format('L');
+};
+
 /*
   FAQ:
 */
@@ -46,6 +51,7 @@ export interface FaqSection {
 export interface FaqContent {
   header: string;
   intro: Markdown;
+  lastUpdatedDate: string;
   sections: FaqSection[];
   metadataTitle: string;
   metadataDescription: string;
@@ -59,6 +65,7 @@ const sanitizeSection = (section: FaqSection): FaqSection => ({
 const sanitizeFaq = (faq: FaqContent): FaqContent => ({
   ...faq,
   sections: faq.sections.map(sanitizeSection),
+  lastUpdatedDate: formatLastUpdatedDate(faq.lastUpdatedDate),
 });
 
 export const faqContent = sanitizeFaq(faq) as FaqContent;
@@ -77,6 +84,7 @@ export interface Term {
 export interface GlossaryContent {
   header: string;
   intro: Markdown;
+  lastUpdatedDate: string;
   terms: Term[];
   metadataTitle: string;
   metadataDescription: string;
@@ -91,6 +99,7 @@ const sanitizeTerm = (term: Term): Term => ({
 const sanitizeGlossary = (glossary: GlossaryContent): GlossaryContent => ({
   ...glossary,
   terms: glossary.terms.map(sanitizeTerm),
+  lastUpdatedDate: formatLastUpdatedDate(glossary.lastUpdatedDate),
 });
 
 export const glossaryContent = sanitizeGlossary(glossary) as GlossaryContent;

--- a/src/cms-content/learn/learn-faq.json
+++ b/src/cms-content/learn/learn-faq.json
@@ -174,5 +174,6 @@
   "header": "FAQs",
   "intro": "We know that you have a lot of questions, and accurate information is more important than ever. If you have a question you'd like us to include that we don't address here, please [email us](mailto:info@covidactnow.org).",
   "metadataTitle": "COVID-19 FAQ - Covid Act Now",
-  "metadataDescription": "Find trusted answers to the most Frequently Asked Questions (FAQs) about the novel Coronavirus. Make informed decisions to stop the disease for you and your community."
+  "metadataDescription": "Find trusted answers to the most Frequently Asked Questions (FAQs) about the novel Coronavirus. Make informed decisions to stop the disease for you and your community.",
+  "lastUpdatedDate": "2020-12-03T22:17:04.368Z"
 }

--- a/src/cms-content/learn/learn-glossary.json
+++ b/src/cms-content/learn/learn-glossary.json
@@ -484,5 +484,6 @@
     }
   ],
   "metadataTitle": "Glossary of COVID-19 Terminology - Covid Act Now",
-  "metadataDescription": "Find clear definitions of the vocabulary and key terms of the novel Coronavirus (2019-nCoV). Understand the COVID terminology and make informed decisions to stop the pandemic."
+  "metadataDescription": "Find clear definitions of the vocabulary and key terms of the novel Coronavirus (2019-nCoV). Understand the COVID terminology and make informed decisions to stop the pandemic.",
+  "lastUpdatedDate": "2020-12-07T22:16:55.111Z"
 }

--- a/src/common/utils/index.ts
+++ b/src/common/utils/index.ts
@@ -67,6 +67,14 @@ export function formatMetatagDate(): string {
 }
 
 /**
+ * Returns a date formatted for timestamps in Learn (glossary + FAQ), ie: 10/26/2020
+ */
+
+export function formatNumericalDate(date: string): string {
+  return moment(date).format('L');
+}
+
+/**
  * Returns a language-sensitive representation of an integer. For US, it
  * adds commas for thousands, millions, etc.
  */

--- a/src/screens/Learn/Faq/Faq.tsx
+++ b/src/screens/Learn/Faq/Faq.tsx
@@ -6,7 +6,11 @@ import Breadcrumbs from 'components/Breadcrumbs';
 import { MarkdownContent } from 'components/Markdown';
 import PageContent, { MobileOnly } from 'components/PageContent';
 import { faqContent, FaqSection, learnPages } from 'cms-content/learn';
-import { BreadcrumbsContainer, LearnHeading1 } from '../Learn.style';
+import {
+  BreadcrumbsContainer,
+  LearnHeading1,
+  LastUpdatedDate,
+} from '../Learn.style';
 import Section from './Section';
 import { useScrollToTopButton } from 'common/hooks';
 import ScrollToTopButton from 'components/SharedComponents/ScrollToTopButton';
@@ -16,6 +20,7 @@ const Faq: React.FC = () => {
   const {
     header,
     intro,
+    lastUpdatedDate,
     sections,
     metadataTitle,
     metadataDescription,
@@ -48,6 +53,7 @@ const Faq: React.FC = () => {
         </BreadcrumbsContainer>
         <LearnHeading1>{header}</LearnHeading1>
         <MarkdownContent source={intro} />
+        <LastUpdatedDate>Last updated {lastUpdatedDate}</LastUpdatedDate>
         <MobileOnly>
           <TableOfContents items={getSectionItems(sections)} />
         </MobileOnly>

--- a/src/screens/Learn/Faq/Faq.tsx
+++ b/src/screens/Learn/Faq/Faq.tsx
@@ -1,5 +1,5 @@
 import React, { Fragment, useState } from 'react';
-import { formatMetatagDate } from 'common/utils';
+import { formatMetatagDate, formatNumericalDate } from 'common/utils';
 import TableOfContents, { Item } from 'components/TableOfContents';
 import AppMetaTags from 'components/AppMetaTags/AppMetaTags';
 import Breadcrumbs from 'components/Breadcrumbs';
@@ -53,7 +53,9 @@ const Faq: React.FC = () => {
         </BreadcrumbsContainer>
         <LearnHeading1>{header}</LearnHeading1>
         <MarkdownContent source={intro} />
-        <LastUpdatedDate>Last updated {lastUpdatedDate}</LastUpdatedDate>
+        <LastUpdatedDate>
+          Last updated {formatNumericalDate(lastUpdatedDate)}
+        </LastUpdatedDate>
         <MobileOnly>
           <TableOfContents items={getSectionItems(sections)} />
         </MobileOnly>

--- a/src/screens/Learn/Glossary/Glossary.tsx
+++ b/src/screens/Learn/Glossary/Glossary.tsx
@@ -3,6 +3,7 @@ import {
   BreadcrumbsContainer,
   SectionName,
   LearnHeading1,
+  LastUpdatedDate,
 } from '../Learn.style';
 import AppMetaTags from 'components/AppMetaTags/AppMetaTags';
 import { MarkdownContent } from 'components/Markdown';
@@ -19,6 +20,7 @@ const Glossary: React.FC = () => {
   const {
     header,
     intro,
+    lastUpdatedDate,
     terms,
     metadataTitle,
     metadataDescription,
@@ -45,6 +47,7 @@ const Glossary: React.FC = () => {
         </BreadcrumbsContainer>
         <LearnHeading1>{header}</LearnHeading1>
         <MarkdownContent source={intro} />
+        <LastUpdatedDate>Last updated {lastUpdatedDate}</LastUpdatedDate>
         {terms.map((term: Term, i: number) => (
           <Fragment key={`glossary-term-${i}`}>
             <Anchor id={term.termId} />

--- a/src/screens/Learn/Glossary/Glossary.tsx
+++ b/src/screens/Learn/Glossary/Glossary.tsx
@@ -12,7 +12,7 @@ import PageContent from 'components/PageContent';
 import { glossaryContent, learnPages, Term } from 'cms-content/learn';
 import Breadcrumbs from 'components/Breadcrumbs';
 import { Anchor } from 'components/TableOfContents';
-import { formatMetatagDate } from 'common/utils';
+import { formatMetatagDate, formatNumericalDate } from 'common/utils';
 import ScrollToTopButton from 'components/SharedComponents/ScrollToTopButton';
 import { useScrollToTopButton } from 'common/hooks';
 
@@ -47,7 +47,9 @@ const Glossary: React.FC = () => {
         </BreadcrumbsContainer>
         <LearnHeading1>{header}</LearnHeading1>
         <MarkdownContent source={intro} />
-        <LastUpdatedDate>Last updated {lastUpdatedDate}</LastUpdatedDate>
+        <LastUpdatedDate>
+          Last updated {formatNumericalDate(lastUpdatedDate)}
+        </LastUpdatedDate>
         {terms.map((term: Term, i: number) => (
           <Fragment key={`glossary-term-${i}`}>
             <Anchor id={term.termId} />

--- a/src/screens/Learn/Learn.style.tsx
+++ b/src/screens/Learn/Learn.style.tsx
@@ -5,6 +5,7 @@ import {
   Heading2,
   Heading3,
   MarkdownContent,
+  Paragraph,
 } from 'components/Markdown';
 import { mobileBreakpoint, materialSMBreakpoint } from 'assets/theme/sizes';
 
@@ -61,4 +62,8 @@ export const SmallSubtext = styled(MarkdownContent)`
   p {
     font-size: 14px;
   }
+`;
+
+export const LastUpdatedDate = styled(Paragraph)`
+  font-size: 0.875rem;
 `;


### PR DESCRIPTION
- The timestamps are fields in the glossary+FAQ's CMS UIs
- Whoever deploys cms changes for either of those pages needs to be sure to update the respective timestamp to `now` before shipping 