### PR TITLE
implement setup for A/B testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "react-ga": "^3.1.2",
     "react-helmet": "^5.2.1",
     "react-markdown": "^4.3.1",
+    "react-optimize": "^2.4.0",
     "react-router-dom": "^5.1.2",
     "react-router-hash-link": "^2.2.2",
     "react-scripts": "3.4.0",

--- a/public/index.html
+++ b/public/index.html
@@ -60,6 +60,9 @@
     href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;700&family=Roboto:wght@400;500;700&display=swap"
     rel="stylesheet">
 
+  <!-- Google Optimize for A/B testing-->
+  <script src="https://www.googleoptimize.com/optimize.js?id=OPT-WT27VPR"></script>
+
   <!-- fullstory -->
   <script async>
     window['_fs_debug'] = false;

--- a/src/components/AppBar/DonateButton.style.ts
+++ b/src/components/AppBar/DonateButton.style.ts
@@ -3,8 +3,13 @@ import MuiButton from '@material-ui/core/Button';
 import { COLOR_MAP } from 'common/colors';
 import { mobileBreakpoint } from 'assets/theme/sizes';
 
-export const StyledDonateButton = styled(MuiButton)`
-  color: white;
+const DonateButtonBase = styled(MuiButton).attrs(props => ({
+  disableRipple: true,
+  disableFocusRipple: true,
+  variant: 'contained',
+}))``;
+
+export const StyledDonateButton = styled(DonateButtonBase)`
   background-color: white;
   margin: auto 0;
   display: inline-flex;
@@ -14,6 +19,23 @@ export const StyledDonateButton = styled(MuiButton)`
 
   &:hover {
     box-shadow: 0 4px 10px rgba(0, 0, 0, 0.12);
+  }
+
+  @media (min-width: ${mobileBreakpoint}) {
+    margin-left: 2rem;
+  }
+`;
+
+export const StyledDonateButtonB = styled(DonateButtonBase)`
+  margin: auto 0;
+  display: inline-flex;
+  background-color: ${COLOR_MAP.PURPLE};
+  color: white;
+  box-shadow: none;
+
+  &:hover {
+    background-color: ${COLOR_MAP.PURPLE};
+    color: white; */
   }
 
   @media (min-width: ${mobileBreakpoint}) {

--- a/src/components/AppBar/DonateButton.tsx
+++ b/src/components/AppBar/DonateButton.tsx
@@ -2,23 +2,28 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import useScrollPosition from '@react-hook/window-scroll';
 import { Fade } from '@material-ui/core';
-import { StyledDonateButton, DonateButtonWrapper } from './DonateButton.style';
+import {
+  StyledDonateButton,
+  DonateButtonWrapper,
+  StyledDonateButtonB,
+} from './DonateButton.style';
 import { EventAction, EventCategory, trackEvent } from 'components/Analytics';
+import {
+  Experiment,
+  ExperimentID,
+  Variant,
+  VariantID,
+} from 'components/Experiment';
+
+function trackClickDonate() {
+  const trackLabel = 'AppBar donate button';
+  trackEvent(EventCategory.DONATE, EventAction.CLICK, trackLabel);
+}
 
 const ButtonContent = () => {
-  const trackLabel = 'AppBar donate button';
-
   return (
     <Link to="/donate">
-      <StyledDonateButton
-        variant="contained"
-        color="primary"
-        disableRipple
-        disableFocusRipple
-        onClick={() => {
-          trackEvent(EventCategory.DONATE, EventAction.CLICK, trackLabel);
-        }}
-      >
+      <StyledDonateButton color="primary" onClick={trackClickDonate}>
         Donate
       </StyledDonateButton>
     </Link>
@@ -30,10 +35,21 @@ Splits donate button into 2 separate components (with/without fade)
 so that the useScrollPosition hook is only called when necessary
 */
 
-export const DonateButtonWithoutFade = (props: {}) => {
+export const DonateButtonVariantA = (props: {}) => {
   return (
     <DonateButtonWrapper>
       <ButtonContent />
+    </DonateButtonWrapper>
+  );
+};
+
+// Donate button on a different color to test A/B testing setup
+export const DonateButtonVariantB = (props: {}) => {
+  return (
+    <DonateButtonWrapper>
+      <StyledDonateButtonB onClick={trackClickDonate}>
+        Donate
+      </StyledDonateButtonB>
     </DonateButtonWrapper>
   );
 };
@@ -52,3 +68,14 @@ export const DonateButtonWithFade = () => {
     </Fade>
   );
 };
+
+export const DonateButton = () => (
+  <Experiment id={ExperimentID.DONATE_BTN_COLOR}>
+    <Variant id={VariantID.A}>
+      <DonateButtonVariantA />
+    </Variant>
+    <Variant id={VariantID.B}>
+      <DonateButtonVariantB />
+    </Variant>
+  </Experiment>
+);

--- a/src/components/AppBar/DonateButton.tsx
+++ b/src/components/AppBar/DonateButton.tsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom';
 import useScrollPosition from '@react-hook/window-scroll';
 import { Fade } from '@material-ui/core';
 import {
-  StyledDonateButton,
+  StyledDonateButton as StyledDonateButtonA,
   DonateButtonWrapper,
   StyledDonateButtonB,
 } from './DonateButton.style';
@@ -20,40 +20,6 @@ function trackClickDonate() {
   trackEvent(EventCategory.DONATE, EventAction.CLICK, trackLabel);
 }
 
-const ButtonContent = () => {
-  return (
-    <Link to="/donate">
-      <StyledDonateButton color="primary" onClick={trackClickDonate}>
-        Donate
-      </StyledDonateButton>
-    </Link>
-  );
-};
-
-/*
-Splits donate button into 2 separate components (with/without fade)
-so that the useScrollPosition hook is only called when necessary
-*/
-
-export const DonateButtonVariantA = (props: {}) => {
-  return (
-    <DonateButtonWrapper>
-      <ButtonContent />
-    </DonateButtonWrapper>
-  );
-};
-
-// Donate button on a different color to test A/B testing setup
-export const DonateButtonVariantB = (props: {}) => {
-  return (
-    <DonateButtonWrapper>
-      <StyledDonateButtonB onClick={trackClickDonate}>
-        Donate
-      </StyledDonateButtonB>
-    </DonateButtonWrapper>
-  );
-};
-
 export const DonateButtonWithFade = () => {
   // uses https://www.npmjs.com/package/@react-hook/window-scroll :
   const scrollY = useScrollPosition();
@@ -63,19 +29,31 @@ export const DonateButtonWithFade = () => {
   return (
     <Fade in={isPassedBanner} timeout={150}>
       <DonateButtonWrapper>
-        <ButtonContent />
+        <Link to="/donate">
+          <StyledDonateButtonA onClick={trackClickDonate}>
+            Donate
+          </StyledDonateButtonA>
+        </Link>
       </DonateButtonWrapper>
     </Fade>
   );
 };
 
 export const DonateButton = () => (
-  <Experiment id={ExperimentID.DONATE_BTN_COLOR}>
-    <Variant id={VariantID.A}>
-      <DonateButtonVariantA />
-    </Variant>
-    <Variant id={VariantID.B}>
-      <DonateButtonVariantB />
-    </Variant>
-  </Experiment>
+  <DonateButtonWrapper>
+    <Link to="/donate">
+      <Experiment id={ExperimentID.DONATE_BTN_COLOR}>
+        <Variant id={VariantID.A}>
+          <StyledDonateButtonA onClick={trackClickDonate}>
+            Donate
+          </StyledDonateButtonA>
+        </Variant>
+        <Variant id={VariantID.B}>
+          <StyledDonateButtonB onClick={trackClickDonate}>
+            Donate
+          </StyledDonateButtonB>
+        </Variant>
+      </Experiment>
+    </Link>
+  </DonateButtonWrapper>
 );

--- a/src/components/AppBar/NavBar.tsx
+++ b/src/components/AppBar/NavBar.tsx
@@ -4,7 +4,7 @@ import Logo from 'assets/images/logo';
 import ArrowBack from '@material-ui/icons/ArrowBack';
 import * as Style from './NavBar.style';
 import MobileMenu from './MobileMenu';
-import { DonateButtonWithoutFade } from './DonateButton';
+import { DonateButton } from './DonateButton';
 import { useIsEmbed } from 'common/utils/hooks';
 
 const isLocationPage = (pathname: string) => pathname.includes('/us');
@@ -70,11 +70,11 @@ const NavBar: React.FC = () => {
           <Style.NavLink to="/contact" key="contact">
             Contact Us
           </Style.NavLink>
-          <DonateButtonWithoutFade />
+          <DonateButton />
         </Style.DesktopOnly>
         <Style.MobileOnly>
           <Style.StyledMobileMenu>
-            <DonateButtonWithoutFade />
+            <DonateButton />
             <Style.IconButton
               onClick={() => setMenuOpen(!isMenuOpen)}
               edge="end"

--- a/src/components/Experiment/Experiment.tsx
+++ b/src/components/Experiment/Experiment.tsx
@@ -4,6 +4,28 @@ import {
   ExperimentProps as OptimizeExperimentProps,
 } from 'react-optimize';
 
+/**
+ * Google Optimize provides a UI to define A/B tests and takes care of
+ * assigning users (browser sessions) to each variant in the experiment.
+ * The process to setup an experiment is as follows:
+ *
+ * 1. Create an experiment in Google Optimize
+ *   - name the experiment
+ *   - define the variants in the UI
+ * 2. define objective (page views, events or custom)
+ * 3. copy the experiment ID and add it below
+ * 4. Implement the variants in the code. The default will be A, the variant
+ *    will be B.
+ * 5. Once the code with the experiment is deployed, start the experiment in
+ *    Google Optimize. Optimize will show results and let us know which
+ *    version is better.
+ * 6. Finish the experiment
+ * 7. Remove the experiment code and keep the successful version
+ *
+ * The code always defaults to version A if the experiment is not running
+ * (or ended) and we still have both versions in the code.
+ */
+
 export enum ExperimentID {
   DONATE_BTN_COLOR = 'P_IiKCRHSGCFqFQaEThuDw',
 }

--- a/src/components/Experiment/Experiment.tsx
+++ b/src/components/Experiment/Experiment.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import {
+  Experiment as OptimizeExperiment,
+  ExperimentProps as OptimizeExperimentProps,
+} from 'react-optimize';
+
+export enum ExperimentID {
+  DONATE_BTN_COLOR = 'P_IiKCRHSGCFqFQaEThuDw',
+}
+
+export type ExperimentProps = Omit<OptimizeExperimentProps, 'id'> & {
+  id: ExperimentID;
+};
+
+const Experiment: React.FC<ExperimentProps> = props => {
+  const { id, ...otherProps } = props;
+  return <OptimizeExperiment id={id} {...otherProps} />;
+};
+
+export default Experiment;

--- a/src/components/Experiment/Variant.tsx
+++ b/src/components/Experiment/Variant.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import {
+  Variant as OptimizeVariant,
+  VariantProps as OptimizeVariantProps,
+} from 'react-optimize';
+
+export enum VariantID {
+  A = '0',
+  B = '1',
+}
+
+export type VariantProps = Omit<OptimizeVariantProps, 'id'> & {
+  id: VariantID;
+};
+
+const Variant: React.FC<VariantProps> = props => {
+  const { id, ...otherProps } = props;
+  return <OptimizeVariant id={id} {...otherProps} />;
+};
+
+export default Variant;

--- a/src/components/Experiment/index.ts
+++ b/src/components/Experiment/index.ts
@@ -1,0 +1,5 @@
+import Experiment, { ExperimentID, ExperimentProps } from './Experiment';
+import Variant, { VariantID, VariantProps } from './Variant';
+
+export type { ExperimentProps, VariantProps };
+export { Experiment, ExperimentID, Variant, VariantID };

--- a/yarn.lock
+++ b/yarn.lock
@@ -17018,6 +17018,11 @@ react-markdown@^4.3.1:
     unist-util-visit "^1.3.0"
     xtend "^4.0.1"
 
+react-optimize@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/react-optimize/-/react-optimize-2.4.0.tgz#fcea0af3927223334dde256e18927f911ca227c8"
+  integrity sha512-QK+z8wwOGKUVk6zC2q6l2H67V/bgMleCdm+xpefWQu9F5363LX0nh0ZGcewE8miUWF1xk5U1jWWKjhiVv8lb7g==
+
 react-popper-tooltip@^2.11.0:
   version "2.11.1"
   resolved "https://registry.yarnpkg.com/react-popper-tooltip/-/react-popper-tooltip-2.11.1.tgz#3c4bdfd8bc10d1c2b9a162e859bab8958f5b2644"


### PR DESCRIPTION
Adds support for [Google Optimize](https://optimize.google.com/) and add an experiment to test the tool (makes the donate button purple for 50% of people).

Google Optimize provides a UI to define A/B tests and takes care of assigning users (browser sessions) to each variant in the experiment. The process is as follows:

1. Create an experiment in Google Optimize
   - name the experiment
   - define the variants
   - define objective (visits to /donate in this case)  
   - copy the experiment ID
2. Implement the variants in the code
3. Once the code with the experiment is deployed, start the experiment
4. Optimize will show results and let us know which version is better
5. Finish the experiment
5. Remove the experiment code and keep the successful version

The code always defaults to version A if the experiment is not running (or ended) and we still have both versions in the code.

Note:
- We are going to use A/B testing for other things, but we want to have a "test experiment" to get a good sense of the tool. Igor proposed this experiment for testing the tool (should be almost inconsequential, but who knows!)