### PR TITLE
exposure notifications: fix New Jersey and add Hawaii

### DIFF
--- a/src/components/LocationPage/Notifications.tsx
+++ b/src/components/LocationPage/Notifications.tsx
@@ -23,6 +23,7 @@ const EXPOSURE_NOTIFICATIONS_STATE_FIPS = [
   '08', // Colorado,
   '09', // Connecticut,
   '10', // Delaware,
+  '15', // Hawaii
   '24', // Maryland,
   '26', // Michigan,
   '27', // Minnesota,

--- a/src/components/LocationPage/Notifications.tsx
+++ b/src/components/LocationPage/Notifications.tsx
@@ -27,7 +27,7 @@ const EXPOSURE_NOTIFICATIONS_STATE_FIPS = [
   '26', // Michigan,
   '27', // Minnesota,
   '32', // Nevada,
-  '24', // New Jersey,
+  '34', // New Jersey,
   '36', // New York,
   '37', // North Carolina,
   '38', // North Dakota,


### PR DESCRIPTION
Fixes a typo on NJ's FIPS code and adds Hawaii 