### PR TITLE
Compare bug fix

### DIFF
--- a/src/components/Compare/LocationTable.tsx
+++ b/src/components/Compare/LocationTable.tsx
@@ -242,7 +242,7 @@ const LocationTable: React.FunctionComponent<{
   // In the modal, if the rank of the pinned-location-row is #1, we remove
   // the location's inline row, so as to not have the location listed twice consecutively:
   const removePinnedIfRankedFirst = (location: SummaryForCompare) =>
-    location.region.fipsCode !== pinnedLocation?.region.fipsCode;
+    location.region.fipsCode === pinnedLocation?.region.fipsCode;
 
   const modalLocations = hideInlineLocation
     ? remove(sortedLocations, removePinnedIfRankedFirst)

--- a/src/components/LocationPage/ChartsHolder.tsx
+++ b/src/components/LocationPage/ChartsHolder.tsx
@@ -23,7 +23,7 @@ import {
 } from 'common/utils/recommend';
 import { mainContent } from 'cms-content/recommendations';
 import { getRecommendationsShareUrl } from 'common/urls';
-import { Region, State } from 'common/regions';
+import { Region, State, getStateName } from 'common/regions';
 
 // TODO: 180 is rough accounting for the navbar and searchbar;
 // could make these constants so we don't have to manually update
@@ -148,7 +148,7 @@ const ChartsHolder = ({ projections, region, chartId }: ChartsHolderProps) => {
           region={region}
         />
         <CompareMain
-          stateName={region.name} // rename prop
+          stateName={getStateName(region) || region.name} // rename prop
           locationsViewable={6}
           stateId={(region as State).stateCode || undefined}
           region={region}


### PR DESCRIPTION
Fixes [compare bug](https://trello.com/c/pYKWaSYH/789-compare-modal-broken-if-county-is-first-in-list). Weirdly it looks like a `===` became a `!==` at some point and stopped checking if the pinned row is also the first ranked row. Spooky and mysterious :/