### PR TITLE
Filters out DC county

### DIFF
--- a/src/common/regions/regions_data.ts
+++ b/src/common/regions/regions_data.ts
@@ -54,34 +54,38 @@ function buildCounties(
   statesByFips: Dictionary<State>,
   countyAdjacency: { [fipsCode: string]: AdjacencyInfo },
 ): County[] {
-  return chain(state_county_map_dataset)
-    .map(stateData => stateData.county_dataset)
-    .flatten()
-    .map(countyInfo => {
-      /**
-       * TODO: The following counties in New York State have the same
-       * `full_fips_code ` (36061), but different `county_fips_code`.
-       * Determine how we want to handle this before shipping.
-       *
-       * - New York County (county_fips_code: 061)
-       * - Queens County (county_fips_code: 081)
-       * - Richmond County" (county_fips_code: 085)
-       * - Bronx County" (county_fips_code: 005)
-       */
-      const countyFips = `${countyInfo.state_fips_code}${countyInfo.county_fips_code}`;
-      const state = statesByFips[countyInfo.state_fips_code];
-      const adjacentCounties = countyAdjacency[countyFips]?.adjacent_counties;
-      return new County(
-        countyInfo.county,
-        countyInfo.county_url_name,
-        countyFips,
-        countyInfo.population,
-        state,
-        countyInfo.cities || [],
-        adjacentCounties || [],
-      );
-    })
-    .value();
+  return (
+    chain(state_county_map_dataset)
+      .map(stateData => stateData.county_dataset)
+      .flatten()
+      .map(countyInfo => {
+        /**
+         * TODO: The following counties in New York State have the same
+         * `full_fips_code ` (36061), but different `county_fips_code`.
+         * Determine how we want to handle this before shipping.
+         *
+         * - New York County (county_fips_code: 061)
+         * - Queens County (county_fips_code: 081)
+         * - Richmond County" (county_fips_code: 085)
+         * - Bronx County" (county_fips_code: 005)
+         */
+        const countyFips = `${countyInfo.state_fips_code}${countyInfo.county_fips_code}`;
+        const state = statesByFips[countyInfo.state_fips_code];
+        const adjacentCounties = countyAdjacency[countyFips]?.adjacent_counties;
+        return new County(
+          countyInfo.county,
+          countyInfo.county_url_name,
+          countyFips,
+          countyInfo.population,
+          state,
+          countyInfo.cities || [],
+          adjacentCounties || [],
+        );
+      })
+      /* Filtering out DC county (which is redundant to DC state + has mismatching data) */
+      .filter(countyInfo => countyInfo.fipsCode !== '11001')
+      .value()
+  );
 }
 
 function buildMetroAreas(countiesByFips: Dictionary<County>): MetroArea[] {

--- a/src/components/Compare/CompareMain.tsx
+++ b/src/components/Compare/CompareMain.tsx
@@ -130,7 +130,9 @@ const CompareMain = (props: {
 
   const locations = !stateId
     ? homepageLocationsForCompare
-    : locationPageLocationsForCompare;
+    : locationPageLocationsForCompare.filter(
+        location => location.region.fipsCode !== '11001',
+      ); // Note (12/15): filtering out DC county
   const viewMoreCopy = !stateId
     ? homepageViewMoreCopy
     : locationPageViewMoreCopy;

--- a/src/components/Compare/CompareMain.tsx
+++ b/src/components/Compare/CompareMain.tsx
@@ -130,9 +130,7 @@ const CompareMain = (props: {
 
   const locations = !stateId
     ? homepageLocationsForCompare
-    : locationPageLocationsForCompare.filter(
-        location => location.region.fipsCode !== '11001',
-      ); // Note (12/15): filtering out DC county
+    : locationPageLocationsForCompare;
   const viewMoreCopy = !stateId
     ? homepageViewMoreCopy
     : locationPageViewMoreCopy;


### PR DESCRIPTION
DC currently has both a state page and a county page (noticed via DC state page's compare table, which was showing the non-matching county page's data - screenshot below). This PR filters out DC county when building regions in `regions_data.ts`.

[Trello item](https://trello.com/c/tIqXApGD/667-dc-has-two-location-pages-state-and-county-with-different-data)

<img width="959" alt="Screen Shot 2020-12-10 at 2 34 57 PM" src="https://user-images.githubusercontent.com/44076375/102243913-b753c080-3ec9-11eb-9a00-cd024325e1db.png">
