### PR TITLE
update generate-index-page

### DIFF
--- a/scripts/generate_index_pages.ts
+++ b/scripts/generate_index_pages.ts
@@ -145,7 +145,7 @@ async function main() {
   }
 
   for (const state of regions.states) {
-    const relativeImageUrl = `/states/${state.fipsCode}`;
+    const relativeImageUrl = `/states/${state.stateCode.toLowerCase()}`;
     await buildLocationPages(
       builder,
       state.relativeUrl,


### PR DESCRIPTION
The `generate-index-pages` script was using the old URL structure for sharing, even when the sharing component was using new URLs (`https://covidactnow.org/us/washington-wa`).

I also discovered that the `index.html` pages for sharing have the wrong canonical URL and image URL (for example, see `og:url` in https://covidactnow.org/us/alabama-al/county/baldwin_county/chart/0?s=1485441)

![image](https://user-images.githubusercontent.com/114084/103588891-112f2100-4e9f-11eb-8e8c-6cbee5ac0e24.png)

I fixed the canonical URL, but might need help with the `image` tag (I think that the regular expression is ignoring meta tags with ` data-react-helmet="true"`).

