### PR TITLE
add search icons for MSA items

### DIFF
--- a/src/components/Search/MenuItem.tsx
+++ b/src/components/Search/MenuItem.tsx
@@ -1,15 +1,13 @@
 import React from 'react';
 import ShortNumber from 'common/utils/ShortNumber';
-import StateCircleSvg from 'components/StateSvg/StateCircleSvg';
 import {
   MenuItemWrapper,
-  IconWrapper,
   LocationName,
   Zipcode,
   StyledLink,
 } from './Search.style';
-import { getLocationIconFillColor } from 'components/Search';
-import { getStateCode, State, County, Region } from 'common/regions';
+import { Region } from 'common/regions';
+import MenuItemIcon from './MenuItemIcon';
 
 const MenuItem: React.FC<{ region: Region; zipCodeInput: string }> = ({
   region,
@@ -18,16 +16,7 @@ const MenuItem: React.FC<{ region: Region; zipCodeInput: string }> = ({
   return (
     <StyledLink to={`/${region.relativeUrl}`}>
       <MenuItemWrapper>
-        {/* TODO (chelsi): fix once figured out metro icon/svg */}
-        {(region instanceof State || region instanceof County) && (
-          <IconWrapper>
-            <StateCircleSvg
-              ratio={0.8}
-              fillColor={getLocationIconFillColor(region)}
-              state={getStateCode(region)}
-            />
-          </IconWrapper>
-        )}
+        <MenuItemIcon region={region} />
         <div>
           <LocationName>{region.shortName}</LocationName>
           {zipCodeInput && <Zipcode>contains zipcode {zipCodeInput}</Zipcode>}

--- a/src/components/Search/MenuItemIcon.tsx
+++ b/src/components/Search/MenuItemIcon.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import StateCircleSvg from 'components/StateSvg/StateCircleSvg';
+import { IconWrapper } from './Search.style';
+import { getLocationIconFillColor } from 'components/Search';
+import { getStateCode, State, County, MetroArea, Region } from 'common/regions';
+import MetroItemIcon from './MetroItemIcon';
+
+const MenuItemIcon: React.FC<{ region: Region }> = ({ region }) => {
+  const fillColor = getLocationIconFillColor(region);
+  if (region instanceof State || region instanceof County) {
+    return (
+      <IconWrapper>
+        <StateCircleSvg
+          ratio={0.8}
+          fillColor={fillColor}
+          state={getStateCode(region)}
+        />
+      </IconWrapper>
+    );
+  } else if (region instanceof MetroArea) {
+    return (
+      <IconWrapper>
+        <MetroItemIcon ratio={0.8} fillColor={fillColor} />
+      </IconWrapper>
+    );
+  } else {
+    return null;
+  }
+};
+
+export default MenuItemIcon;

--- a/src/components/Search/MetroItemIcon.tsx
+++ b/src/components/Search/MetroItemIcon.tsx
@@ -2,13 +2,13 @@ import React from 'react';
 import { CircleWrapper, StateWrapper } from 'components/StateSvg/Circle.style';
 import RoomIcon from '@material-ui/icons/Room';
 
+// Taken from components/StateSvg/Circle
 const MetroItemIcon: React.FC<{ ratio: number; fillColor: string }> = ({
   ratio,
   fillColor,
 }) => {
   const DEFAULT_SIZE = 64;
   const DEFAULT_CIRCLE_RADIUS = 32;
-
   const size = ratio * DEFAULT_SIZE;
 
   return (

--- a/src/components/Search/MetroItemIcon.tsx
+++ b/src/components/Search/MetroItemIcon.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { CircleWrapper, StateWrapper } from 'components/StateSvg/Circle.style';
+import RoomIcon from '@material-ui/icons/Room';
+
+const MetroItemIcon: React.FC<{ ratio: number; fillColor: string }> = ({
+  ratio,
+  fillColor,
+}) => {
+  const DEFAULT_SIZE = 64;
+  const DEFAULT_CIRCLE_RADIUS = 32;
+
+  const size = ratio * DEFAULT_SIZE;
+
+  return (
+    <CircleWrapper size={size}>
+      <div>
+        <svg
+          width={size}
+          height={size}
+          viewBox="0 0 64 64"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <g>
+            <circle
+              cx="32"
+              cy="32"
+              r={ratio * DEFAULT_CIRCLE_RADIUS}
+              fill={fillColor}
+            />
+          </g>
+        </svg>
+      </div>
+      <StateWrapper size={size} ratio={ratio}>
+        <RoomIcon />
+      </StateWrapper>
+    </CircleWrapper>
+  );
+};
+
+export default MetroItemIcon;

--- a/src/components/StateSvg/Circle.style.ts
+++ b/src/components/StateSvg/Circle.style.ts
@@ -1,11 +1,11 @@
 import styled from 'styled-components';
 
-export const CircleWrapper = styled.div`
+export const CircleWrapper = styled.div<{ size: number }>`
   position: relative;
   width: ${props => props.size}px;
 `;
 
-export const StateWrapper = styled.div`
+export const StateWrapper = styled.div<{ ratio: number; size: number }>`
   position: absolute;
   width: ${props => (props.ratio === 1 ? 1 : props.ratio * 0.9) * 38}px;
   height: ${props => (props.ratio === 1 ? 1 : props.ratio * 0.9) * 38}px;


### PR DESCRIPTION
Based on the [mocks](https://www.figma.com/file/NMKWJ9RU3SxSPZcF1w5VCT/MSA-County-Bundling?node-id=108%3A1475). Using the icon from Material UI that looks closer to the one in the mocks.

![image](https://user-images.githubusercontent.com/114084/102421162-a46be980-3fb8-11eb-8f5a-47412d2f433a.png)
