### PR TITLE
Use div for beta tag so google (hopefully) indexes it as a separate word.

### DIFF
--- a/src/components/LocationPage/ChartsHolder.style.tsx
+++ b/src/components/LocationPage/ChartsHolder.style.tsx
@@ -91,7 +91,7 @@ export const ChartDescription = styled(Typography)`
   margin-bottom: 1rem;
 `;
 
-export const BetaTag = styled.span`
+export const BetaTag = styled.div`
   font-size: 0.675rem;
   padding: 0 0.75rem;
   line-height: 1.25rem;


### PR DESCRIPTION
Currently Google is picking up "ICU capacity usedBeta".  I'm assuming if we use a `<div>` it'll at least treat beta as a separate word.  But we could also add an explicit space before it or something. 🤷 

![image](https://user-images.githubusercontent.com/206364/103715274-0c3ca100-4f75-11eb-8846-e38840e16357.png)
