### PR TITLE
New york metro URL segment update

### DIFF
--- a/scripts/cbsa/parse-metro-areas.ts
+++ b/scripts/cbsa/parse-metro-areas.ts
@@ -80,6 +80,11 @@ function formatGroup(groupItems: CsvRow[]) {
 
   const totalPopulation = sum(counties.map(county => county?.population || 0));
 
+  const nameForFormatUrl =
+    firstItem.cbsaTitle === 'New York-Newark-Jersey City, NY-NJ-PA'
+      ? 'New York City-Newark-Jersey City, NY-NJ-PA'
+      : firstItem.cbsaTitle;
+
   return {
     cbsaCode: firstItem.cbsaCode,
     cbsaTitle: firstItem.cbsaTitle,
@@ -87,7 +92,7 @@ function formatGroup(groupItems: CsvRow[]) {
     countyFipsCodes: groupItems.map(
       item => `${item.fipsStateCode}${item.fipsCountyCode}`,
     ),
-    urlSegment: formatUrl(firstItem.cbsaTitle),
+    urlSegment: formatUrl(nameForFormatUrl),
     population: totalPopulation,
   };
 }

--- a/src/common/data/msa-data.json
+++ b/src/common/data/msa-data.json
@@ -3077,8 +3077,8 @@
         "36087",
         "36119"
       ],
-      "urlSegment": "new-york-newark-jersey-city_ny-nj-pa",
-      "population": 19954092
+      "urlSegment": "new-york-city-newark-jersey-city_ny-nj-pa",
+      "population": 19216182
     },
     {
       "cbsaCode": "35660",
@@ -4560,7 +4560,7 @@
         "54037"
       ],
       "urlSegment": "washington-arlington-alexandria_dc-va-md-wv",
-      "population": 6280487
+      "population": 5574738
     },
     {
       "cbsaCode": "47940",


### PR DESCRIPTION
Updates NY metro area's URL segment to include 'city'

[prod ny metro url](https://covidactnow.org/us/metro/new-york-newark-jersey-city_ny-nj-pa/?s=1490446) --> [preview ny metro url](https://covid-projections-git-casulin-city-in-ny-metro-url.covidactnow.vercel.app/us/metro/new-york-city-newark-jersey-city_ny-nj-pa?s=1490446)