### PR TITLE
Embed with regions

### DIFF
--- a/public/scripts/embed.js
+++ b/public/scripts/embed.js
@@ -124,10 +124,17 @@
       href = 'https://covidactnow.org/embed/us/';
       var fips = widget.getAttribute('data-fips-id');
       var stateId = widget.getAttribute('data-state-id');
-      if (fips) {
-        href += 'county/' + fips;
-      } else if (stateId) {
-        href += stateId;
+      // Fips can be passed to embed,
+      if (stateId) {
+        // Older versions of the embed passed state id + optionally fips.
+        // In a later version, we will always pass fips and send embeds to one url
+        if (fips) {
+          href += 'county/' + fips;
+        } else if (stateId) {
+          href += stateId;
+        }
+      } else if (fips) {
+        href += 'fips/' + fips;
       }
 
       // duplicated in EmbedEnums.ts

--- a/public/scripts/embed.js
+++ b/public/scripts/embed.js
@@ -124,16 +124,16 @@
       href = 'https://covidactnow.org/embed/us/';
       var fips = widget.getAttribute('data-fips-id');
       var stateId = widget.getAttribute('data-state-id');
-      // Fips can be passed to embed,
       if (stateId) {
-        // Older versions of the embed passed state id + optionally fips.
-        // In a later version, we will always pass fips and send embeds to one url
+        // Older versions of the embed passed state id + optionally fips. This block
+        // handles that case.
         if (fips) {
           href += 'county/' + fips;
         } else if (stateId) {
           href += stateId;
         }
       } else if (fips) {
+        // In most recent version, we will only pass fips and send all embeds to one url.
         href += 'fips/' + fips;
       }
 

--- a/src/App.js
+++ b/src/App.js
@@ -183,7 +183,7 @@ export default function App() {
                 path="/embed/us/county/:countyFipsId"
                 component={Embed}
               />
-
+              <Route exact path="/embed/us/fips/:fipsCode" component={Embed} />
               {/* <Route path="/donate" component={ComingSoon} /> */}
               {/* /model, /contact, and /about are deprecated in favor of /faq */}
               <Route path="/model">

--- a/src/common/regions/region_hooks.ts
+++ b/src/common/regions/region_hooks.ts
@@ -19,13 +19,23 @@ export const useLocationPageRegion = () => {
 };
 
 export const useRegionFromParams = (): Region | null => {
-  const { stateId, countyId, countyFipsId, metroAreaUrlSegment } = useParams<{
+  const {
+    stateId,
+    countyId,
+    countyFipsId,
+    metroAreaUrlSegment,
+    fipsCode,
+  } = useParams<{
     stateId?: string;
     countyId?: string;
     countyFipsId: string;
     metroAreaUrlSegment?: string;
+    fipsCode?: string;
   }>();
 
+  if (fipsCode) {
+    return regions.findByFipsCode(fipsCode);
+  }
   if (countyFipsId) {
     return regions.findByFipsCode(countyFipsId);
   }

--- a/src/common/utils/hooks.tsx
+++ b/src/common/utils/hooks.tsx
@@ -1,5 +1,5 @@
 import { Region } from 'common/regions';
-import { useLocation, useParams } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 import {
   EMBED_HEIGHT,
   EMBED_WIDTH,
@@ -9,8 +9,6 @@ import {
 
 export function useEmbed(region?: Region) {
   // Check if we're embedded in an iFrame
-  const { stateId } = useParams();
-
   const hostPath = window.location.origin;
 
   const getEmbedHeight = () => (region ? EMBED_HEIGHT : US_MAP_EMBED_HEIGHT);
@@ -35,7 +33,6 @@ export function useEmbed(region?: Region) {
     return (
       '<div ' +
       'class="covid-act-now-embed" ' +
-      (stateId ? `data-state-id="${stateId}" ` : '') +
       (region ? `data-fips-id="${region.fipsCode}" ` : '') +
       '/>' +
       `<script src="${hostPath}/scripts/embed.js"></script>`

--- a/src/common/utils/hooks.tsx
+++ b/src/common/utils/hooks.tsx
@@ -1,3 +1,4 @@
+import { Region } from 'common/regions';
 import { useLocation, useParams } from 'react-router-dom';
 import {
   EMBED_HEIGHT,

--- a/src/common/utils/hooks.tsx
+++ b/src/common/utils/hooks.tsx
@@ -6,50 +6,42 @@ import {
   US_MAP_EMBED_WIDTH,
 } from 'screens/Embed/EmbedEnums';
 
-export function useEmbed() {
+export function useEmbed(region?: Region) {
   // Check if we're embedded in an iFrame
-  const { pathname } = useLocation();
   const { stateId } = useParams();
 
-  const isEmbed = pathname.includes('/embed');
   const hostPath = window.location.origin;
 
-  const getEmbedHeight = (countyFipsCode: string | null) =>
-    !stateId && !countyFipsCode ? US_MAP_EMBED_HEIGHT : EMBED_HEIGHT;
+  const getEmbedHeight = () => (region ? EMBED_HEIGHT : US_MAP_EMBED_HEIGHT);
 
-  const getEmbedWidth = (countyFipsCode: string | null) =>
-    !stateId && !countyFipsCode ? US_MAP_EMBED_WIDTH : EMBED_WIDTH;
+  const getEmbedWidth = () => (region ? EMBED_WIDTH : US_MAP_EMBED_WIDTH);
 
-  const getPath = (countyFipsCode: string) =>
-    // Either "/us/county/:countyId" or "/us/:stateId"
-    `us/${countyFipsCode ? 'county/' + countyFipsCode : stateId || ''}`;
+  const getPath = () => (region ? `us/fips/${region.fipsCode}` : 'us/');
 
-  const getIframePath = (countyFipsCode: string) =>
-    `${hostPath}/embed/${getPath(countyFipsCode)}`;
+  const getIframePath = () => `${hostPath}/embed/${getPath()}`;
 
-  const getIframeCodeSnippet = (countyFipsCode: string) =>
+  const getIframeCodeSnippet = () =>
     '<iframe ' +
-    `src="${getIframePath(countyFipsCode)}" ` +
+    `src="${getIframePath()}" ` +
     'title="CoVid Act Now" ' +
-    `width="${getEmbedWidth(countyFipsCode)}" ` +
-    `height="${getEmbedHeight(countyFipsCode)}" ` +
+    `width="${getEmbedWidth()}" ` +
+    `height="${getEmbedHeight()}" ` +
     'frameBorder="0" ' +
     'scrolling="no"' +
     '></iframe>';
 
-  const getJsCodeSnippet = (countyFipsCode: string) => {
+  const getJsCodeSnippet = () => {
     return (
       '<div ' +
       'class="covid-act-now-embed" ' +
       (stateId ? `data-state-id="${stateId}" ` : '') +
-      (countyFipsCode ? `data-fips-id="${countyFipsCode}" ` : '') +
+      (region ? `data-fips-id="${region.fipsCode}" ` : '') +
       '/>' +
       `<script src="${hostPath}/scripts/embed.js"></script>`
     );
   };
 
   return {
-    isEmbed,
     EMBED_WIDTH,
     EMBED_HEIGHT,
     getEmbedWidth,
@@ -59,3 +51,8 @@ export function useEmbed() {
     getJsCodeSnippet,
   };
 }
+
+export const useIsEmbed = () => {
+  const { pathname } = useLocation();
+  return pathname.includes('/embed');
+};

--- a/src/components/AppBar/NavBar.tsx
+++ b/src/components/AppBar/NavBar.tsx
@@ -5,7 +5,7 @@ import ArrowBack from '@material-ui/icons/ArrowBack';
 import * as Style from './NavBar.style';
 import MobileMenu from './MobileMenu';
 import { DonateButtonWithoutFade } from './DonateButton';
-import { useEmbed } from 'common/utils/hooks';
+import { useIsEmbed } from 'common/utils/hooks';
 
 const isLocationPage = (pathname: string) => pathname.includes('/us');
 
@@ -21,7 +21,7 @@ const NavBar: React.FC = () => {
   const [isMenuOpen, setMenuOpen] = useState(false);
   const closeMenu = () => setMenuOpen(false);
 
-  const { isEmbed } = useEmbed();
+  const isEmbed = useIsEmbed();
 
   // We only fade the donate button on the home page on mobile, where the donate
   // button doesn't appear until the banner is scrolled away.

--- a/src/components/AppBar/SocialIcons.tsx
+++ b/src/components/AppBar/SocialIcons.tsx
@@ -7,7 +7,7 @@ Keeping all social-icons-related code here for if/when we reinstate them.
 import React, { Fragment } from 'react';
 import { find } from 'lodash';
 import { useLocation, match as MatchType, matchPath } from 'react-router-dom';
-import { useEmbed } from 'common/utils/hooks';
+import { useIsEmbed } from 'common/utils/hooks';
 import {
   FacebookIcon,
   FacebookShareButton,
@@ -57,7 +57,7 @@ function locationNameFromMatch(
 const SocialIcons = (props: { isMobile: boolean }) => {
   const { isMobile } = props;
   const locationPath = useLocation();
-  const { isEmbed } = useEmbed();
+  const isEmbed = useIsEmbed();
 
   // Don't show in iFrame
   if (isEmbed) return null;

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import Logo from 'assets/images/footerlogoDarkWithURL';
-import { useEmbed } from 'common/utils/hooks';
+import { useIsEmbed } from 'common/utils/hooks';
 import ExternalLink from 'components/ExternalLink';
 import FooterSocialLinks from './FooterSocialLinks';
 import {
@@ -16,7 +16,7 @@ import {
 const Footer = ({ children }: { children: React.ReactNode }) => {
   const { pathname } = useLocation();
   const isMapPage = pathname.startsWith('/us') || pathname.startsWith('/state');
-  const { isEmbed } = useEmbed();
+  const isEmbed = useIsEmbed();
 
   if (isEmbed) {
     return null;

--- a/src/components/LocationPage/LocationPageHeader.tsx
+++ b/src/components/LocationPage/LocationPageHeader.tsx
@@ -17,7 +17,7 @@ import {
   LevelDescription,
   WarningIcon,
 } from 'components/LocationPage/LocationPageHeader.style';
-import { useEmbed } from 'common/utils/hooks';
+import { useIsEmbed } from 'common/utils/hooks';
 import { LOCATION_SUMMARY_LEVELS } from 'common/metrics/location_summary';
 import { Level } from 'common/level';
 import { COLOR_MAP } from 'common/colors';
@@ -76,7 +76,7 @@ const LocationPageHeader = (props: {
   const fillColor =
     alarmLevel !== Level.UNKNOWN ? levelInfo.color : COLOR_MAP.GRAY.LIGHT;
 
-  const { isEmbed } = useEmbed();
+  const isEmbed = useIsEmbed();
 
   const lastUpdatedDate: Date | null = useModelLastUpdatedDate() || new Date();
   const lastUpdatedDateString =

--- a/src/components/ShareBlock/EmbedPreview.tsx
+++ b/src/components/ShareBlock/EmbedPreview.tsx
@@ -17,8 +17,8 @@ import Snackbar from '@material-ui/core/Snackbar';
 import Typography from '@material-ui/core/Typography';
 import { CopyToClipboard } from 'react-copy-to-clipboard';
 
-import { useEmbed } from 'common/utils/hooks';
-import { County } from 'common/locations';
+import { useEmbed, useIsEmbed } from 'common/utils/hooks';
+import { Region } from 'common/regions';
 
 interface Message {
   message: string;
@@ -28,16 +28,16 @@ interface Message {
 const EmbedPreview: React.FC<{
   open: boolean;
   onClose: () => void;
-  county: County;
-}> = ({ open, onClose, county }) => {
+  region?: Region;
+}> = ({ open, onClose, region }) => {
+  const isEmbed = useIsEmbed();
   const {
-    isEmbed,
     getEmbedHeight,
     getEmbedWidth,
     getIframePath,
     getJsCodeSnippet,
     getIframeCodeSnippet,
-  } = useEmbed();
+  } = useEmbed(region);
 
   // When you click both copy links back to back, it'll trigger multiple snackbar
   // messages.  We show them serially using a queue per example at
@@ -81,10 +81,9 @@ const EmbedPreview: React.FC<{
     processSnackbarQueue();
   };
 
-  const countyFipsCode = county && county['full_fips_code'];
-  const iFramePath = getIframePath(countyFipsCode);
-  const iFrameCodeSnippet = getIframeCodeSnippet(countyFipsCode);
-  const jsCodeSnippet = getJsCodeSnippet(countyFipsCode);
+  const iFramePath = getIframePath();
+  const iFrameCodeSnippet = getIframeCodeSnippet();
+  const jsCodeSnippet = getJsCodeSnippet();
 
   return (
     <>
@@ -101,8 +100,8 @@ const EmbedPreview: React.FC<{
                   <iframe
                     src={iFramePath}
                     title="Embed Preview"
-                    width={getEmbedWidth(countyFipsCode)}
-                    height={getEmbedHeight(countyFipsCode)}
+                    width={getEmbedWidth()}
+                    height={getEmbedHeight()}
                     frameBorder="0"
                   ></iframe>
                 </Grid>

--- a/src/components/ShareBlock/ShareModelBlock.tsx
+++ b/src/components/ShareBlock/ShareModelBlock.tsx
@@ -4,7 +4,6 @@ import { County, MetroArea, Region, State } from 'common/regions';
 
 import EmbedPreview from './EmbedPreview';
 import { Projections } from 'common/models/Projections';
-import { findCountyByFips } from 'common/locations';
 import { fail } from 'common/utils';
 
 const BASE_SHARE_URL = 'https://covidactnow.org/us';
@@ -23,7 +22,6 @@ const ShareModelBlock = ({
   const { displayName, shareURL } = getUrlAndShareQuote(region);
   const shareQuote = `I'm keeping track of ${displayName}'s COVID data and risk level with @CovidActNow. What does your community look like?`;
   const [showEmbedPreviewModal, setShowEmbedPreviewModal] = useState(false);
-  const county = region && findCountyByFips(region.fipsCode);
   return (
     <>
       <ShareBlock
@@ -38,7 +36,7 @@ const ShareModelBlock = ({
       <EmbedPreview
         open={showEmbedPreviewModal}
         onClose={() => setShowEmbedPreviewModal(false)}
-        county={county}
+        region={region}
       />
     </>
   );


### PR DESCRIPTION
Separates out the `isEmbed` logic into it's own hook as it's a pretty different use case, and this felt more clean to separate the `useEmbed` to rely solely on the region passed into it rather than url params.

Also modified the embed so that all embed requests hit `/embed/fips/<fipsCode` instead of having separate sections for state and county.  This will let it work seamlessly with Metros.  As a result, I had to change the public Embed script to handle the old version of the embed (with state code + optionally fips) set and the new version (with just fips).

I don't have a ton of experience with the embeds so i might be missing something, but it seems to work on my tests!