### PR TITLE
fix: filter out county projections if the county is not in the regions instance

### DIFF
--- a/src/common/utils/model.ts
+++ b/src/common/utils/model.ts
@@ -75,6 +75,8 @@ export function fetchAllCountyProjections(snapshotUrl: string | null = null) {
           getStateName(summaryWithTimeseries.state) !== undefined,
       )
       .filter(summaryWithTimeseries => {
+        // We don't want to return county projections for counties that we
+        // don't have in the regions instance
         const region = regions.findByFipsCode(summaryWithTimeseries.fips);
         return region instanceof County;
       })

--- a/src/common/utils/model.ts
+++ b/src/common/utils/model.ts
@@ -81,8 +81,7 @@ export function fetchAllCountyProjections(snapshotUrl: string | null = null) {
         return region instanceof County;
       })
       .map(summaryWithTimeseries => {
-        const region = regions.findByFipsCode(summaryWithTimeseries.fips);
-        assert(region, 'Failed to find region ' + summaryWithTimeseries.fips);
+        const region = regions.findByFipsCodeStrict(summaryWithTimeseries.fips);
         return new Projections(summaryWithTimeseries, region);
       });
   }

--- a/src/common/utils/model.ts
+++ b/src/common/utils/model.ts
@@ -5,7 +5,7 @@ import { getStateName } from 'common/locations';
 import moment from 'moment';
 import { assert } from '.';
 import { getSnapshotUrlOverride } from './snapshots';
-import regions, { Region } from 'common/regions';
+import regions, { Region, County } from 'common/regions';
 
 export enum APIRegionSubPath {
   COUNTIES = 'counties',
@@ -74,6 +74,10 @@ export function fetchAllCountyProjections(snapshotUrl: string | null = null) {
         summaryWithTimeseries =>
           getStateName(summaryWithTimeseries.state) !== undefined,
       )
+      .filter(summaryWithTimeseries => {
+        const region = regions.findByFipsCode(summaryWithTimeseries.fips);
+        return region instanceof County;
+      })
       .map(summaryWithTimeseries => {
         const region = regions.findByFipsCode(summaryWithTimeseries.fips);
         assert(region, 'Failed to find region ' + summaryWithTimeseries.fips);


### PR DESCRIPTION
The job [update-data-snapshot](https://github.com/covid-projections/covid-projections/runs/1560828963?check_suite_focus=true#step:10:24) failed because because the API returns the projections for the county with FIPS `11001` (District of Columbia), but we don't have it in `regions` as a county (we have it as a state, with FIPS code "11").

This PR filters out the county projections that don't have a county.