### PR TITLE
change sort order to be by county population on location pages

### DIFF
--- a/src/common/regions/utils.ts
+++ b/src/common/regions/utils.ts
@@ -7,6 +7,9 @@ export function belongsToState(county: County, stateFips: string | null) {
   return county.state.fipsCode === stateFips;
 }
 
+const sortByPopulation = (regions: Region[]): Region[] =>
+  sortBy(regions, region => -region.population);
+
 /**
  * Returns a list of regions in the order that is most relevant given the
  * region passed as argument
@@ -28,10 +31,7 @@ export function getAutocompleteRegions(region?: Region) {
     const [countiesInMetro, otherCounties] = partition(counties, county =>
       region.counties.includes(county),
     );
-    const sortedMetroCounties = sortBy(
-      countiesInMetro,
-      county => -county.population,
-    );
+    const sortedMetroCounties = sortByPopulation(countiesInMetro);
 
     return concat<Region>(
       sortedMetroCounties,
@@ -44,10 +44,7 @@ export function getAutocompleteRegions(region?: Region) {
     const [stateCounties, otherCounties] = partition(counties, county =>
       belongsToState(county, stateFips),
     );
-    const sortedStateCounties = sortBy(
-      stateCounties,
-      county => -county.population,
-    );
+    const sortedStateCounties = sortByPopulation(stateCounties);
 
     return concat<Region>(
       sortedStateCounties,

--- a/src/common/regions/utils.ts
+++ b/src/common/regions/utils.ts
@@ -1,4 +1,4 @@
-import { concat, partition } from 'lodash';
+import { concat, partition, sortBy } from 'lodash';
 import regions from './region_db';
 import { getStateFips } from './regions_data';
 import { County, State, Region, MetroArea } from './types';
@@ -28,13 +28,33 @@ export function getAutocompleteRegions(region?: Region) {
     const [countiesInMetro, otherCounties] = partition(counties, county =>
       region.counties.includes(county),
     );
-    return concat<Region>(countiesInMetro, states, otherCounties, metroAreas);
+    const sortedMetroCounties = sortBy(
+      countiesInMetro,
+      county => -county.population,
+    );
+
+    return concat<Region>(
+      sortedMetroCounties,
+      states,
+      otherCounties,
+      metroAreas,
+    );
   } else if (region instanceof State || region instanceof County) {
     const stateFips = getStateFips(region);
     const [stateCounties, otherCounties] = partition(counties, county =>
       belongsToState(county, stateFips),
     );
-    return concat<Region>(stateCounties, states, metroAreas, otherCounties);
+    const sortedStateCounties = sortBy(
+      stateCounties,
+      county => -county.population,
+    );
+
+    return concat<Region>(
+      sortedStateCounties,
+      states,
+      metroAreas,
+      otherCounties,
+    );
   } else {
     return [];
   }


### PR DESCRIPTION
Proposal to match closer to the behavior we have on production - just sorts the counties in a state from largest to smallest when you're on a state, county or metro page