### PR TITLE
Reenable email alerts report and add subscriptions by date.

### DIFF
--- a/.github/workflows/alert-email-report-prod.yml
+++ b/.github/workflows/alert-email-report-prod.yml
@@ -1,10 +1,9 @@
 name: Generate Alert Email Report
 
 on:
-# TODO(michael): We need to re-implement this on top of AWS SES API. :-(
-#  schedule:
-#    # 12:00 GMT = 05:00 PDT
-#    - cron: '0 12 * * *'
+  schedule:
+    # 12:00 GMT = 05:00 PDT
+    - cron: '0 12 * * *'
   workflow_dispatch:
 
 jobs:

--- a/scripts/alert_emails/firestore.ts
+++ b/scripts/alert_emails/firestore.ts
@@ -30,23 +30,24 @@ export function getFirestore(): FirebaseFirestore.Firestore {
   return admin.firestore();
 }
 
-export interface FipsEmail {
-  fips: string;
+export interface Subscription {
   email: string;
+  locations: string[];
+  subscribedAt: Date;
 }
 
 export async function fetchAllAlertSubscriptions(
   db: FirebaseFirestore.Firestore,
-): Promise<FipsEmail[]> {
+): Promise<Subscription[]> {
   return new Promise(function (resolve, reject) {
-    const subscriptions: FipsEmail[] = [];
+    const subscriptions: Subscription[] = [];
     db.collection(ALERTS_SUBSCRIPTIONS_COLLECTION)
       .stream()
-      .on('data', emailDoc => {
-        const { locations } = emailDoc.data();
-        locations.forEach((fips: string) => {
-          subscriptions.push({ fips, email: emailDoc.id });
-        });
+      .on('data', subscription => {
+        const data = subscription.data();
+        // Convert Firestore timestamp to plain Date.
+        data.subscribedAt = data.subscribedAt && data.subscribedAt.toDate();
+        subscriptions.push(data);
       })
       .on('end', () => {
         resolve(subscriptions);


### PR DESCRIPTION
I haven't hooked up AWS engagement stats, but we at least get the location stats and the (new) "subscribers by date" stats.

Context: Gaia had asked for a graph of subscribers over time.