### PR TITLE
Remove additional push to history on click of state from state map

### DIFF
--- a/src/components/CountyMap/CountyMap.js
+++ b/src/components/CountyMap/CountyMap.js
@@ -13,7 +13,7 @@ import { CountyMapWrapper, CountyMapLayerWrapper } from './CountyMap.style';
 import regions, { getStateCode } from 'common/regions';
 import { assert } from 'common/utils';
 
-const CountyMap = ({ region, setSelectedCounty }) => {
+const CountyMap = ({ region }) => {
   const stateCode = getStateCode(region);
   assert(stateCode, 'Only regions with states currently supported');
 
@@ -78,7 +78,6 @@ const CountyMap = ({ region, setSelectedCounty }) => {
                   setContent(NAME);
                 }}
                 onMouseLeave={onMouseLeave}
-                onClick={() => setSelectedCounty()}
                 style={{
                   cursor: 'pointer',
                   hover: {

--- a/src/components/Header/SearchHeader.tsx
+++ b/src/components/Header/SearchHeader.tsx
@@ -42,8 +42,6 @@ const SearchHeader = ({
     history.push(route);
 
     window.scrollTo(0, 0);
-
-    setMobileMenuOpen(false);
   };
 
   const toggleMobileMenu = () => {

--- a/src/components/Map/Map.js
+++ b/src/components/Map/Map.js
@@ -1,12 +1,9 @@
 import React, { useState } from 'react';
 import '../../App.css'; /* optional for styling like the :hover pseudo-class */
-import { useHistory } from 'react-router-dom';
-import { REVERSED_STATES } from 'common';
 import { Level } from 'common/level';
 import { LOCATION_SUMMARY_LEVELS } from 'common/metrics/location_summary';
 import { Legend, LegendItem } from './Legend';
 import USACountyMap from './USACountyMap';
-import { MAP_FILTERS } from '../../screens/LocationPage/Enums/MapFilterEnums';
 import ReactTooltip from 'react-tooltip';
 import { MapInstructions, MobileLineBreak } from './Map.style';
 
@@ -16,46 +13,24 @@ function Map({
   hideLegend = false,
   hideInstructions = false,
   hideLegendTitle = false,
-  setMobileMenuOpen,
-  setMapOption,
   onClick = null,
   isMiniMap = false,
   showCounties = false,
 }) {
-  const history = useHistory();
   const [content, setContent] = useState('');
 
-  const goToStatePage = React.useCallback(
-    page => {
-      window.scrollTo(0, 0);
-      history.push(page);
-    },
-    [history],
-  );
-
-  // TODO(michael): Since we wrap every state in a <Link> we may not need this
-  // onClick handler anymore (which would mean we don't need setMobileMenuOpen,
-  // setMapOption, or onClick anymore either!)
+  // TODO(chris): The only user of `onClick` is the embed. When you click on a state
+  // it eventually navigates you to the home page. If we want the action of clicking
+  // on a state to take you to the home page, we should change the link in USACountyMap
+  // rather than redirecting here.
   const handleClick = React.useCallback(
     stateName => {
       // externally provided click handler
       if (onClick) {
-        return onClick(stateName);
-      }
-
-      const stateCode = REVERSED_STATES[stateName];
-
-      goToStatePage(`/us/${stateCode.toLowerCase()}`);
-
-      if (setMapOption) {
-        setMapOption(MAP_FILTERS.STATE);
-      }
-
-      if (setMobileMenuOpen) {
-        setMobileMenuOpen(false);
+        return onClick();
       }
     },
-    [onClick, goToStatePage, setMapOption, setMobileMenuOpen],
+    [onClick],
   );
 
   return (

--- a/src/components/MiniMap/MiniMap.tsx
+++ b/src/components/MiniMap/MiniMap.tsx
@@ -9,7 +9,6 @@ import RegionMap from 'components/RegionMap';
 interface MiniMapProperties {
   region: Region;
   mobileMenuOpen: boolean;
-  setMobileMenuOpen: (input: boolean) => void;
   mapOption: string;
   setMapOption: (input: string) => void;
 }
@@ -21,14 +20,9 @@ interface MiniMapProperties {
 const MiniMap: FunctionComponent<MiniMapProperties> = ({
   region,
   mobileMenuOpen,
-  setMobileMenuOpen,
   mapOption,
   setMapOption,
 }) => {
-  const onSelectCounty = () => {
-    setMobileMenuOpen(false);
-  };
-
   // Exception for District of Columbia
   const showState = !region.fipsCode.startsWith('11');
 
@@ -66,7 +60,7 @@ const MiniMap: FunctionComponent<MiniMapProperties> = ({
         {/* State Map */}
         {mapOption === MAP_FILTERS.STATE && (
           <Styles.StateMapContainer>
-            <CountyMap region={region} setSelectedCounty={onSelectCounty} />
+            <CountyMap region={region} />
           </Styles.StateMapContainer>
         )}
         {mapOption === MAP_FILTERS.MSA && (

--- a/src/components/MiniMap/MiniMap.tsx
+++ b/src/components/MiniMap/MiniMap.tsx
@@ -61,12 +61,7 @@ const MiniMap: FunctionComponent<MiniMapProperties> = ({
       <Styles.MapContainer>
         {/* US Map */}
         {mapOption === MAP_FILTERS.NATIONAL && (
-          <Map
-            hideLegend={true}
-            setMapOption={setMapOption}
-            setMobileMenuOpen={setMobileMenuOpen}
-            isMiniMap
-          />
+          <Map hideLegend={true} isMiniMap />
         )}
         {/* State Map */}
         {mapOption === MAP_FILTERS.STATE && (

--- a/src/components/SocialLocationPreview/SocialLocationPreview.tsx
+++ b/src/components/SocialLocationPreview/SocialLocationPreview.tsx
@@ -51,8 +51,6 @@ const SocialLocationPreview = (props: {
               hideLegend={!isEmbed}
               hideLegendTitle={true}
               hideInstructions={true}
-              setMapOption={function () {}}
-              setMobileMenuOpen={function () {}}
             />
           </MapWrapper>
           {isEmbed ? (

--- a/src/screens/LocationPage/LocationPage.tsx
+++ b/src/screens/LocationPage/LocationPage.tsx
@@ -30,13 +30,15 @@ function LocationPage({ region }: LocationPageProps) {
   };
   const [mapOption, setMapOption] = useState(defaultMapOption(region));
 
-  useEffect(() => {
-    setMapOption(defaultMapOption(region));
-  }, [region]);
-
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const projections = useProjectionsFromRegion(region);
 
+  useEffect(() => {
+    setMapOption(defaultMapOption(region));
+
+    // Close the map on mobile on any change to a region.
+    setMobileMenuOpen(false);
+  }, [region]);
   // Projections haven't loaded yet
   // If a new county has just been selected, we may not have projections
   // for the new county loaded yet
@@ -70,7 +72,6 @@ function LocationPage({ region }: LocationPageProps) {
         <MiniMap
           region={region}
           mobileMenuOpen={mobileMenuOpen}
-          setMobileMenuOpen={setMobileMenuOpen}
           mapOption={mapOption}
           setMapOption={setMapOption}
         />


### PR DESCRIPTION
This removes most of the logic in the `goToStatePage` click handler when navigating to a state from the map.  It was causing some weirdness in the history by including an old url.  

Now that we are using links in the map, we don't need to control as much state from places that we click.  For instance, in this PR I move the logic to close the mobile map to simply change when the region changes on a location page.