### PR TITLE
Performance - defer loading and evaluating 3rd party scripts

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -119,7 +119,7 @@
 
   <!-- Global site tag (gtag.js) - Google Ads: 527465415 -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=AW-527465415"></script>
-  <script async>
+  <script>
     window.dataLayer = window.dataLayer || [];
     function gtag() { dataLayer.push(arguments); }
     gtag('js', new Date());
@@ -127,7 +127,7 @@
   </script>
 
   <!-- Event snippet for Website traffic conversion page -->
-  <script async>
+  <script>
     gtag('event', 'conversion', { 'send_to': 'AW-527465415/lRyqCM2a9-kBEMf3wfsB' });
   </script>
 

--- a/public/index.html
+++ b/public/index.html
@@ -61,33 +61,33 @@
     rel="stylesheet">
 
   <!-- fullstory -->
-  <script>
-  window['_fs_debug'] = false;
-  window['_fs_host'] = 'fullstory.com';
-  window['_fs_script'] = 'edge.fullstory.com/s/fs.js';
-  window['_fs_org'] = 'XEVN9';
-  window['_fs_namespace'] = 'FS';
-  (function(m,n,e,t,l,o,g,y){
-      if (e in m) {if(m.console && m.console.log) { m.console.log('FullStory namespace conflict. Please set window["_fs_namespace"].');} return;}
-      g=m[e]=function(a,b,s){g.q?g.q.push([a,b,s]):g._api(a,b,s);};g.q=[];
-      o=n.createElement(t);o.async=1;o.crossOrigin='anonymous';o.src='https://'+_fs_script;
-      y=n.getElementsByTagName(t)[0];y.parentNode.insertBefore(o,y);
-      g.identify=function(i,v,s){g(l,{uid:i},s);if(v)g(l,v,s)};g.setUserVars=function(v,s){g(l,v,s)};g.event=function(i,v,s){g('event',{n:i,p:v},s)};
-      g.anonymize=function(){g.identify(!!0)};
-      g.shutdown=function(){g("rec",!1)};g.restart=function(){g("rec",!0)};
-      g.log = function(a,b){g("log",[a,b])};
-      g.consent=function(a){g("consent",!arguments.length||a)};
-      g.identifyAccount=function(i,v){o='account';v=v||{};v.acctId=i;g(o,v)};
-      g.clearUserCookie=function(){};
-      g.setVars=function(n, p){g('setVars',[n,p]);};
-      g._w={};y='XMLHttpRequest';g._w[y]=m[y];y='fetch';g._w[y]=m[y];
-      if(m[y])m[y]=function(){return g._w[y].apply(this,arguments)};
-      g._v="1.3.0";
-  })(window,document,window['_fs_namespace'],'script','user');
+  <script async>
+    window['_fs_debug'] = false;
+    window['_fs_host'] = 'fullstory.com';
+    window['_fs_script'] = 'edge.fullstory.com/s/fs.js';
+    window['_fs_org'] = 'XEVN9';
+    window['_fs_namespace'] = 'FS';
+    (function (m, n, e, t, l, o, g, y) {
+      if (e in m) { if (m.console && m.console.log) { m.console.log('FullStory namespace conflict. Please set window["_fs_namespace"].'); } return; }
+      g = m[e] = function (a, b, s) { g.q ? g.q.push([a, b, s]) : g._api(a, b, s); }; g.q = [];
+      o = n.createElement(t); o.async = 1; o.crossOrigin = 'anonymous'; o.src = 'https://' + _fs_script;
+      y = n.getElementsByTagName(t)[0]; y.parentNode.insertBefore(o, y);
+      g.identify = function (i, v, s) { g(l, { uid: i }, s); if (v) g(l, v, s) }; g.setUserVars = function (v, s) { g(l, v, s) }; g.event = function (i, v, s) { g('event', { n: i, p: v }, s) };
+      g.anonymize = function () { g.identify(!!0) };
+      g.shutdown = function () { g("rec", !1) }; g.restart = function () { g("rec", !0) };
+      g.log = function (a, b) { g("log", [a, b]) };
+      g.consent = function (a) { g("consent", !arguments.length || a) };
+      g.identifyAccount = function (i, v) { o = 'account'; v = v || {}; v.acctId = i; g(o, v) };
+      g.clearUserCookie = function () { };
+      g.setVars = function (n, p) { g('setVars', [n, p]); };
+      g._w = {}; y = 'XMLHttpRequest'; g._w[y] = m[y]; y = 'fetch'; g._w[y] = m[y];
+      if (m[y]) m[y] = function () { return g._w[y].apply(this, arguments) };
+      g._v = "1.3.0";
+    })(window, document, window['_fs_namespace'], 'script', 'user');
   </script>
 
   <!-- Twitter universal website tag code -->
-  <script>
+  <script async>
     !function (e, t, n, s, u, a) {
       e.twq || (s = e.twq = function () {
         s.exe ? s.exe.apply(s, arguments) : s.queue.push(arguments);
@@ -101,7 +101,7 @@
   <!-- End Twitter universal website tag code -->
 
   <!-- Facebook Pixel Code -->
-  <script>
+  <script async>
     !function (f, b, e, v, n, t, s) {
       if (f.fbq) return; n = f.fbq = function () {
         n.callMethod ?
@@ -119,7 +119,7 @@
 
   <!-- Global site tag (gtag.js) - Google Ads: 527465415 -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=AW-527465415"></script>
-  <script>
+  <script async>
     window.dataLayer = window.dataLayer || [];
     function gtag() { dataLayer.push(arguments); }
     gtag('js', new Date());
@@ -127,7 +127,7 @@
   </script>
 
   <!-- Event snippet for Website traffic conversion page -->
-  <script>
+  <script async>
     gtag('event', 'conversion', { 'send_to': 'AW-527465415/lRyqCM2a9-kBEMf3wfsB' });
   </script>
 


### PR DESCRIPTION
According to [PageSpeed Insights](https://developers.google.com/speed/pagespeed/insights/?url=https%3A%2F%2Fcovidactnow.org&tab=mobile), we need to optimize loading third party code.

![image](https://user-images.githubusercontent.com/114084/104225125-d2e3b580-53fa-11eb-825e-c7bbe8e35310.png)

Using `async` instead of `defer` because I imagine that the page load event is important to event trackers

- [Loading third-party JavaScript](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript)