### PR TITLE
Adds state codes to metro labels in compare + search autocomplete

### DIFF
--- a/src/common/regions/index.ts
+++ b/src/common/regions/index.ts
@@ -1,8 +1,13 @@
 import regions from 'common/regions/region_db';
-import { getStateName, getStateCode, getStateFips } from './regions_data';
+import {
+  getStateName,
+  getStateCode,
+  getStateFips,
+  getFormattedStateCode,
+} from './regions_data';
 
 export default regions;
-export { getStateName, getStateCode, getStateFips };
+export { getStateName, getStateCode, getStateFips, getFormattedStateCode };
 export * from './types';
 export * from './region_hooks';
 export * from './utils';

--- a/src/common/regions/regions_data.ts
+++ b/src/common/regions/regions_data.ts
@@ -27,6 +27,12 @@ export function getStateName(region: Region): string | null {
   return null;
 }
 
+/*
+Returns each region's version of a stateCode:
+  metro -> dash-separated list of all states in which the MSA resides ('NY-NJ-PA')
+  state -> state's stateCode ('NY')
+  county -> stateCode of county's state ('NY')
+*/
 export function getStateCode(region: Region): string | null {
   if (region.regionType === RegionType.COUNTY) {
     return (region as County).state.stateCode;

--- a/src/common/regions/regions_data.ts
+++ b/src/common/regions/regions_data.ts
@@ -34,6 +34,9 @@ export function getStateCode(region: Region): string | null {
   if (region.regionType === RegionType.STATE) {
     return (region as State).stateCode;
   }
+  if (region.regionType === RegionType.MSA) {
+    return (region as MetroArea).stateCodes;
+  }
   return null;
 }
 

--- a/src/common/regions/regions_data.ts
+++ b/src/common/regions/regions_data.ts
@@ -27,12 +27,6 @@ export function getStateName(region: Region): string | null {
   return null;
 }
 
-/*
-Returns each region's version of a stateCode:
-  metro -> dash-separated list of all states in which the MSA resides ('NY-NJ-PA')
-  state -> state's stateCode ('NY')
-  county -> stateCode of county's state ('NY')
-*/
 export function getStateCode(region: Region): string | null {
   if (region.regionType === RegionType.COUNTY) {
     return (region as County).state.stateCode;
@@ -40,10 +34,26 @@ export function getStateCode(region: Region): string | null {
   if (region.regionType === RegionType.STATE) {
     return (region as State).stateCode;
   }
-  if (region.regionType === RegionType.MSA) {
-    return (region as MetroArea).stateCodes;
-  }
   return null;
+}
+
+/*
+Goes one step beyond getStateCode(). Inludes MSAs and returns each regionType's 'version' of a stateCode:
+  metro -> dash-separated list of all states in which the MSA resides ('NY-NJ-PA')
+  state -> state's stateCode ('NY')
+  county -> stateCode of county's state ('NY')
+*/
+export function getFormattedStateCode(region: Region): string | null {
+  if (
+    region.regionType === RegionType.COUNTY ||
+    region.regionType === RegionType.STATE
+  ) {
+    return getStateCode(region);
+  } else if (region.regionType === RegionType.MSA) {
+    return (region as MetroArea).stateCodes;
+  } else {
+    return null;
+  }
 }
 
 export const getStateFips = (region: Region): string | null => {

--- a/src/common/utils/compare.ts
+++ b/src/common/utils/compare.ts
@@ -261,21 +261,27 @@ export function getAbbreviatedCounty(county: string) {
   else return county.replace('County', 'Co.');
 }
 
-function splitCountyName(countyName: string) {
-  const splitCounty = countyName.split(' ');
-  const suffix = splitCounty.pop();
-  const withoutSuffix = splitCounty;
-  return [withoutSuffix.join(' '), suffix];
+/*
+Used to split location names for county and metro in order ot set multiple font weights:
+(final format once eventually styled: bold locationName, non-bold suffix)
+  ie: [bold] Boston [non-bold] metro
+  ie: [bold] Fairfield [non-bold] Co.
+*/
+function splitLocationName(locationName: string) {
+  const splitLocation = locationName.split(' ');
+  const suffix = splitLocation.pop();
+  const finalSuffix = suffix?.includes('metro') ? `${suffix},` : suffix;
+  const withoutSuffix = splitLocation;
+  return [withoutSuffix.join(' '), finalSuffix];
 }
 
 export function getColumnLocationName(region: Region) {
   if (region instanceof State) {
     return [region.fullName];
   } else if (region instanceof County) {
-    const countyWithAbbreviatedSuffix = region.abbreviation;
-    return splitCountyName(countyWithAbbreviatedSuffix);
+    return splitLocationName(region.abbreviation);
   } else if (region instanceof MetroArea) {
-    return [region.shortName];
+    return splitLocationName(region.shortName);
   } else {
     fail('dont support other regions');
   }

--- a/src/common/utils/compare.ts
+++ b/src/common/utils/compare.ts
@@ -14,7 +14,7 @@ import regions, {
   State,
   MetroArea,
   getStateName,
-  getStateCode,
+  getFormattedStateCode,
 } from 'common/regions';
 import { fail } from 'assert';
 import { assert } from '.';
@@ -390,7 +390,7 @@ export function getShareQuote(
 // Determines which location field is shown under the main Compare feature header + formats it
 export const getCompareSubheader = (region: Region): string => {
   if (region instanceof County) {
-    return `${getAbbreviatedCounty(region.name)}, ${getStateCode(
+    return `${getAbbreviatedCounty(region.name)}, ${getFormattedStateCode(
       region,
     )} to other counties`;
   } else if (region instanceof MetroArea || region instanceof State) {

--- a/src/common/utils/compare.ts
+++ b/src/common/utils/compare.ts
@@ -262,26 +262,32 @@ export function getAbbreviatedCounty(county: string) {
 }
 
 /*
-Used to split location names for county and metro in order ot set multiple font weights:
-(final format once eventually styled: bold locationName, non-bold suffix)
-  ie: [bold] Boston [non-bold] metro
-  ie: [bold] Fairfield [non-bold] Co.
+Used to split region names for county and metro in order to set multiple font weights.
+Outputs arr with split name:
+  metro ex: ['Boston', 'metro,']
+  county ex: ['Fairfield', 'Co.']
+
+(Final format once eventually styled: bold locationName, non-bold suffix):
+  ex: [bold] Boston [non-bold] metro
+  ex: [bold] Fairfield [non-bold] Co.
 */
-function splitLocationName(locationName: string) {
-  const splitLocation = locationName.split(' ');
-  const suffix = splitLocation.pop();
-  const finalSuffix = suffix?.includes('metro') ? `${suffix},` : suffix;
-  const withoutSuffix = splitLocation;
-  return [withoutSuffix.join(' '), finalSuffix];
+function splitRegionName(regionName: string) {
+  const splitRegion = regionName.split(' ');
+  const suffixUnformatted = splitRegion.pop();
+  const regionSuffix = suffixUnformatted?.includes('metro')
+    ? `${suffixUnformatted},`
+    : suffixUnformatted;
+  const regionNameMain = splitRegion.join(' ');
+  return [regionNameMain, regionSuffix];
 }
 
-export function getColumnLocationName(region: Region) {
+export function getRegionNameForRow(region: Region) {
   if (region instanceof State) {
     return [region.fullName];
   } else if (region instanceof County) {
-    return splitLocationName(region.abbreviation);
+    return splitRegionName(region.abbreviation);
   } else if (region instanceof MetroArea) {
-    return splitLocationName(region.shortName);
+    return splitRegionName(region.shortName);
   } else {
     fail('dont support other regions');
   }

--- a/src/components/Compare/Compare.style.tsx
+++ b/src/components/Compare/Compare.style.tsx
@@ -281,7 +281,7 @@ export const LocationInfoWrapper = styled.div`
   align-items: center;
 `;
 
-export const LocationSuffix = styled.span`
+export const RegionSuffix = styled.span`
   font-weight: normal;
   margin-right: 0.25rem;
 `;

--- a/src/components/Compare/Compare.style.tsx
+++ b/src/components/Compare/Compare.style.tsx
@@ -281,7 +281,7 @@ export const LocationInfoWrapper = styled.div`
   align-items: center;
 `;
 
-export const CountySuffix = styled.span`
+export const LocationSuffix = styled.span`
   font-weight: normal;
   margin-right: 0.25rem;
 `;

--- a/src/components/Compare/CompareTableRow.tsx
+++ b/src/components/Compare/CompareTableRow.tsx
@@ -19,7 +19,7 @@ import {
 } from 'common/utils/compare';
 import { Level } from 'common/level';
 import { formatEstimate } from 'common/utils';
-import regions, { getStateCode } from 'common/regions';
+import regions, { getFormattedStateCode } from 'common/regions';
 import { fail } from 'assert';
 
 function cellValue(metric: any, metricType: Metric) {
@@ -88,7 +88,7 @@ const CompareTableRow = (props: {
             {regionNameMain}{' '}
             {regionSuffix && <RegionSuffix>{regionSuffix}</RegionSuffix>}
             {showStateCode && (
-              <Fragment>{getStateCode(location.region)}</Fragment>
+              <Fragment>{getFormattedStateCode(location.region)}</Fragment>
             )}
             <br />
             <LocationInfoWrapper>

--- a/src/components/Compare/CompareTableRow.tsx
+++ b/src/components/Compare/CompareTableRow.tsx
@@ -6,7 +6,7 @@ import {
   Row,
   MetricValue,
   Population,
-  LocationSuffix,
+  RegionSuffix,
   LocationInfoWrapper,
   LocationNameCell,
   Rank,
@@ -15,7 +15,7 @@ import { Metric, formatValue } from 'common/metric';
 import {
   RankedLocationSummary,
   orderedMetrics,
-  getColumnLocationName,
+  getRegionNameForRow,
 } from 'common/utils/compare';
 import { Level } from 'common/level';
 import { formatEstimate } from 'common/utils';
@@ -64,7 +64,8 @@ const CompareTableRow = (props: {
     fail(`missing region for fips code ${fipsCode}`);
   }
   const locationLink = region.relativeUrl;
-  const locationName = getColumnLocationName(location.region);
+
+  const [regionNameMain, regionSuffix] = getRegionNameForRow(location.region);
 
   const populationRoundTo = isHomepage ? 3 : 2;
 
@@ -84,10 +85,8 @@ const CompareTableRow = (props: {
             <FiberManualRecordIcon />
           </div>
           <div>
-            {locationName[0]}{' '}
-            {locationName[1] && (
-              <LocationSuffix>{locationName[1]}</LocationSuffix>
-            )}
+            {regionNameMain}{' '}
+            {regionSuffix && <RegionSuffix>{regionSuffix}</RegionSuffix>}
             {showStateCode && (
               <Fragment>{getStateCode(location.region)}</Fragment>
             )}

--- a/src/components/Compare/CompareTableRow.tsx
+++ b/src/components/Compare/CompareTableRow.tsx
@@ -6,7 +6,7 @@ import {
   Row,
   MetricValue,
   Population,
-  CountySuffix,
+  LocationSuffix,
   LocationInfoWrapper,
   LocationNameCell,
   Rank,
@@ -85,7 +85,9 @@ const CompareTableRow = (props: {
           </div>
           <div>
             {locationName[0]}{' '}
-            {locationName[1] && <CountySuffix>{locationName[1]}</CountySuffix>}
+            {locationName[1] && (
+              <LocationSuffix>{locationName[1]}</LocationSuffix>
+            )}
             {showStateCode && (
               <Fragment>{getStateCode(location.region)}</Fragment>
             )}

--- a/src/components/Compare/LocationTable.tsx
+++ b/src/components/Compare/LocationTable.tsx
@@ -258,7 +258,7 @@ const LocationTable: React.FunctionComponent<{
     if (region) {
       return region instanceof MetroArea || geoScope === GeoScopeFilter.NEARBY;
     } else {
-      return homepageScope === HomepageLocationScope.COUNTY;
+      return homepageScope !== HomepageLocationScope.STATE;
     }
   };
 

--- a/src/components/Search/MenuItem.tsx
+++ b/src/components/Search/MenuItem.tsx
@@ -6,19 +6,23 @@ import {
   Zipcode,
   StyledLink,
 } from './Search.style';
-import { Region } from 'common/regions';
+import { Region, MetroArea } from 'common/regions';
 import MenuItemIcon from './MenuItemIcon';
 
 const MenuItem: React.FC<{ region: Region; zipCodeInput: string }> = ({
   region,
   zipCodeInput,
 }) => {
+  const locationLabel =
+    region instanceof MetroArea
+      ? `${region.shortName}, ${region.stateCodes}`
+      : region.shortName;
   return (
     <StyledLink to={region.relativeUrl}>
       <MenuItemWrapper>
         <MenuItemIcon region={region} />
         <div>
-          <LocationName>{region.shortName}</LocationName>
+          <LocationName>{locationLabel}</LocationName>
           {zipCodeInput && <Zipcode>contains zipcode {zipCodeInput}</Zipcode>}
           <div>
             <span>{ShortNumber(region.population)} residents</span>


### PR DESCRIPTION
Trello items:
- [Add state codes](https://trello.com/c/1sDb8zix/722-add-state-codes-to-metro-names-in-search-albany-metro-has-3-identical-search-results)
- [Format/style metro names in compare](https://trello.com/c/QsOLuKKO/709-compare-table-metros-name-bolding)