### PR TITLE
Location page header redirect fix 

### DIFF
--- a/src/components/LocationPage/LocationPageHeading.tsx
+++ b/src/components/LocationPage/LocationPageHeading.tsx
@@ -15,9 +15,7 @@ const LocationPageHeading: React.FC<{
       </Styles.Container>
     );
   } else if (region instanceof County) {
-    const stateUrl = `${isEmbed ? '/embed' : ''}/us/${
-      region.state.relativeUrl
-    }`;
+    const stateUrl = `${isEmbed ? '/embed' : ''}/${region.state.relativeUrl}`;
     return (
       <Styles.Container>
         <Styles.HeaderTitle $isEmbed={isEmbed}>


### PR DESCRIPTION
There was an extra `/us` in the stateCode redirect on county pages