### PR TITLE
update page metatags to calculate them with summaries

### DIFF
--- a/src/screens/LocationPage/LocationPage.tsx
+++ b/src/screens/LocationPage/LocationPage.tsx
@@ -48,9 +48,11 @@ function LocationPage({ region }: LocationPageProps) {
         pageTitle={getPageTitle(region)}
         pageDescription={getPageDescription(region)}
       />
-      {/* Shows a loading screen if projections are now loaded yet, or
+      {/* Shows a loading screen if projections are not loaded yet, or
        * if a new location has been selected */}
-      {projections && projections.fips === region.fipsCode ? (
+      {!projections || projections.fips !== region.fipsCode ? (
+        <LoadingScreen />
+      ) : (
         <div>
           <SearchHeader
             setMapOption={setMapOption}
@@ -70,8 +72,6 @@ function LocationPage({ region }: LocationPageProps) {
             setMapOption={setMapOption}
           />
         </div>
-      ) : (
-        <LoadingScreen />
       )}
     </div>
   );

--- a/src/screens/LocationPage/LocationPage.tsx
+++ b/src/screens/LocationPage/LocationPage.tsx
@@ -37,45 +37,31 @@ function LocationPage({ region }: LocationPageProps) {
         pageTitle={getPageTitle(region)}
         pageDescription={getPageDescription(region)}
       />
-      {/* Shows a loading screen if projections are not loaded yet, or
-       * if a new location has been selected */}
-      {!projections || projections.fips !== region.fipsCode ? (
-        <div>
-          <SearchHeader
-            setMapOption={setMapOption}
-            mobileMenuOpen={mobileMenuOpen}
-            setMobileMenuOpen={setMobileMenuOpen}
-            region={region}
-          />
+      <div>
+        <SearchHeader
+          setMapOption={setMapOption}
+          mobileMenuOpen={mobileMenuOpen}
+          setMobileMenuOpen={setMobileMenuOpen}
+          region={region}
+        />
+        {/* Shows a loading screen if projections are not loaded yet, or
+         * if a new location has been selected */}
+        {!projections || projections.fips !== region.fipsCode ? (
           <LoadingScreen />
-          <MiniMap
-            region={region}
-            mobileMenuOpen={mobileMenuOpen}
-            mapOption={mapOption}
-            setMapOption={setMapOption}
-          />
-        </div>
-      ) : (
-        <div>
-          <SearchHeader
-            setMapOption={setMapOption}
-            mobileMenuOpen={mobileMenuOpen}
-            setMobileMenuOpen={setMobileMenuOpen}
-            region={region}
-          />
+        ) : (
           <ChartsHolder
             projections={projections}
             chartId={chartId}
             region={region}
           />
-          <MiniMap
-            region={region}
-            mobileMenuOpen={mobileMenuOpen}
-            mapOption={mapOption}
-            setMapOption={setMapOption}
-          />
-        </div>
-      )}
+        )}
+        <MiniMap
+          region={region}
+          mobileMenuOpen={mobileMenuOpen}
+          mapOption={mapOption}
+          setMapOption={setMapOption}
+        />
+      </div>
     </div>
   );
 }

--- a/src/screens/LocationPage/LocationPage.tsx
+++ b/src/screens/LocationPage/LocationPage.tsx
@@ -18,27 +18,16 @@ interface LocationPageProps {
 function LocationPage({ region }: LocationPageProps) {
   let { chartId } = useParams<{ chartId: string }>();
 
-  const defaultMapOption = (region: Region) => {
-    const stateCode = getStateCode(region);
-    if (stateCode === MAP_FILTERS.DC) {
-      return MAP_FILTERS.NATIONAL;
-    }
-    if (region instanceof MetroArea) {
-      return MAP_FILTERS.MSA;
-    }
-    return MAP_FILTERS.STATE;
-  };
-  const [mapOption, setMapOption] = useState(defaultMapOption(region));
-
+  const defaultMapOption = getDefaultMapOption(region);
+  const [mapOption, setMapOption] = useState(defaultMapOption);
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const projections = useProjectionsFromRegion(region);
 
   useEffect(() => {
-    setMapOption(defaultMapOption(region));
-
+    setMapOption(defaultMapOption);
     // Close the map on mobile on any change to a region.
     setMobileMenuOpen(false);
-  }, [region]);
+  }, [defaultMapOption]);
 
   return (
     <div>
@@ -51,7 +40,21 @@ function LocationPage({ region }: LocationPageProps) {
       {/* Shows a loading screen if projections are not loaded yet, or
        * if a new location has been selected */}
       {!projections || projections.fips !== region.fipsCode ? (
-        <LoadingScreen />
+        <div>
+          <SearchHeader
+            setMapOption={setMapOption}
+            mobileMenuOpen={mobileMenuOpen}
+            setMobileMenuOpen={setMobileMenuOpen}
+            region={region}
+          />
+          <LoadingScreen />
+          <MiniMap
+            region={region}
+            mobileMenuOpen={mobileMenuOpen}
+            mapOption={mapOption}
+            setMapOption={setMapOption}
+          />
+        </div>
       ) : (
         <div>
           <SearchHeader
@@ -75,6 +78,17 @@ function LocationPage({ region }: LocationPageProps) {
       )}
     </div>
   );
+}
+
+function getDefaultMapOption(region: Region) {
+  const stateCode = getStateCode(region);
+  if (stateCode === MAP_FILTERS.DC) {
+    return MAP_FILTERS.NATIONAL;
+  }
+  if (region instanceof MetroArea) {
+    return MAP_FILTERS.MSA;
+  }
+  return MAP_FILTERS.STATE;
 }
 
 export default LocationPage;

--- a/src/screens/LocationPage/LocationPage.tsx
+++ b/src/screens/LocationPage/LocationPage.tsx
@@ -39,44 +39,40 @@ function LocationPage({ region }: LocationPageProps) {
     // Close the map on mobile on any change to a region.
     setMobileMenuOpen(false);
   }, [region]);
-  // Projections haven't loaded yet
-  // If a new county has just been selected, we may not have projections
-  // for the new county loaded yet
-  if (!projections || projections.fips !== region.fipsCode) {
-    return <LoadingScreen></LoadingScreen>;
-  }
-
-  const pageTitle = getPageTitle(region);
-  const pageDescription = getPageDescription(region, projections);
-  const canonicalUrl = region.canonicalUrl;
 
   return (
     <div>
       <EnsureSharingIdInUrl />
       <AppMetaTags
-        canonicalUrl={canonicalUrl}
-        pageTitle={pageTitle}
-        pageDescription={pageDescription}
+        canonicalUrl={region.canonicalUrl}
+        pageTitle={getPageTitle(region)}
+        pageDescription={getPageDescription(region)}
       />
-      <div>
-        <SearchHeader
-          setMapOption={setMapOption}
-          mobileMenuOpen={mobileMenuOpen}
-          setMobileMenuOpen={setMobileMenuOpen}
-          region={region}
-        />
-        <ChartsHolder
-          projections={projections}
-          chartId={chartId}
-          region={region}
-        />
-        <MiniMap
-          region={region}
-          mobileMenuOpen={mobileMenuOpen}
-          mapOption={mapOption}
-          setMapOption={setMapOption}
-        />
-      </div>
+      {/* Shows a loading screen if projections are now loaded yet, or
+       * if a new location has been selected */}
+      {projections && projections.fips === region.fipsCode ? (
+        <div>
+          <SearchHeader
+            setMapOption={setMapOption}
+            mobileMenuOpen={mobileMenuOpen}
+            setMobileMenuOpen={setMobileMenuOpen}
+            region={region}
+          />
+          <ChartsHolder
+            projections={projections}
+            chartId={chartId}
+            region={region}
+          />
+          <MiniMap
+            region={region}
+            mobileMenuOpen={mobileMenuOpen}
+            mapOption={mapOption}
+            setMapOption={setMapOption}
+          />
+        </div>
+      ) : (
+        <LoadingScreen />
+      )}
     </div>
   );
 }

--- a/src/screens/LocationPage/utils.ts
+++ b/src/screens/LocationPage/utils.ts
@@ -1,8 +1,8 @@
 import { LOCATION_SUMMARY_LEVELS } from 'common/metrics/location_summary';
 import { formatMetatagDate } from 'common/utils';
-import { Projections } from 'common/models/Projections';
 import { Region, State, County, MetroArea } from 'common/regions';
 import { replace } from 'lodash';
+import { LocationSummariesByFIPS } from 'common/location_summaries';
 
 function locationName(region: Region) {
   if (region instanceof State) {
@@ -20,12 +20,9 @@ export function getPageTitle(region: Region): string {
   return `${locationName(region)} - COVID Data & Key Metrics`;
 }
 
-export function getPageDescription(
-  region: Region,
-  projections: Projections,
-): string {
+export function getPageDescription(region: Region): string {
   const date = formatMetatagDate();
-  const alarmLevel = projections.getAlarmLevel();
+  const { level: alarmLevel } = LocationSummariesByFIPS[region.fipsCode];
   const levelInfo = LOCATION_SUMMARY_LEVELS[alarmLevel];
   return `${date} COVID RISK LEVEL: ${levelInfo.detail(locationName(region))}`;
 }


### PR DESCRIPTION
The page meta tags don't really depend on the projections, we can calculate them using location summaries, which should be faster.