### PR TITLE
implement autocomplete regions component

### DIFF
--- a/src/components/AutocompleteLocations/AutocompleteRegions.stories.tsx
+++ b/src/components/AutocompleteLocations/AutocompleteRegions.stories.tsx
@@ -1,0 +1,25 @@
+import React, { Fragment } from 'react';
+import AutocompleteRegions from './AutocompleteRegions';
+import regions from 'common/regions';
+
+export default {
+  title: 'Shared Components/AutocompleteRegions',
+  component: AutocompleteRegions,
+  argTypes: {
+    onChangeRegions: { action: 'change' },
+  },
+};
+
+const states = regions.states;
+
+export const States = (args: any) => (
+  <Fragment>
+    <label id="select-states-label">Select states</label>
+    <AutocompleteRegions
+      {...args}
+      regions={states}
+      selectedRegions={[states[0], states[3]]}
+      ariaLabelledBy="select-states-label"
+    />
+  </Fragment>
+);

--- a/src/components/AutocompleteLocations/AutocompleteRegions.tsx
+++ b/src/components/AutocompleteLocations/AutocompleteRegions.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import Autocomplete from '@material-ui/lab/Autocomplete';
+import { createFilterOptions } from '@material-ui/lab/useAutocomplete';
+import TextField from '@material-ui/core/TextField';
+import { Region } from 'common/regions';
+/**
+ * `createFilterOptions` creates a configuration object that defines how the
+ * user input will be matched against the options in the Autocomplete
+ * component.
+ *
+ * The input of the user will be compared with the output of `getOptionLabel`
+ * applied to each location. The option `matchFrom: 'start'` means that the
+ * beginning of the option label needs to match with the user input. For
+ * example, if the user types "king", "King County, TX" and "Kingfisher County, OR"
+ * will be a match (among others), but not "Rockingham County, NC".
+ *
+ * See material-ui/lab/useAutocomplete.js for additional options.
+ */
+
+function getOptionSelected(option: Region, selectedOption: Region) {
+  return option.fipsCode === selectedOption.fipsCode;
+}
+
+// TODO(Pablo): Use this component for the Newsletter
+const AutocompleteRegions: React.FC<{
+  regions: Region[];
+  selectedRegions: Region[];
+  onChangeRegions: (event: React.ChangeEvent<{}>, newRegions: Region[]) => void;
+  ariaLabelledBy?: string;
+}> = ({ regions, onChangeRegions, selectedRegions, ariaLabelledBy }) => (
+  <Autocomplete
+    multiple
+    options={regions}
+    getOptionLabel={region => region.shortName}
+    onChange={onChangeRegions}
+    getOptionSelected={getOptionSelected}
+    value={selectedRegions}
+    filterOptions={createFilterOptions({ matchFrom: 'start' })}
+    renderInput={params => (
+      <TextField
+        {...params}
+        variant="outlined"
+        placeholder="+ Add"
+        inputProps={{
+          ...params.inputProps,
+          'aria-labelledby': ariaLabelledBy,
+        }}
+      />
+    )}
+  />
+);
+
+export default AutocompleteRegions;


### PR DESCRIPTION
Similar to `AutocompleteLocations`, but for regions. I want to update the email alert form to use this component, but will do that on a separate PR.

I added the `ariaLabelledBy` prop so we can label the input correctly