### PR TITLE
remove iframe-resizer

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -127,8 +127,6 @@
       To begin the development, run `npm start` or `yarn start`.
       To create a production bundle, use `npm run build` or `yarn build`.
     -->
-
-  <script type="text/javascript" src="https://app.mailjet.com/statics/js/iframeResizer.min.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
Remove an unused script (see https://github.com/covid-projections/covid-projections/issues/70), it was added to autosize an iframe for email signups with Mailjet back in March.