### PR TITLE
Return NYC from regions database

### DIFF
--- a/src/common/regions/region_db.ts
+++ b/src/common/regions/region_db.ts
@@ -2,6 +2,29 @@ import { sortBy, takeRight, values, Dictionary } from 'lodash';
 import { Region, County, State, MetroArea, FipsCode } from './types';
 import { statesByFips, countiesByFips, metroAreasByFips } from './regions_data';
 
+// More NYC Borough logic.  This should be removed when
+// https://github.com/covid-projections/covid-projections/pull/2090 is merged.
+const NYC_BOROUGH_SEGMENTS = [
+  'new_york_county',
+  'queens_county',
+  'richmond_county',
+  'bronx_county',
+  'kings_county',
+];
+const replaceNYCBoroughURLSegment = (urlSegment: string) => {
+  if (NYC_BOROUGH_SEGMENTS.includes(urlSegment)) {
+    return 'new_york_county';
+  }
+  return urlSegment;
+};
+
+const replaceNYCBoroughFips = (fipsCode: string) => {
+  if (['36047', '36061', '36005', '36081', '36085'].includes(fipsCode)) {
+    return '36061';
+  }
+  return fipsCode;
+};
+
 class RegionDB {
   public states: State[];
   public counties: County[];
@@ -24,7 +47,8 @@ class RegionDB {
   }
 
   findByFipsCode(fipsCode: FipsCode): Region | null {
-    return this.regionsByFips[fipsCode] || null;
+    const fips = replaceNYCBoroughFips(fipsCode);
+    return this.regionsByFips[fips] || null;
   }
 
   findCountiesByStateCode(stateCode: string): County[] {
@@ -54,7 +78,10 @@ class RegionDB {
     const foundCounty = this.counties.find(
       county =>
         county.state.fipsCode === foundState.fipsCode &&
-        equalLower(county.urlSegment, countyUrlSegment),
+        equalLower(
+          county.urlSegment,
+          replaceNYCBoroughURLSegment(countyUrlSegment),
+        ),
     );
 
     return foundCounty || null;

--- a/src/common/regions/regions.test.ts
+++ b/src/common/regions/regions.test.ts
@@ -34,6 +34,11 @@ describe('regions', () => {
       const notFound = regions.findByFipsCode('xx');
       expect(notFound).toBeNull();
     });
+
+    test('Other NYC counties return new york county fips', () => {
+      const region = regions.findByFipsCode('36047');
+      expect(region?.fipsCode).toBe('36061');
+    });
   });
 
   describe('findStateByUrlParams', () => {
@@ -79,6 +84,11 @@ describe('regions', () => {
     test('returns null for invalid stateId and countyID', () => {
       const county = regions.findCountyByUrlParams('xxx', 'xxx');
       expect(county).toBeNull();
+    });
+
+    test('Other NYC counties urls return nyc county', () => {
+      const region = regions.findCountyByUrlParams('NY', 'kings_county');
+      expect(region?.fipsCode).toBe('36061');
     });
   });
 });


### PR DESCRIPTION
Queries to regions from either fips codes or regions were returning the rest of the nyc counties.  we just want to return a single nyc county for all nyc boroughs