### PR TITLE
Remove unused state+setState variables

### DIFF
--- a/src/components/Compare/CompareMain.tsx
+++ b/src/components/Compare/CompareMain.tsx
@@ -109,7 +109,6 @@ const CompareMain = (props: {
   const [countyTypeToView, setCountyTypeToView] = useState(MetroFilter.ALL);
 
   // For homepage:
-  const [viewAllCounties, setViewAllCounties] = useState(false);
   const [homepageScope, setHomepageScope] = useState(
     HomepageLocationScope.COUNTY,
   );
@@ -164,7 +163,10 @@ const CompareMain = (props: {
     scrollToCompare();
   };
 
+  // Location page slider:
   const defaultSliderValue = scopeValueMap[geoScope];
+
+  // Homepage slider:
   const [sliderValue, setSliderValue] = useState(defaultSliderValue);
 
   const defaultHomepageSliderValue = homepageScopeValueMap[homepageScope];
@@ -236,7 +238,6 @@ const CompareMain = (props: {
     currentCounty,
     ...uiState,
     setCountyTypeToView,
-    setViewAllCounties,
     setGeoScope,
     setSorter,
     setSortDescending,

--- a/src/components/Compare/CompareTable.tsx
+++ b/src/components/Compare/CompareTable.tsx
@@ -43,8 +43,6 @@ const CompareTable = (props: {
   isHomepage?: boolean;
   locations: SummaryForCompare[];
   currentCounty?: any;
-  viewAllCounties?: boolean;
-  setViewAllCounties?: React.Dispatch<React.SetStateAction<boolean>>;
   viewMoreCopy?: string;
   setCountyTypeToView: React.Dispatch<React.SetStateAction<MetroFilter>>;
   countyTypeToView: MetroFilter;
@@ -85,7 +83,6 @@ const CompareTable = (props: {
     homepageSliderValue,
     setHomepageSliderValue,
   } = props;
-  const { setViewAllCounties } = props;
 
   const currentCounty = props.county && props.currentCounty;
 
@@ -256,8 +253,6 @@ const CompareTable = (props: {
               isHomepage={props.isHomepage}
               countyTypeToView={props.countyTypeToView}
               setCountyTypeToView={props.setCountyTypeToView}
-              viewAllCounties={props.viewAllCounties}
-              setViewAllCounties={setViewAllCounties}
               stateId={props.stateId}
               county={props.county}
               geoScope={props.geoScope}
@@ -287,7 +282,6 @@ const CompareTable = (props: {
         setSortByPopulation={setSortByPopulation}
         sortByPopulation={sortByPopulation}
         isHomepage={props.isHomepage}
-        viewAllCounties={props.viewAllCounties}
         geoScope={props.geoScope}
         homepageScope={homepageScope}
       />

--- a/src/components/Compare/Filters.tsx
+++ b/src/components/Compare/Filters.tsx
@@ -47,8 +47,6 @@ const Filters = (props: {
   isHomepage?: boolean;
   setCountyTypeToView: React.Dispatch<React.SetStateAction<MetroFilter>>;
   countyTypeToView: MetroFilter;
-  viewAllCounties?: boolean;
-  setViewAllCounties?: React.Dispatch<React.SetStateAction<boolean>>;
   stateId?: string;
   county?: any | null;
   geoScope?: GeoScopeFilter;

--- a/src/components/Compare/LocationTable.tsx
+++ b/src/components/Compare/LocationTable.tsx
@@ -181,7 +181,6 @@ const LocationTable: React.FunctionComponent<{
   setSortByPopulation: React.Dispatch<React.SetStateAction<boolean>>;
   sortByPopulation: boolean;
   isHomepage?: boolean;
-  viewAllCounties?: boolean;
   geoScope?: GeoScopeFilter;
   homepageScope: HomepageLocationScope;
 }> = ({
@@ -201,7 +200,6 @@ const LocationTable: React.FunctionComponent<{
   setSortByPopulation,
   sortByPopulation,
   isHomepage,
-  viewAllCounties,
   geoScope,
   homepageScope,
 }) => {

--- a/src/components/Compare/ModalCompare.tsx
+++ b/src/components/Compare/ModalCompare.tsx
@@ -19,10 +19,8 @@ const ModalCompare = (props: {
   locations: SummaryForCompare[];
   currentCounty?: any;
   handleCloseModal: () => void;
-  viewAllCounties?: boolean;
   setCountyTypeToView: React.Dispatch<React.SetStateAction<MetroFilter>>;
   countyTypeToView: MetroFilter;
-  setViewAllCounties?: React.Dispatch<React.SetStateAction<boolean>>;
   geoScope?: GeoScopeFilter;
   setGeoScope?: React.Dispatch<React.SetStateAction<GeoScopeFilter>>;
   stateId?: string;
@@ -36,7 +34,6 @@ const ModalCompare = (props: {
   setSliderValue: React.Dispatch<React.SetStateAction<GeoScopeFilter>>;
   setShowFaqModal: React.Dispatch<React.SetStateAction<boolean>>;
   createCompareShareId: () => Promise<string>;
-
   homepageScope: HomepageLocationScope;
   setHomepageScope: React.Dispatch<React.SetStateAction<HomepageLocationScope>>;
   homepageSliderValue: HomepageLocationScope;
@@ -68,8 +65,6 @@ const ModalCompare = (props: {
           isHomepage={props.isHomepage}
           countyTypeToView={props.countyTypeToView}
           setCountyTypeToView={props.setCountyTypeToView}
-          viewAllCounties={props.viewAllCounties}
-          setViewAllCounties={props.setViewAllCounties}
           stateId={props.stateId}
           county={props.county}
           geoScope={props.geoScope}
@@ -92,10 +87,8 @@ const ModalCompare = (props: {
         isHomepage={props.isHomepage}
         locations={props.locations}
         currentCounty={props.currentCounty}
-        viewAllCounties={props.viewAllCounties}
         countyTypeToView={props.countyTypeToView}
         setCountyTypeToView={props.setCountyTypeToView}
-        setViewAllCounties={props.setViewAllCounties}
         geoScope={props.geoScope}
         setGeoScope={props.setGeoScope}
         stateId={props.stateId}


### PR DESCRIPTION
`viewAllCounties` and `setViewAllCounties` controlled the state<->county switch that is no longer used (replaced by state/city/county slider)