### PR TITLE
More metro area in name

### DIFF
--- a/src/common/regions/regions_data.ts
+++ b/src/common/regions/regions_data.ts
@@ -94,7 +94,7 @@ function buildMetroAreas(countiesByFips: Dictionary<County>): MetroArea[] {
       const [name, statesText] = metro.cbsaTitle.split(', ');
       const stateCodes = statesText.split('-');
       return new MetroArea(
-        name,
+        `${name.split('-')[0]} metro area`,
         metro.urlSegment,
         metro.cbsaCode,
         metro.population,

--- a/src/common/regions/types.ts
+++ b/src/common/regions/types.ts
@@ -110,7 +110,7 @@ export class MetroArea extends Region {
   }
 
   get fullName() {
-    return `${this.name}, ${this.stateCodes}`;
+    return `${this.name}`;
   }
 
   get shortName() {

--- a/src/components/LocationPage/LocationPageHeading.tsx
+++ b/src/components/LocationPage/LocationPageHeading.tsx
@@ -33,9 +33,7 @@ const LocationPageHeading: React.FC<{
     return (
       <Styles.Container>
         <Styles.HeaderTitle $isEmbed={isEmbed}>
-          <strong>{region.name}</strong>
-          {', '}
-          <Styles.HeaderStateCode>{region.stateCodes}</Styles.HeaderStateCode>
+          <strong>{region.fullName}</strong>
         </Styles.HeaderTitle>
       </Styles.Container>
     );


### PR DESCRIPTION
This uses `<first city name> metro area` as the name instead of the full cbsa title.  I think we're going to need to add some more context somewhere, but my thinking is that this is a better starting point than the cbsa title.

Also, in this process I realized that our names are a bit confusing on `Region`.  We have `name`, `fullName`, `shortName`, and `abbrevation`.  As we go forward we may want to be more principled as to what those mean exactly.