### PR TITLE
Guard against missing counties

### DIFF
--- a/src/screens/internal/CompareSnapshots/CompareSnapshots.tsx
+++ b/src/screens/internal/CompareSnapshots/CompareSnapshots.tsx
@@ -571,6 +571,9 @@ function fetchCountyProjections(
   counties: Region[],
   summaries: SummariesMap | null = null,
 ): Promise<Projections[]> {
+  // If a county is missing in a snapshot, `fetchProjectionsRegion` will fail
+  // an assertion. passing in the summaries map will let us check that the fips
+  // exists in the snapshot before attempting to fetch.
   const isCountyInSummary = (region: Region): boolean => {
     if (!summaries) {
       return true;


### PR DESCRIPTION
This guards against the case where there is a new county in a snapshot.  

If a county is missing in a snapshot, `fetchProjectionsRegion` will fail an assertion. passing in the summaries map will let us check that the fips exists in the snapshot before attempting to fetch.
