### PR TITLE
update location header to support MSAs

### DIFF
--- a/src/components/LocationPage/LocationPageHeader.style.tsx
+++ b/src/components/LocationPage/LocationPageHeader.style.tsx
@@ -1,7 +1,6 @@
 import styled from 'styled-components';
 import Typography from '@material-ui/core/Typography';
 import { Box } from '@material-ui/core';
-import palette from 'assets/theme/palette';
 import { COLORS } from 'common';
 import { COLOR_MAP } from 'common/colors';
 import { Level } from 'common/level';
@@ -80,38 +79,6 @@ export const HeaderSection = styled(Box)`
   @media (min-width: 600px) {
     flex-direction: row;
     justify-content: space-between;
-  }
-`;
-
-export const LocationCopyWrapper = styled(Box)`
-  line-height: 1.4;
-  margin: 1.5rem 1rem;
-
-  @media (min-width: 600px) {
-    margin: 2.5rem 0.875rem 2.5rem 2.25rem;
-  }
-`;
-
-export const HeaderTitle = styled(Typography)<{
-  isEmbed?: Boolean;
-}>`
-  color: ${palette.black};
-  font-size: ${props => (props.isEmbed ? '1.8rem' : '22px')};
-  font-weight: normal;
-  line-height: ${props => (props.isEmbed ? '1.5rem' : '2.2rem')};
-  padding: 0;
-  text-align: center;
-
-  @media (min-width: 600px) {
-    font-size: 30px;
-    text-align: left;
-  }
-`;
-
-export const HeaderStateCode = styled.span`
-  a {
-    color: ${palette.black};
-    text-decoration: none;
   }
 `;
 

--- a/src/components/LocationPage/LocationPageHeader.style.tsx
+++ b/src/components/LocationPage/LocationPageHeader.style.tsx
@@ -102,14 +102,16 @@ export const HeaderTitle = styled(Typography)<{
   padding: 0;
   text-align: center;
 
-  a {
-    color: ${palette.black};
-    text-decoration: none;
-  }
-
   @media (min-width: 600px) {
     font-size: 30px;
     text-align: left;
+  }
+`;
+
+export const HeaderStateCode = styled.span`
+  a {
+    color: ${palette.black};
+    text-decoration: none;
   }
 `;
 

--- a/src/components/LocationPage/LocationPageHeader.tsx
+++ b/src/components/LocationPage/LocationPageHeader.tsx
@@ -5,12 +5,10 @@ import {
   Wrapper,
   TopContainer,
   FooterContainer,
-  HeaderTitle,
   HeaderSection,
   HeaderSubCopy,
   ButtonsWrapper,
   HeaderButton,
-  LocationCopyWrapper,
   LastUpdatedDate,
   SectionHalf,
   Copy,
@@ -96,11 +94,7 @@ const LocationPageHeader = (props: {
       >
         <TopContainer>
           <HeaderSection>
-            <LocationCopyWrapper>
-              <HeaderTitle isEmbed={isEmbed}>
-                <LocationPageHeading region={region} isEmbed={isEmbed} />
-              </HeaderTitle>
-            </LocationCopyWrapper>
+            <LocationPageHeading region={region} isEmbed={isEmbed} />
             <ButtonsWrapper>
               <HeaderButton onClick={props.onHeaderShareClick || noop}>
                 <ShareOutlinedIcon />

--- a/src/components/LocationPage/LocationPageHeading.style.ts
+++ b/src/components/LocationPage/LocationPageHeading.style.ts
@@ -1,0 +1,37 @@
+import styled from 'styled-components';
+import { Box } from '@material-ui/core';
+import Typography from '@material-ui/core/Typography';
+import { materialSMBreakpoint } from 'assets/theme/sizes';
+import palette from 'assets/theme/palette';
+
+export const Container = styled(Box)`
+  line-height: 1.4;
+  margin: 1.5rem 1rem;
+
+  @media (min-width: ${materialSMBreakpoint}) {
+    margin: 2.5rem 0.875rem 2.5rem 2.25rem;
+  }
+`;
+
+export const HeaderTitle = styled(Typography).attrs(props => ({
+  component: 'h1',
+}))<{ $isEmbed?: boolean }>`
+  color: ${palette.black};
+  font-size: ${({ $isEmbed }) => ($isEmbed ? '1.8rem' : '22px')};
+  font-weight: normal;
+  line-height: ${({ $isEmbed }) => ($isEmbed ? '1.5rem' : '2.2rem')};
+  padding: 0;
+  text-align: center;
+
+  @media (min-width: ${materialSMBreakpoint}) {
+    font-size: 30px;
+    text-align: left;
+  }
+`;
+
+export const HeaderStateCode = styled.span`
+  a {
+    color: ${palette.black};
+    text-decoration: none;
+  }
+`;

--- a/src/components/LocationPage/LocationPageHeading.tsx
+++ b/src/components/LocationPage/LocationPageHeading.tsx
@@ -15,7 +15,9 @@ const LocationPageHeading: React.FC<{
       </Styles.Container>
     );
   } else if (region instanceof County) {
-    const stateUrl = `${isEmbed ? '/embed' : ''}/us/${region.state.urlSegment}`;
+    const stateUrl = `${isEmbed ? '/embed' : ''}/us/${
+      region.state.relativeUrl
+    }`;
     return (
       <Styles.Container>
         <Styles.HeaderTitle $isEmbed={isEmbed}>

--- a/src/components/LocationPage/LocationPageHeading.tsx
+++ b/src/components/LocationPage/LocationPageHeading.tsx
@@ -1,5 +1,6 @@
 import React, { Fragment } from 'react';
-import { Region, State, County } from 'common/regions';
+import { Region, State, County, MetroArea } from 'common/regions';
+import { HeaderStateCode } from './LocationPageHeader.style';
 
 const LocationPageHeading: React.FC<{ region: Region; isEmbed: boolean }> = ({
   region,
@@ -10,10 +11,21 @@ const LocationPageHeading: React.FC<{ region: Region; isEmbed: boolean }> = ({
   } else if (region instanceof County) {
     return (
       <Fragment>
-        <strong>{region.name}, </strong>
-        <a href={`${isEmbed ? '/embed' : ''}/us/${region.state.urlSegment}`}>
-          {region.state.stateCode}
-        </a>
+        <strong>{region.name}</strong>
+        {', '}
+        <HeaderStateCode>
+          <a href={`${isEmbed ? '/embed' : ''}/us/${region.state.urlSegment}`}>
+            {region.state.stateCode}
+          </a>
+        </HeaderStateCode>
+      </Fragment>
+    );
+  } else if (region instanceof MetroArea) {
+    return (
+      <Fragment>
+        <strong>{region.name}</strong>
+        {', '}
+        <HeaderStateCode>{region.stateCodes}</HeaderStateCode>
       </Fragment>
     );
   } else {

--- a/src/components/LocationPage/LocationPageHeading.tsx
+++ b/src/components/LocationPage/LocationPageHeading.tsx
@@ -1,32 +1,41 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 import { Region, State, County, MetroArea } from 'common/regions';
-import { HeaderStateCode } from './LocationPageHeader.style';
+import * as Styles from './LocationPageHeading.style';
 
-const LocationPageHeading: React.FC<{ region: Region; isEmbed: boolean }> = ({
-  region,
-  isEmbed,
-}) => {
+const LocationPageHeading: React.FC<{
+  region: Region;
+  isEmbed: boolean;
+}> = ({ region, isEmbed }) => {
   if (region instanceof State) {
-    return <strong>{region.name}</strong>;
-  } else if (region instanceof County) {
     return (
-      <Fragment>
-        <strong>{region.name}</strong>
-        {', '}
-        <HeaderStateCode>
-          <a href={`${isEmbed ? '/embed' : ''}/us/${region.state.urlSegment}`}>
-            {region.state.stateCode}
-          </a>
-        </HeaderStateCode>
-      </Fragment>
+      <Styles.Container>
+        <Styles.HeaderTitle $isEmbed={isEmbed}>
+          <strong>{region.name}</strong>
+        </Styles.HeaderTitle>
+      </Styles.Container>
+    );
+  } else if (region instanceof County) {
+    const stateUrl = `${isEmbed ? '/embed' : ''}/us/${region.state.urlSegment}`;
+    return (
+      <Styles.Container>
+        <Styles.HeaderTitle $isEmbed={isEmbed}>
+          <strong>{region.name}</strong>
+          {', '}
+          <Styles.HeaderStateCode>
+            <a href={stateUrl}>{region.state.stateCode}</a>
+          </Styles.HeaderStateCode>
+        </Styles.HeaderTitle>
+      </Styles.Container>
     );
   } else if (region instanceof MetroArea) {
     return (
-      <Fragment>
-        <strong>{region.name}</strong>
-        {', '}
-        <HeaderStateCode>{region.stateCodes}</HeaderStateCode>
-      </Fragment>
+      <Styles.Container>
+        <Styles.HeaderTitle $isEmbed={isEmbed}>
+          <strong>{region.name}</strong>
+          {', '}
+          <Styles.HeaderStateCode>{region.stateCodes}</Styles.HeaderStateCode>
+        </Styles.HeaderTitle>
+      </Styles.Container>
     );
   } else {
     return null;


### PR DESCRIPTION
Update the `LocationPageHeading` component to support MSAs. I'm not adding a link on the state codes because some MSAs go to more than one state.

![image](https://user-images.githubusercontent.com/114084/102124256-e4866d00-3dfc-11eb-9d6d-cf6923333ea8.png)

I tested this on the `pablo/region-page-draft` branch, but didn't commit the changes there because this can be merged to `develop`.
