### PR TITLE
fix timezone on explore chart

### DIFF
--- a/src/components/Explore/MultipleLocationsChart.tsx
+++ b/src/components/Explore/MultipleLocationsChart.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, Fragment } from 'react';
 import { isNumber } from 'lodash';
 import { Group } from '@vx/group';
-import { scaleTime, scaleLinear } from '@vx/scale';
+import { scaleUtc, scaleLinear } from '@vx/scale';
 import { useTooltip } from '@vx/tooltip';
 import { formatDecimal, formatUtcDate } from 'common/utils';
 import { Column } from 'common/models/Projection';
@@ -128,7 +128,7 @@ const MultipleLocationsChart: React.FC<{
   const innerWidth = width - marginLeft - marginRight;
   const innerHeight = height - marginTop - marginBottom;
 
-  const dateScale = scaleTime({
+  const dateScale = scaleUtc({
     domain: [dateFrom, dateTo],
     range: [0, innerWidth],
   });

--- a/src/components/Explore/SingleLocationChart.tsx
+++ b/src/components/Explore/SingleLocationChart.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, Fragment } from 'react';
 import moment from 'moment';
 import { isNumber } from 'lodash';
 import { Group } from '@vx/group';
-import { scaleTime, scaleLinear } from '@vx/scale';
+import { scaleUtc, scaleLinear } from '@vx/scale';
 import { useTooltip } from '@vx/tooltip';
 import { formatInteger, formatDecimal, formatUtcDate } from 'common/utils';
 import { Column } from 'common/models/Projection';
@@ -121,7 +121,7 @@ const SingleLocationChart: React.FC<{
   const innerWidth = width - marginLeft - marginRight;
   const innerHeight = height - marginTop - marginBottom;
 
-  const dateScale = scaleTime({
+  const dateScale = scaleUtc({
     domain: [dateFrom, dateTo],
     range: [0, innerWidth],
   });


### PR DESCRIPTION
The grid line is not aligned with the y-axis because of the timezone difference. This PR uses the `scaleUtc` to make sure they match.

**Before**
![image](https://user-images.githubusercontent.com/114084/105219771-b1c24980-5b0b-11eb-8f48-8bffe9d4b51e.png)

**After**
![image](https://user-images.githubusercontent.com/114084/105219549-6f990800-5b0b-11eb-93b6-f918e0b04a03.png)
