### PR TITLE
Fix compare handling missing counties.

### DIFF
--- a/src/common/regions/types.ts
+++ b/src/common/regions/types.ts
@@ -26,6 +26,10 @@ export abstract class Region {
   get canonicalUrl() {
     return urlJoin('https://covidactnow.org', this.relativeUrl);
   }
+
+  toString() {
+    return `${this.name} (fips=${this.fipsCode})`;
+  }
 }
 
 export class State extends Region {

--- a/src/screens/internal/CompareSnapshots/CompareSnapshots.tsx
+++ b/src/screens/internal/CompareSnapshots/CompareSnapshots.tsx
@@ -527,9 +527,12 @@ function fetchCountyProjections(
 ): Promise<Projections[]> {
   return Promise.all(
     counties.map(region =>
-      fetchProjectionsRegion(region, snapshotUrl(snapshotNumber)),
+      fetchProjectionsRegion(region, snapshotUrl(snapshotNumber)).catch(err => {
+        console.error(err);
+        return null;
+      }),
     ),
-  );
+  ).then(counties => counties.filter(p => p !== null) as Projections[]);
 }
 
 async function fetchCountyDiffs(


### PR DESCRIPTION
Also add a toString() method for better handling in log messages, etc.:

Before:
> Error: INTERNAL ASSERTION FAILED: Failed to fetch projections for [object Object]

After:
> Error: INTERNAL ASSERTION FAILED: Failed to fetch projections for Kalawao County (fips=15005)
