### PR TITLE
Learn footer

### DIFF
--- a/src/cms-content/learn/index.ts
+++ b/src/cms-content/learn/index.ts
@@ -10,6 +10,7 @@ import {
 import faq from './learn-faq.json';
 import caseStudies from './learn-case-studies.json';
 import metricExplainers from './metric-explainers.json';
+import footer from './footer.json';
 import { sanitizeID, Markdown, TocItem } from '../utils';
 
 /*
@@ -167,6 +168,16 @@ export const [introSection, metricSections] = partition(
   metricExplainersContent.sections,
   section => section.sectionId === 'how-covid-risk-is-determined',
 );
+
+/**
+ * Footer:
+ **/
+
+interface Footer {
+  body: Markdown;
+}
+
+export const footerContent = footer as Footer;
 
 // TODO (pablo): Should we have a short heading for categories?
 export const learnPages: TocItem[] = [

--- a/src/screens/Learn/Articles/Article.tsx
+++ b/src/screens/Learn/Articles/Article.tsx
@@ -14,6 +14,7 @@ import {
 import { articlesById } from 'cms-content/articles';
 import SmallShareButtons from 'components/SmallShareButtons';
 import { trackEvent, EventAction, EventCategory } from 'components/Analytics';
+import Footer from 'screens/Learn/Footer/Footer';
 
 const Article = () => {
   let { articleId } = useParams<{ articleId: string }>();
@@ -64,6 +65,7 @@ const Article = () => {
         <SmallSubtext source={`Published ${date}`} />
         <SmallShareButtons {...shareButtonProps} />
         <MarkdownContent source={body} />
+        <Footer />
         <SmallShareButtons {...shareButtonProps} />
       </PageContent>
     </Fragment>

--- a/src/screens/Learn/CaseStudies/CaseStudy.tsx
+++ b/src/screens/Learn/CaseStudies/CaseStudy.tsx
@@ -22,6 +22,7 @@ import {
   SmallSubtext,
 } from '../Learn.style';
 import { Logo, LogoContainer, LearnMoreSection } from './CaseStudy.style';
+import Footer from 'screens/Learn/Footer/Footer';
 
 const { metadataDescription } = caseStudiesContent;
 
@@ -72,6 +73,7 @@ const CaseStudy: React.FC = () => {
             </MarkdownStyleContainer>
           </LearnMoreSection>
         )}
+        <Footer />
       </PageContent>
     </Fragment>
   );

--- a/src/screens/Learn/Faq/Faq.tsx
+++ b/src/screens/Learn/Faq/Faq.tsx
@@ -16,6 +16,7 @@ import { useScrollToTopButton } from 'common/hooks';
 import ScrollToTopButton from 'components/SharedComponents/ScrollToTopButton';
 import { EventCategory } from 'components/Analytics';
 import FaqStructuredData from './FaqStructuredData';
+import Footer from 'screens/Learn/Footer/Footer';
 
 const Faq: React.FC = () => {
   const {
@@ -64,6 +65,7 @@ const Faq: React.FC = () => {
         {sections.map((section: FaqSection) => (
           <Section key={section.sectionId} section={section} />
         ))}
+        <Footer />
         <ScrollToTopButton
           showButton={showScrollToTopButton}
           analyticsCategory={EventCategory.FAQ}

--- a/src/screens/Learn/Footer/Footer.tsx
+++ b/src/screens/Learn/Footer/Footer.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { MarkdownContent } from 'components/Markdown';
+import { footerContent } from 'cms-content/learn';
+import styled from 'styled-components';
+
+const Wrapper = styled.div`
+  margin: 2.5rem 0 1rem;
+`;
+
+const Footer: React.FC = () => {
+  return (
+    <Wrapper>
+      <MarkdownContent source={footerContent.body} />
+    </Wrapper>
+  );
+};
+
+export default Footer;

--- a/src/screens/Learn/Footer/Footer.tsx
+++ b/src/screens/Learn/Footer/Footer.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { MarkdownContent } from 'components/Markdown';
+import { MarkdownContent, Paragraph } from 'components/Markdown';
 import { footerContent } from 'cms-content/learn';
 import styled from 'styled-components';
 
@@ -7,9 +7,12 @@ const Wrapper = styled.div`
   margin: 2.5rem 0 1rem;
 `;
 
-const Footer: React.FC = () => {
+const Footer: React.FC<{ pageSpecificCopy?: React.ReactElement }> = ({
+  pageSpecificCopy,
+}) => {
   return (
     <Wrapper>
+      {pageSpecificCopy && <Paragraph>{pageSpecificCopy}</Paragraph>}
       <MarkdownContent source={footerContent.body} />
     </Wrapper>
   );

--- a/src/screens/Learn/Glossary/Glossary.tsx
+++ b/src/screens/Learn/Glossary/Glossary.tsx
@@ -16,6 +16,7 @@ import { Anchor } from 'components/TableOfContents';
 import { formatMetatagDate, formatNumericalDate } from 'common/utils';
 import ScrollToTopButton from 'components/SharedComponents/ScrollToTopButton';
 import { useScrollToTopButton } from 'common/hooks';
+import Footer from 'screens/Learn/Footer/Footer';
 
 const Glossary: React.FC = () => {
   const {
@@ -58,6 +59,7 @@ const Glossary: React.FC = () => {
             <MarkdownContent source={term.definition} />
           </Fragment>
         ))}
+        <Footer />
         <ScrollToTopButton
           showButton={showScrollToTopButton}
           analyticsCategory={EventCategory.GLOSSARY}

--- a/src/screens/Learn/Glossary/Glossary.tsx
+++ b/src/screens/Learn/Glossary/Glossary.tsx
@@ -26,7 +26,6 @@ function getGlossaryFooter(): React.ReactElement {
       Brown University, Harvard Medical School, Massachusetts Institute of
       Technology and Massachusetts General Hospital. Learn more at{' '}
       <ExternalLink href="https://explaincovid.org/about">
-        {' '}
         https://explaincovid.org/about
       </ExternalLink>
     </Fragment>

--- a/src/screens/Learn/Glossary/Glossary.tsx
+++ b/src/screens/Learn/Glossary/Glossary.tsx
@@ -17,6 +17,21 @@ import { formatMetatagDate, formatNumericalDate } from 'common/utils';
 import ScrollToTopButton from 'components/SharedComponents/ScrollToTopButton';
 import { useScrollToTopButton } from 'common/hooks';
 import Footer from 'screens/Learn/Footer/Footer';
+import ExternalLink from 'components/ExternalLink';
+
+function getGlossaryFooter(): React.ReactElement {
+  return (
+    <Fragment>
+      *Created in collaboration with COVID Explained, a team of researchers from
+      Brown University, Harvard Medical School, Massachusetts Institute of
+      Technology and Massachusetts General Hospital. Learn more at{' '}
+      <ExternalLink href="https://explaincovid.org/about">
+        {' '}
+        https://explaincovid.org/about
+      </ExternalLink>
+    </Fragment>
+  );
+}
 
 const Glossary: React.FC = () => {
   const {
@@ -59,7 +74,7 @@ const Glossary: React.FC = () => {
             <MarkdownContent source={term.definition} />
           </Fragment>
         ))}
-        <Footer />
+        <Footer pageSpecificCopy={getGlossaryFooter()} />
         <ScrollToTopButton
           showButton={showScrollToTopButton}
           analyticsCategory={EventCategory.GLOSSARY}

--- a/src/screens/Learn/MetricExplainer/MetricExplainer.tsx
+++ b/src/screens/Learn/MetricExplainer/MetricExplainer.tsx
@@ -19,6 +19,7 @@ import { useScrollToTopButton } from 'common/hooks';
 import ScrollToTopButton from 'components/SharedComponents/ScrollToTopButton';
 import { EventCategory } from 'components/Analytics';
 import GovLogoGrid from 'screens/About/GovLogoGrid';
+import Footer from 'screens/Learn/Footer/Footer';
 
 const MetricExplainer = () => {
   const {
@@ -86,6 +87,7 @@ const MetricExplainer = () => {
             ))}
           </Fragment>
         ))}
+        <Footer />
         <ScrollToTopButton
           showButton={showScrollToTopButton}
           analyticsCategory={EventCategory.METRIC_EXPLAINERS}


### PR DESCRIPTION
Adds general CAN-related footer to bottom of glossary, faq, metric explainers, articles, and case studies. Also adds glossary-specific footer.