### PR TITLE
Update autocomplete locations order

### DIFF
--- a/src/common/regions/utils.ts
+++ b/src/common/regions/utils.ts
@@ -36,8 +36,8 @@ export function getAutocompleteRegions(region?: Region) {
     return concat<Region>(
       sortedMetroCounties,
       states,
-      otherCounties,
       metroAreas,
+      otherCounties,
     );
   } else if (region instanceof State || region instanceof County) {
     const stateFips = getStateFips(region);


### PR DESCRIPTION
Per [this trello ticket](https://trello.com/c/PhgcJBxK/723-search-priority-inconsistent-across-pages-align-on-homepage-search-order), edits order of autocomplete locations.

Homepage order: all states, all metros, all counties
Location page order: counties in page's state/metro, all states, all metros, counties not in page's state/metro