### PR TITLE
Updating urls to use region where possible

### DIFF
--- a/src/common/urls.ts
+++ b/src/common/urls.ts
@@ -3,8 +3,8 @@ import { assert } from 'common/utils';
 import { County } from './locations';
 import urlJoin from 'url-join';
 import * as QueryString from 'query-string';
-import { getLocationUrlForFips } from 'common/locations';
 import moment from 'moment';
+import { Region } from './regions';
 
 /**
  * We append a short unique string corresponding to the currently published
@@ -37,19 +37,12 @@ function getPagePath(stateId?: string, county?: County): string {
  * - Does not include the sharing ID (?s=...)
  * - Uses window.origin to determine the base URL, so it should match localhost / staging / prod / etc.
  */
-function getPageBaseUrl(stateId?: string, county?: County): string {
-  return urlJoin(window.location.origin, getPagePath(stateId, county));
+function getPageBaseUrl(): string {
+  return window.location.origin;
 }
 
-function getShareImageBaseUrl(stateId?: string, county?: County): string {
-  const imageBaseUrl = ShareImageUrlJSON.share_image_url;
-  if (county) {
-    return urlJoin(imageBaseUrl, 'counties', county.full_fips_code);
-  } else if (stateId) {
-    return urlJoin(imageBaseUrl, 'states', stateId);
-  } else {
-    return imageBaseUrl;
-  }
+function getShareImageBaseUrl(): string {
+  return ShareImageUrlJSON.share_image_url;
 }
 
 export function getMapImageUrl(): string {
@@ -61,19 +54,16 @@ export function getMapImageUrl(): string {
 }
 
 // TODO(michael): Move existing code over to use this method.
-export function getPageUrl(
-  stateId: string | undefined,
-  county: County | undefined,
-): string {
-  return addSharingId(getPageBaseUrl(stateId, county));
+export function getPageUrl(region: Region): string {
+  return addSharingId(region.canonicalUrl);
 }
 
 /*
   Generates URL for sharing CAN Recommends via
   social/copy-link button in Recommends footer
 */
-export function getRecommendationsShareUrl(fips: string): string {
-  return addSharingId(urlJoin(getLocationUrlForFips(fips), 'recommendations'));
+export function getRecommendationsShareUrl(region: Region): string {
+  return addSharingId(urlJoin(region.canonicalUrl, 'recommendations'));
 }
 
 export function getComparePageUrl(

--- a/src/components/LocationPage/ChartsHolder.tsx
+++ b/src/components/LocationPage/ChartsHolder.tsx
@@ -125,9 +125,7 @@ const ChartsHolder = ({ projections, region, chartId }: ChartsHolderProps) => {
     mainContent.recommendations,
   );
 
-  const recommendsShareUrl = getRecommendationsShareUrl(
-    projections.primary.fips,
-  );
+  const recommendsShareUrl = getRecommendationsShareUrl(projections.region);
 
   const alarmLevel = projections.getAlarmLevel();
   const recommendsShareQuote = getShareQuote(

--- a/src/components/LocationPage/ChartsHolder.tsx
+++ b/src/components/LocationPage/ChartsHolder.tsx
@@ -125,7 +125,7 @@ const ChartsHolder = ({ projections, region, chartId }: ChartsHolderProps) => {
     mainContent.recommendations,
   );
 
-  const recommendsShareUrl = getRecommendationsShareUrl(projections.region);
+  const recommendsShareUrl = getRecommendationsShareUrl(region);
 
   const alarmLevel = projections.getAlarmLevel();
   const recommendsShareQuote = getShareQuote(


### PR DESCRIPTION
This updates a handful of url functions to use region.  one thing to think about is we might want to use `window.location.origin` in `canonicalUrl` so that all the links point to links specific to the domain we're on.

A couple functions didn't have any callers with county and state, so I just removed those arguments in favor of cutting code, can re add if we think we'll use those in the future.