### PR TITLE
Updates deep-dives urls, labels, sitemap with CE

### DIFF
--- a/scripts/generate_sitemap/utils.ts
+++ b/scripts/generate_sitemap/utils.ts
@@ -15,7 +15,7 @@ export function getLearnPageItems(): SitemapItemLoose[] {
     '/glossary',
     '/faq',
     '/case-studies',
-    '/deep-dives',
+    '/covid-explained',
     '/covid-risk-levels-metrics',
   ];
 
@@ -23,14 +23,14 @@ export function getLearnPageItems(): SitemapItemLoose[] {
     urlJoin('/case-studies', caseStudy.caseStudyId),
   );
 
-  const deepDiveUrls = articles.map(article =>
-    urlJoin('/deep-dives', article.articleID),
+  const covidExplainedUrls = articles.map(article =>
+    urlJoin('/covid-explained', article.articleID),
   );
 
   const allLearnUrls = concat(
     topLevelRelativeUrls,
     caseStudyUrls,
-    deepDiveUrls,
+    covidExplainedUrls,
   );
 
   return allLearnUrls.map(createSitemapItem);

--- a/src/App.js
+++ b/src/App.js
@@ -155,7 +155,8 @@ export default function App() {
                   <Route exact path="/faq" component={Faq} />
                   <Route exact path="/glossary" component={Glossary} />
                   <Route path="/case-studies" component={CaseStudies} />
-                  <Route path="/deep-dives" component={Articles} />
+                  <Route path="/covid-explained" component={Articles} />
+                  <Redirect from="/deep-dives" to="/covid-explained" />
                   <Route
                     path="/covid-risk-levels-metrics"
                     component={MetricExplainer}

--- a/src/cms-content/learn/index.ts
+++ b/src/cms-content/learn/index.ts
@@ -179,6 +179,10 @@ export const learnPages: TocItem[] = [
     })),
   },
   {
+    label: 'COVID explained',
+    to: '/covid-explained',
+  },
+  {
     // TODO(pablo): Hardcoding the title to avoid importing the glossary content
     label: 'Glossary',
     to: '/glossary',
@@ -190,10 +194,6 @@ export const learnPages: TocItem[] = [
       to: `/faq#${section.sectionId}`,
       label: section.sectionTitle,
     })),
-  },
-  {
-    label: 'Deep dives',
-    to: '/deep-dives',
   },
   {
     label: caseStudiesContent.header,

--- a/src/cms-content/learn/learn-landing.json
+++ b/src/cms-content/learn/learn-landing.json
@@ -12,6 +12,13 @@
       "buttonRedirect": "/covid-risk-levels-metrics"
     },
     {
+      "sectionTitle": "COVID explained",
+      "sectionId": "covid-explained",
+      "buttonCta": "View COVID explained",
+      "buttonRedirect": "/covid-explained",
+      "description": "This section offers a deeper analysis of how, why, and where COVID is spreading. Our editors and guest authors dig into the details of what COVID means for people – particularly the least advantaged in society – and the impact policies have in protecting them."
+    },
+    {
       "sectionTitle": "Glossary",
       "sectionId": "glossary",
       "description": "R₀ vs R(t) vs Infection rate. Here is a simple glossary of COVID-related terms.",
@@ -24,13 +31,6 @@
       "description": "\"Who is most at risk of getting COVID?\" to \"how soon after possible exposure to COVID should I get tested?\" Here are answers to some of the top COVID questions.",
       "buttonCta": "View FAQ",
       "buttonRedirect": "/faq"
-    },
-    {
-      "sectionTitle": "Deep dives",
-      "sectionId": "deep-dives",
-      "buttonCta": "View deep dives",
-      "buttonRedirect": "/deep-dives",
-      "description": "This section offers a deeper analysis of how, why, and where COVID is spreading. Our editors and guest authors dig into the details of what COVID means for people – particularly the least advantaged in society – and the impact policies have in protecting them."
     },
     {
       "sectionTitle": "Case studies",

--- a/src/components/AppBar/NavBar.tsx
+++ b/src/components/AppBar/NavBar.tsx
@@ -15,7 +15,6 @@ const isHomePage = (pathname: string) =>
 const isLearnPage = (pathname: string) =>
   ['/glossary', '/faq', '/explained', '/learn'].includes(pathname) ||
   pathname.startsWith('/case-studies') ||
-  pathname.startsWith('/deep-dives') ||
   pathname.startsWith('/covid-explained');
 
 const NavBar: React.FC = () => {

--- a/src/components/AppBar/NavBar.tsx
+++ b/src/components/AppBar/NavBar.tsx
@@ -15,7 +15,8 @@ const isHomePage = (pathname: string) =>
 const isLearnPage = (pathname: string) =>
   ['/glossary', '/faq', '/explained', '/learn'].includes(pathname) ||
   pathname.startsWith('/case-studies') ||
-  pathname.startsWith('/deep-dives');
+  pathname.startsWith('/deep-dives') ||
+  pathname.startsWith('/covid-explained');
 
 const NavBar: React.FC = () => {
   const [isMenuOpen, setMenuOpen] = useState(false);

--- a/src/components/Banner/ThirdWaveBanner.tsx
+++ b/src/components/Banner/ThirdWaveBanner.tsx
@@ -11,7 +11,7 @@ const trackClick = () => {
   trackEvent(EventCategory.ARTICLES, EventAction.CLICK, 'Banner: Third wave');
 };
 
-const articleURL = '/deep-dives/us-third-wave';
+const articleURL = '/covid-explained/us-third-wave';
 
 const renderButton = () => (
   <Link to={articleURL} id="3rd-wave-banner" onClick={trackClick}>

--- a/src/components/IndigenousPopulationsFeature/IndigenousDataCheckbox.tsx
+++ b/src/components/IndigenousPopulationsFeature/IndigenousDataCheckbox.tsx
@@ -67,7 +67,7 @@ const IndigenousDataCheckbox = (props: {
         </label>
         Learn more about{' '}
         <span onClick={onClickMethodology}>our methodology</span> or view{' '}
-        <Link to="/deep-dives/covid-spread-native-american">
+        <Link to="/covid-explained/covid-spread-native-american">
           our observations
         </Link>
         .

--- a/src/components/LocationPage/Notifications.tsx
+++ b/src/components/LocationPage/Notifications.tsx
@@ -114,7 +114,8 @@ const NYCAggregationChangeCopy: React.FC<{ locationName: string }> = ({
 const ThirdWaveCopy = () => {
   return (
     <Copy isUpdateCopy>
-      {BANNER_COPY} <Link to={'/deep-dives/us-third-wave'}>Learn more</Link>.
+      {BANNER_COPY}{' '}
+      <Link to={'/covid-explained/us-third-wave'}>Learn more</Link>.
     </Copy>
   );
 };

--- a/src/screens/Learn/Articles/Article.tsx
+++ b/src/screens/Learn/Articles/Article.tsx
@@ -36,7 +36,7 @@ const Article = () => {
   };
 
   const shareButtonProps = {
-    shareUrl: `https://covidactnow.org/deep-dives/${articleId}`,
+    shareUrl: `https://covidactnow.org/covid-explained/${articleId}`,
     shareQuote: 'stand-in-copy', // TODO (Chelsi): input copy
     onCopyLink: trackCopyLink,
     onShareOnFacebook: trackShareFacebook,
@@ -50,13 +50,15 @@ const Article = () => {
   return (
     <Fragment>
       <AppMetaTags
-        canonicalUrl={`/deep-dives/${articleId}`}
+        canonicalUrl={`/covid-explained/${articleId}`}
         pageTitle={`${header}`}
         pageDescription={`${metatagDate} ${summary}`}
       />
       <PageContent sidebarItems={learnPages}>
         <BreadcrumbsContainer>
-          <Breadcrumbs item={{ to: '/deep-dives', label: 'Deep dives' }} />
+          <Breadcrumbs
+            item={{ to: '/covid-explained', label: 'COVID explained' }}
+          />
         </BreadcrumbsContainer>
         <LearnHeading1>{header}</LearnHeading1>
         <SmallSubtext source={`Published ${date}`} />

--- a/src/screens/Learn/Articles/ArticlesLanding.tsx
+++ b/src/screens/Learn/Articles/ArticlesLanding.tsx
@@ -19,15 +19,15 @@ const ArticlesLanding = () => {
   return (
     <Fragment>
       <AppMetaTags
-        canonicalUrl="/deep-dives"
-        pageTitle="COVID-19 Deep Dives"
+        canonicalUrl="/covid-explained"
+        pageTitle="COVID-19 Explained"
         pageDescription={`${date} Explore deeper analysis about how, why, and where COVID is spreading.`}
       />
       <PageContent sidebarItems={learnPages}>
         <BreadcrumbsContainer>
           <Breadcrumbs item={{ to: '/learn', label: 'Learn' }} />
         </BreadcrumbsContainer>
-        <LearnHeading1>Deep dives</LearnHeading1>
+        <LearnHeading1>COVID explained</LearnHeading1>
         {articles.map((article: Article) => {
           return (
             <Fragment key={article.articleID}>


### PR DESCRIPTION
Replaces `deep-dives` with `covid-explained`