### PR TITLE
Explicitly exit the process when generate-index-pages is done so we don't wait on Firestore connections to shut down.

### DIFF
--- a/scripts/generate_index_pages.ts
+++ b/scripts/generate_index_pages.ts
@@ -258,7 +258,13 @@ class IndexPageBuilder {
   }
 }
 
-main().catch(e => {
-  console.error(e);
-  process.exit(-1);
-});
+main()
+  .then(() => {
+    // HACK: We aggressively exit the process, else Firestore SDK will keep node from exiting for 60s
+    // thanks to open network connections.
+    process.exit(0);
+  })
+  .catch(e => {
+    console.error(e);
+    process.exit(-1);
+  });


### PR DESCRIPTION
NOTE: We could alternatively call `getFirebase().firestore().terminate()` but that seemed more hacky given the Firestore usage is currently abstracted behind the `getNextSharedComponentId()` call.