### PR TITLE
updates titles and descriptions

### DIFF
--- a/cypress/integration/ModelPage_spec.js
+++ b/cypress/integration/ModelPage_spec.js
@@ -3,7 +3,7 @@ describe('/state/:id', () => {
     cy.visit('/us/ny');
     cy.title().should(
       'eq',
-      'New York (NY) - COVID Risk Map & Key Metrics - Covid Act Now',
+      'New York (NY) - COVID Data & Key Metrics - Covid Act Now',
     );
     cy.get('head meta[name="description"]')
       .should('have.attr', 'content')

--- a/src/cms-content/learn/learn-faq.json
+++ b/src/cms-content/learn/learn-faq.json
@@ -178,7 +178,7 @@
   ],
   "header": "FAQs",
   "intro": "\"Who is most at risk of getting COVID?\" and \"How soon after possible exposure to COVID should I get tested?\" Here are answers to some of the top COVID questions.",
-  "metadataTitle": "COVID-19 FAQ - Covid Act Now",
+  "metadataTitle": "COVID-19 FAQ",
   "metadataDescription": "Find trusted answers to the most Frequently Asked Questions (FAQs) about the novel Coronavirus. Make informed decisions to stop the disease for you and your community.",
   "lastUpdatedDate": "2020-12-15T08:00:00.000Z"
 }

--- a/src/cms-content/learn/learn-glossary.json
+++ b/src/cms-content/learn/learn-glossary.json
@@ -471,7 +471,7 @@
       "category": "Disease science"
     }
   ],
-  "metadataTitle": "Glossary of COVID-19 Terminology - Covid Act Now",
+  "metadataTitle": "Glossary of COVID-19 Terminology",
   "metadataDescription": "Find clear definitions of the vocabulary and key terms of the novel Coronavirus (2019-nCoV). Understand the COVID terminology and make informed decisions to stop the pandemic.",
   "lastUpdatedDate": "2020-12-22T08:00:00.000Z"
 }

--- a/src/cms-content/learn/learn-landing.json
+++ b/src/cms-content/learn/learn-landing.json
@@ -1,7 +1,7 @@
 {
   "intro": "Here you can find clear, trusted, shareable information to make informed decisions around COVID, as well as essential resources that will help you understand, interpret, and apply Covid Act Now’s data.",
   "header": "Learn about COVID",
-  "metadataTitle": "COVID-19 Essential Information & Resources - Covid Act Now",
+  "metadataTitle": "COVID-19 Essential Information & Resources",
   "metadataDescription": "Find recent and trusted information & resources about the novel Coronavirus (2019-nCoV). Learn about Symptoms, Tests, Risks, and more. Backed by medical experts. Make informed decisions to stop the disease for you and your community.",
   "sections": [
     {

--- a/src/cms-content/learn/metric-explainers.json
+++ b/src/cms-content/learn/metric-explainers.json
@@ -1,6 +1,6 @@
 {
   "frameworkBody": "Covid Act Now worked alongside a network of research, policy, and public health experts convened by Harvard’s Global Health Institute and Edmond J. Safra Center for Ethics to develop the [Key Metrics for COVID Suppression](https://globalhealth.harvard.edu/key-metrics-for-covid-suppression-researchers-and-public-health-experts-unite-to-bring-clarity-to-key-metrics-guiding-coronavirus-response/) framework.\n\nCentral to this framework is our five-color COVID warning system, which communicates the severity of a location’s outbreak and offers corresponding guidance on mitigation efforts needed at each risk level. This facilitates a unified approach with common metrics, enabling leaders at all levels to anticipate and adequately respond to their community’s COVID spread, and informing the general public on their community’s risk to COVID. To develop this framework, we prioritized metrics vital to guiding suppression efforts that allow a community to safely reopen.",
-  "metadataTitle": "Risk Levels and Key Metrics for COVID-19 - Covid Act Now",
+  "metadataTitle": "Risk Levels and Key Metrics for COVID-19",
   "metadataDescription": "Understand the Risk Levels in your community and COVID Metrics: daily new cases, infection rate, positive test rate, ICU capacity used, contact tracing.",
   "sections": [
     {

--- a/src/screens/HomePage/HomePage.js
+++ b/src/screens/HomePage/HomePage.js
@@ -36,7 +36,7 @@ import { getNationalText } from 'components/NationalText';
 
 function getPageDescription() {
   const date = formatMetatagDate();
-  return `${date} View the recent wave of US COVID cases, deaths, hospitalizations, and other important metrics. 50 States. 3000+ Counties. Click the map to dive in.`;
+  return `${date} Explore our interactive U.S. COVID map for the latest cases, deaths, hospitalizations, and other key metrics. 50 States. 390+ Metros. 3200+ Counties.`;
 }
 
 export default function HomePage() {
@@ -81,7 +81,7 @@ export default function HomePage() {
       <EnsureSharingIdInUrl />
       <AppMetaTags
         canonicalUrl="/"
-        pageTitle="U.S. COVID Map & Risk Levels"
+        pageTitle="Realtime U.S. COVID Map & Risk Levels - Covid Act Now"
         pageDescription={getPageDescription()}
       />
       <BannerContainer>

--- a/src/screens/HomePage/HomePage.js
+++ b/src/screens/HomePage/HomePage.js
@@ -81,7 +81,7 @@ export default function HomePage() {
       <EnsureSharingIdInUrl />
       <AppMetaTags
         canonicalUrl="/"
-        pageTitle="Realtime U.S. COVID Map & Risk Levels - Covid Act Now"
+        pageTitle="Realtime U.S. COVID Map & Risk Levels"
         pageDescription={getPageDescription()}
       />
       <BannerContainer>

--- a/src/screens/Learn/Articles/ArticlesLanding.tsx
+++ b/src/screens/Learn/Articles/ArticlesLanding.tsx
@@ -20,7 +20,7 @@ const ArticlesLanding = () => {
     <Fragment>
       <AppMetaTags
         canonicalUrl="/deep-dives"
-        pageTitle={'COVID-19 Deep Dives - Covid Act Now'}
+        pageTitle="COVID-19 Deep Dives"
         pageDescription={`${date} Explore deeper analysis about how, why, and where COVID is spreading.`}
       />
       <PageContent sidebarItems={learnPages}>

--- a/src/screens/LocationPage/utils.ts
+++ b/src/screens/LocationPage/utils.ts
@@ -17,7 +17,7 @@ function locationName(region: Region) {
 }
 
 export function getPageTitle(region: Region): string {
-  return `${locationName(region)} - COVID Data & Key Metrics - Covid Act Now`;
+  return `${locationName(region)} - COVID Data & Key Metrics`;
 }
 
 export function getPageDescription(

--- a/src/screens/LocationPage/utils.ts
+++ b/src/screens/LocationPage/utils.ts
@@ -1,20 +1,23 @@
 import { LOCATION_SUMMARY_LEVELS } from 'common/metrics/location_summary';
 import { formatMetatagDate } from 'common/utils';
 import { Projections } from 'common/models/Projections';
-import { Region, State, County } from 'common/regions';
+import { Region, State, County, MetroArea } from 'common/regions';
+import { replace } from 'lodash';
 
 function locationName(region: Region) {
   if (region instanceof State) {
     return `${region.name} (${region.stateCode})`;
   } else if (region instanceof County) {
-    return `${region.fullName}, (${region.state.stateCode})`;
+    return `${region.fullName} (${region.state.stateCode})`;
+  } else if (region instanceof MetroArea) {
+    return replace(region.name, /-/g, ', ');
   } else {
     return region.fullName;
   }
 }
 
 export function getPageTitle(region: Region): string {
-  return `${locationName(region)} - COVID Risk Map & Key Metrics`;
+  return `${locationName(region)} - COVID Data & Key Metrics - Covid Act Now`;
 }
 
 export function getPageDescription(


### PR DESCRIPTION
- Updates page titles+descriptions to match [trello ticket](https://trello.com/c/hC06LW0n/702-update-homepage-and-location-pages-meta-titles-and-tags-according-to-new-headline)
- Removes hardcoded '- Covid Act Now' from individual page titles because `AppMetaTags` component already appends it