### PR TITLE
Region API: Use region context to access location properties

### DIFF
--- a/src/common/regions.test.ts
+++ b/src/common/regions.test.ts
@@ -2,66 +2,66 @@ import regions, { RegionType } from './regions';
 
 describe('regions', () => {
   test('states() returns all the states', () => {
-    const states = regions.states();
+    const states = regions.states;
     expect(states).toHaveLength(53);
   });
 
   test('counties() returns all the counties', () => {
-    const counties = regions.counties();
+    const counties = regions.counties;
     expect(counties).toHaveLength(3224);
   });
 
   describe('findByFipsCode', () => {
     test('returns a state when passing a valid state FIPS', () => {
       const dc = regions.findByFipsCode('11');
-      expect(dc).toBeTruthy();
+      expect(dc).not.toBeNull();
       expect(dc?.regionType).toBe(RegionType.STATE);
     });
 
     test('returns a county when passing a valid county FIPS', () => {
       const county = regions.findByFipsCode('53033');
-      expect(county).toBeTruthy();
+      expect(county).not.toBeNull();
       expect(county?.regionType).toBe(RegionType.COUNTY);
     });
 
     test('returns null if the FIPS doesn’t exist', () => {
       const notFound = regions.findByFipsCode('xx');
-      expect(notFound).toBe(null);
+      expect(notFound).toBeNull();
     });
   });
 
   describe('findStateByUrlParams', () => {
-    test(`returns the correct state when passing a state code"`, () => {
+    test('returns the correct state when passing a state code', () => {
       const state = regions.findStateByUrlParams('OR');
-      expect(state).toBeTruthy();
+      expect(state).not.toBeNull();
       expect(state?.fipsCode).toBe('41');
     });
 
     test('returns the correct state when passing a valid URL segment', () => {
       const state = regions.findStateByUrlParams('oregon-or');
-      expect(state).toBeTruthy();
+      expect(state).not.toBeNull();
       expect(state?.fipsCode).toBe('41');
     });
 
     test('returns null for invalid params "xxx"', () => {
       const state = regions.findStateByUrlParams('xxx');
-      expect(state).toBe(null);
+      expect(state).toBeNull();
     });
   });
 
   describe('findCountyByUrlParams', () => {
-    test('returns the correct county for valid state and county IDs ', () => {
+    test('returns the correct county for valid state and county IDs', () => {
       const county = regions.findCountyByUrlParams(
         'washington-wa',
         'king_county',
       );
-      expect(county).toBeTruthy();
+      expect(county).not.toBeNull();
       expect(county?.fipsCode).toBe('53033');
     });
 
     test('returns the correct county when using state code as stateId', () => {
       const county = regions.findCountyByUrlParams('wa', 'king_county');
-      expect(county).toBeTruthy();
+      expect(county).not.toBeNull();
       expect(county?.fipsCode).toBe('53033');
     });
 
@@ -72,7 +72,7 @@ describe('regions', () => {
 
     test('returns null for invalid stateId and countyID', () => {
       const county = regions.findCountyByUrlParams('xxx', 'xxx');
-      expect(county).toBe(null);
+      expect(county).toBeNull();
     });
   });
 });

--- a/src/common/regions.test.ts
+++ b/src/common/regions.test.ts
@@ -11,15 +11,69 @@ describe('regions', () => {
     expect(counties).toHaveLength(3224);
   });
 
-  test('findByFipsCode returns a state for a state FIPS', () => {
-    const dc = regions.findByFipsCode('11');
-    expect(dc).toBeTruthy();
-    expect(dc?.regionType).toBe(RegionType.STATE);
+  describe('findByFipsCode', () => {
+    test('returns a state when passing a valid state FIPS', () => {
+      const dc = regions.findByFipsCode('11');
+      expect(dc).toBeTruthy();
+      expect(dc?.regionType).toBe(RegionType.STATE);
+    });
+
+    test('returns a county when passing a valid county FIPS', () => {
+      const county = regions.findByFipsCode('53033');
+      expect(county).toBeTruthy();
+      expect(county?.regionType).toBe(RegionType.COUNTY);
+    });
+
+    test('returns null if the FIPS doesn’t exist', () => {
+      const notFound = regions.findByFipsCode('xx');
+      expect(notFound).toBe(null);
+    });
   });
 
-  test('findByFipsCode returns null if the FIPS doesn’t exist', () => {
-    const notFound = regions.findByFipsCode('xx');
-    expect(notFound).toBe(null);
+  describe('findStateByUrlParams', () => {
+    test(`returns the correct state when passing a state code"`, () => {
+      const state = regions.findStateByUrlParams('OR');
+      expect(state).toBeTruthy();
+      expect(state?.fipsCode).toBe('41');
+    });
+
+    test('returns the correct state when passing a valid URL segment', () => {
+      const state = regions.findStateByUrlParams('oregon-or');
+      expect(state).toBeTruthy();
+      expect(state?.fipsCode).toBe('41');
+    });
+
+    test('returns null for invalid params "xxx"', () => {
+      const state = regions.findStateByUrlParams('xxx');
+      expect(state).toBe(null);
+    });
+  });
+
+  describe('findCountyByUrlParams', () => {
+    test('returns the correct county for valid state and county IDs ', () => {
+      const county = regions.findCountyByUrlParams(
+        'washington-wa',
+        'king_county',
+      );
+      expect(county).toBeTruthy();
+      expect(county?.fipsCode).toBe('53033');
+    });
+
+    test('returns the correct county when using state code as stateId', () => {
+      const county = regions.findCountyByUrlParams('wa', 'king_county');
+      expect(county).toBeTruthy();
+      expect(county?.fipsCode).toBe('53033');
+    });
+
+    test('returns null for invalid stateId and valid countyID', () => {
+      const county = regions.findCountyByUrlParams('xxx', 'king_county');
+      expect(county).toBe(null);
+    });
+
+    test('returns null for invalid stateId and countyID', () => {
+      const county = regions.findCountyByUrlParams('xxx', 'xxx');
+      expect(county).toBe(null);
+    });
   });
 });
 
@@ -41,7 +95,7 @@ describe('State', () => {
 describe('County', () => {
   const county = regions.findByFipsCode('53033');
   test('fullName', () => {
-    expect(county?.fullName()).toBe('King County, WA');
+    expect(county?.fullName()).toBe('King County, Washington');
   });
 
   test('relativeUrl', () => {

--- a/src/common/regions.ts
+++ b/src/common/regions.ts
@@ -141,13 +141,9 @@ class RegionDB {
       return null;
     }
 
-    const stateCounties = this.counties().filter(
-      county => county.state.fipsCode === foundState.fipsCode,
-    );
-
-    const foundCounty = stateCounties.find(county =>
-      equalLower(county.urlSegment, countyId),
-    );
+    const foundCounty = this.counties()
+      .filter(county => county.state.fipsCode === foundState.fipsCode)
+      .find(county => equalLower(county.urlSegment, countyId));
 
     return foundCounty || null;
   }

--- a/src/common/regions.ts
+++ b/src/common/regions.ts
@@ -1,6 +1,7 @@
 import { createContext, useContext } from 'react';
 import { chain, fromPairs } from 'lodash';
 import urlJoin from 'url-join';
+import { assert } from 'common/utils';
 import US_STATE_DATASET from 'components/MapSelectors/datasets/us_states_dataset_01_02_2020.json';
 import countyAdjacencyMsa from './data/county_adjacency_msa.json';
 const { state_dataset, state_county_map_dataset } = US_STATE_DATASET;
@@ -176,4 +177,11 @@ export default regions;
 // value is non-nullable
 export const RegionContext = createContext<Region>(null as any);
 
-export const useLocationPageRegion = () => useContext(RegionContext);
+export const useLocationPageRegion = () => {
+  const region = useContext(RegionContext);
+  assert(
+    region,
+    '`useLocationPageRegion` can only be called from components inside LocationPage',
+  );
+  return region;
+};

--- a/src/components/LocationPage/ChartsHolder.tsx
+++ b/src/components/LocationPage/ChartsHolder.tsx
@@ -25,6 +25,7 @@ import {
 } from 'common/utils/recommend';
 import { mainContent } from 'cms-content/recommendations';
 import { getRecommendationsShareUrl } from 'common/urls';
+import { useRegion } from 'common/regions';
 
 // TODO: 180 is rough accounting for the navbar and searchbar;
 // could make these constants so we don't have to manually update
@@ -45,6 +46,8 @@ const ChartsHolder = (props: {
 }) => {
   const { chartId } = props;
   const projection = props.projections.primary;
+
+  const region = useRegion();
 
   const metricRefs = {
     [Metric.CASE_DENSITY]: useRef<HTMLDivElement>(null),
@@ -177,7 +180,7 @@ const ChartsHolder = (props: {
               <Recommend
                 introCopy={recommendationsIntro}
                 recommendations={recommendationsMainContent}
-                locationName={projection.locationName}
+                locationName={region.fullName()}
                 shareUrl={recommendsShareUrl}
                 shareQuote={recommendsShareQuote}
                 recommendationsRef={recommendationsRef}

--- a/src/components/LocationPage/ChartsHolder.tsx
+++ b/src/components/LocationPage/ChartsHolder.tsx
@@ -25,7 +25,7 @@ import {
 } from 'common/utils/recommend';
 import { mainContent } from 'cms-content/recommendations';
 import { getRecommendationsShareUrl } from 'common/urls';
-import { useRegion } from 'common/regions';
+import { useLocationPageRegion } from 'common/regions';
 
 // TODO: 180 is rough accounting for the navbar and searchbar;
 // could make these constants so we don't have to manually update
@@ -47,7 +47,7 @@ const ChartsHolder = (props: {
   const { chartId } = props;
   const projection = props.projections.primary;
 
-  const region = useRegion();
+  const region = useLocationPageRegion();
 
   const metricRefs = {
     [Metric.CASE_DENSITY]: useRef<HTMLDivElement>(null),

--- a/src/components/LocationPage/LocationPageHeader.tsx
+++ b/src/components/LocationPage/LocationPageHeader.tsx
@@ -51,27 +51,6 @@ const NewFeatureCopy = (props: {
   );
 };
 
-// const LocationPageHeading = (props: { projections: Projections }) => {
-//   const { isEmbed } = useEmbed();
-
-//   const displayName = props.projections.countyName ? (
-//     <>
-//       <strong>{props.projections.countyName}, </strong>
-//       <a
-//         href={`${
-//           isEmbed ? '/embed' : ''
-//         }/us/${props.projections.stateCode.toLowerCase()}`}
-//       >
-//         {props.projections.stateCode}
-//       </a>
-//     </>
-//   ) : (
-//     <strong>{props.projections.stateName}</strong>
-//   );
-
-//   return <span>{displayName}</span>;
-// };
-
 const noop = () => {};
 
 const LocationPageHeader = (props: {
@@ -93,8 +72,6 @@ const LocationPageHeader = (props: {
   //TODO (chelsi): get rid of this use of 'magic' numbers
   const headerTopMargin = !hasStats ? -202 : -218;
   const headerBottomMargin = !hasStats ? 0 : 0;
-
-  const locationName = region.name;
 
   const alarmLevel = projections.getAlarmLevel();
 
@@ -147,7 +124,7 @@ const LocationPageHeader = (props: {
               <SectionColumn>
                 <ColumnTitle>Covid risk level</ColumnTitle>
                 <LevelDescription>{levelInfo.summary}</LevelDescription>
-                <Copy>{levelInfo.detail(locationName)}</Copy>
+                <Copy>{levelInfo.detail(region.name)}</Copy>
               </SectionColumn>
             </SectionHalf>
             <SectionHalf>
@@ -158,7 +135,7 @@ const LocationPageHeader = (props: {
                   <HospitalizationsAlert projection={projections.primary} />
                 ) : (
                   <NewFeatureCopy
-                    locationName={locationName}
+                    locationName={region.name}
                     onNewUpdateClick={props.onNewUpdateClick}
                   />
                 )}

--- a/src/components/LocationPage/LocationPageHeader.tsx
+++ b/src/components/LocationPage/LocationPageHeader.tsx
@@ -37,6 +37,8 @@ import HospitalizationsAlert, {
   isHospitalizationsPeak,
 } from './HospitalizationsAlert';
 import { ThermometerImage } from 'components/Thermometer';
+import { useRegion } from 'common/regions';
+import LocationPageHeading from './LocationPageHeading';
 
 const NewFeatureCopy = (props: {
   locationName: string;
@@ -49,26 +51,26 @@ const NewFeatureCopy = (props: {
   );
 };
 
-const LocationPageHeading = (props: { projections: Projections }) => {
-  const { isEmbed } = useEmbed();
+// const LocationPageHeading = (props: { projections: Projections }) => {
+//   const { isEmbed } = useEmbed();
 
-  const displayName = props.projections.countyName ? (
-    <>
-      <strong>{props.projections.countyName}, </strong>
-      <a
-        href={`${
-          isEmbed ? '/embed' : ''
-        }/us/${props.projections.stateCode.toLowerCase()}`}
-      >
-        {props.projections.stateCode}
-      </a>
-    </>
-  ) : (
-    <strong>{props.projections.stateName}</strong>
-  );
+//   const displayName = props.projections.countyName ? (
+//     <>
+//       <strong>{props.projections.countyName}, </strong>
+//       <a
+//         href={`${
+//           isEmbed ? '/embed' : ''
+//         }/us/${props.projections.stateCode.toLowerCase()}`}
+//       >
+//         {props.projections.stateCode}
+//       </a>
+//     </>
+//   ) : (
+//     <strong>{props.projections.stateName}</strong>
+//   );
 
-  return <span>{displayName}</span>;
-};
+//   return <span>{displayName}</span>;
+// };
 
 const noop = () => {};
 
@@ -86,12 +88,13 @@ const LocationPageHeader = (props: {
     (val: number | null) => val !== null,
   ).length;
   const { projections } = props;
+  const region = useRegion();
 
   //TODO (chelsi): get rid of this use of 'magic' numbers
   const headerTopMargin = !hasStats ? -202 : -218;
   const headerBottomMargin = !hasStats ? 0 : 0;
 
-  const locationName = projections.countyName || projections.stateName;
+  const locationName = region.name;
 
   const alarmLevel = projections.getAlarmLevel();
 
@@ -124,7 +127,7 @@ const LocationPageHeader = (props: {
           <HeaderSection>
             <LocationCopyWrapper>
               <HeaderTitle isEmbed={isEmbed}>
-                <LocationPageHeading projections={projections} />
+                <LocationPageHeading region={region} />
               </HeaderTitle>
             </LocationCopyWrapper>
             <ButtonsWrapper>

--- a/src/components/LocationPage/LocationPageHeader.tsx
+++ b/src/components/LocationPage/LocationPageHeader.tsx
@@ -37,7 +37,7 @@ import HospitalizationsAlert, {
   isHospitalizationsPeak,
 } from './HospitalizationsAlert';
 import { ThermometerImage } from 'components/Thermometer';
-import { useRegion } from 'common/regions';
+import { useLocationPageRegion } from 'common/regions';
 import LocationPageHeading from './LocationPageHeading';
 
 const NewFeatureCopy = (props: {
@@ -67,7 +67,7 @@ const LocationPageHeader = (props: {
     (val: number | null) => val !== null,
   ).length;
   const { projections } = props;
-  const region = useRegion();
+  const region = useLocationPageRegion();
 
   //TODO (chelsi): get rid of this use of 'magic' numbers
   const headerTopMargin = !hasStats ? -202 : -218;
@@ -104,7 +104,7 @@ const LocationPageHeader = (props: {
           <HeaderSection>
             <LocationCopyWrapper>
               <HeaderTitle isEmbed={isEmbed}>
-                <LocationPageHeading region={region} />
+                <LocationPageHeading region={region} isEmbed={isEmbed} />
               </HeaderTitle>
             </LocationCopyWrapper>
             <ButtonsWrapper>

--- a/src/components/LocationPage/LocationPageHeading.tsx
+++ b/src/components/LocationPage/LocationPageHeading.tsx
@@ -1,21 +1,24 @@
 import React, { Fragment } from 'react';
 import { Region, State, County } from 'common/regions';
 
-const LocationPageHeading: React.FC<{ region: Region }> = ({ region }) => {
+const LocationPageHeading: React.FC<{ region: Region; isEmbed: boolean }> = ({
+  region,
+  isEmbed,
+}) => {
   if (region instanceof State) {
     return <strong>{region.name}</strong>;
-  }
-
-  if (region instanceof County) {
+  } else if (region instanceof County) {
     return (
       <Fragment>
         <strong>{region.name}, </strong>
-        {region.state.stateCode}
+        <a href={`${isEmbed ? '/embed' : ''}/us/${region.state.urlSegment}`}>
+          {region.state.stateCode}
+        </a>
       </Fragment>
     );
+  } else {
+    return null;
   }
-
-  return null;
 };
 
 export default LocationPageHeading;

--- a/src/components/LocationPage/LocationPageHeading.tsx
+++ b/src/components/LocationPage/LocationPageHeading.tsx
@@ -1,0 +1,21 @@
+import React, { Fragment } from 'react';
+import { Region, State, County } from 'common/regions';
+
+const LocationPageHeading: React.FC<{ region: Region }> = ({ region }) => {
+  if (region instanceof State) {
+    return <strong>{region.name}</strong>;
+  }
+
+  if (region instanceof County) {
+    return (
+      <Fragment>
+        <strong>{region.name}, </strong>
+        {region.state.stateCode}
+      </Fragment>
+    );
+  }
+
+  return null;
+};
+
+export default LocationPageHeading;

--- a/src/screens/LocationPage/LocationRouter.tsx
+++ b/src/screens/LocationPage/LocationRouter.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useParams, Redirect } from 'react-router-dom';
-import { getCountyByUrlName, getStateByUrlName } from 'common/locations';
+import regions, { RegionContext } from 'common/regions';
 import LocationPage from './LocationPage';
 
 interface LocationPageUrlParams {
@@ -10,15 +10,22 @@ interface LocationPageUrlParams {
 
 const LocationRouter: React.FC = () => {
   let { stateId, countyId } = useParams<LocationPageUrlParams>();
-  const state = getStateByUrlName(stateId);
-  const countyOption =
-    countyId && getCountyByUrlName(state?.state_code, countyId);
 
-  // The URL parameters don't correspond to a valid state or county, we
-  // redirect the user to the homepage
-  const isValidLocation = state && !(countyId && !countyOption);
+  const state = regions.findStateByUrlParams(stateId);
+  const county = countyId
+    ? regions.findCountyByUrlParams(stateId, countyId)
+    : null;
+  const region = county || state;
 
-  return isValidLocation ? <LocationPage /> : <Redirect to="/" />;
+  if (!region) {
+    return <Redirect to="/" />;
+  }
+
+  return (
+    <RegionContext.Provider value={region}>
+      <LocationPage />
+    </RegionContext.Provider>
+  );
 };
 
 export default LocationRouter;


### PR DESCRIPTION
This PR builds on top of  #2043 and uses the proposed region context to get location information from within location pages. It doesn't migrate all the instances yet.

- Adds the methods `findCountyByUrlParams` and `findStateByUrlParams` to `RegionDB` (and corresponding test cases)
- Implements `RegionContext` and `useRegion` to allow accessing the `region` object from anywhere under a location page.

When creating the `RegionContext`, I passed a stand-in region as default value. This allows TypeScript to understand that `useRegion` will always return an instance of `Region` (otherwise we will have to null-check everywhere). Open to suggestions!