### PR TITLE
Appends 'city' to New York metro principal city

### DIFF
--- a/src/common/regions/types.ts
+++ b/src/common/regions/types.ts
@@ -10,7 +10,18 @@ export enum RegionType {
   MSA = 'MSA',
 }
 
+/* Used to rename some metro principal cities for clarity: */
 const DC_METRO_FIPS = '47900';
+const NY_METRO_FIPS = '35620';
+
+interface FipsToPrincipalCityName {
+  [key: string]: string;
+}
+
+const fipsToPrincipalCityRenames: FipsToPrincipalCityName = {
+  [DC_METRO_FIPS]: 'Washington DC',
+  [NY_METRO_FIPS]: 'New York City',
+};
 
 export abstract class Region {
   constructor(
@@ -113,9 +124,8 @@ export class MetroArea extends Region {
   }
 
   private get principalCityName() {
-    // Make Washington DC metro principal city name more clear.
-    if (this.fipsCode === DC_METRO_FIPS) {
-      return 'Washington DC';
+    if (this.fipsCode in fipsToPrincipalCityRenames) {
+      return fipsToPrincipalCityRenames[this.fipsCode];
     }
     return this.name.split('-')[0];
   }


### PR DESCRIPTION
[Trello item](https://trello.com/c/pPCFELxY/725-seo-some-metros-could-be-more-easily-discoverable-with-multiple-names)