### PR TITLE
Fixes autocomplete bug

### DIFF
--- a/src/components/Search/SearchAutocomplete.tsx
+++ b/src/components/Search/SearchAutocomplete.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { Autocomplete } from '@material-ui/lab';
 import { createFilterOptions } from '@material-ui/lab/useAutocomplete';
 import TextField from '@material-ui/core/TextField';
-import { Region, County } from 'common/regions';
+import { Region, County, MetroArea } from 'common/regions';
 import MenuItem from './MenuItem';
 import { StyledPaper } from './Search.style';
 
@@ -33,8 +33,13 @@ const SearchAutocomplete: React.FC<{
   const stringifyOption = (option: Region) => {
     if (checkForZipcodeMatch && (option as County).zipCodes) {
       return `${(option as County).zipCodes.join(' ')}`;
+    } else {
+      if (option instanceof MetroArea) {
+        return `${option.shortName}, ${(option as MetroArea).stateCodes}`;
+      } else {
+        return option.shortName;
+      }
     }
-    return option.name;
   };
 
   const onSelect = (e: any, value: Region) => {


### PR DESCRIPTION
Addresses bug mentioned in [this trello card](https://trello.com/c/PhgcJBxK/723-search-priority-inconsistent-across-pages-align-on-homepage-search-order):
"For example, another question i have is: should searching metro pull up the metros? Also, right now if you search "new york metro area" it actually doesn't show the result (seems like a bug)."

Search was matching against the wrong location name variation. This fixes (now matches against the same name variation used throughout the dropdown menu).