### PR TITLE
vaccination: copy updates 2

### DIFF
--- a/src/common/metric.tsx
+++ b/src/common/metric.tsx
@@ -46,6 +46,11 @@ export function getLevelInfo(metric: Metric, value: number | null): LevelInfo {
 }
 
 export function getLevel(metric: Metric, value: number | null): Level {
+  // Vaccinations don't have levels
+  if (metric === Metric.VACCINATIONS) {
+    return Level.UNKNOWN;
+  }
+
   const levelInfoMap = ALL_METRICS_LEVEL_INFO_MAP[metric];
   if (value === null) return Level.UNKNOWN;
   for (const level of ALL_LEVELS) {

--- a/src/common/metrics/vaccinations.tsx
+++ b/src/common/metrics/vaccinations.tsx
@@ -15,7 +15,7 @@ export const VaccinationsMetric: MetricDefinition = {
   renderThermometer,
   metricName: METRIC_NAME,
   extendedMetricName: 'Percent vaccinated with 1st and 2nd shot',
-  metricNameForCompare: 'Vaccinated 1st shot',
+  metricNameForCompare: 'Vaccinated (1st shot)',
 };
 
 const SHORT_DESCRIPTION_LOW = 'Population given the first shot';
@@ -67,7 +67,7 @@ function renderStatus(projections: Projections): React.ReactElement {
 
   return (
     <Fragment>
-      In {locationName}, {peopleInitiated} ({percentInitiated}) people have
+      In {locationName}, {peopleInitiated} people ({percentInitiated}) have
       received the first shot and {peopleVaccinated} ({percentVaccinated}) have
       also received the second shot. According to the CDC, fewer than 0.001% of
       those who have received the first dose have experienced a severe adverse

--- a/src/common/metrics/vaccinations.tsx
+++ b/src/common/metrics/vaccinations.tsx
@@ -15,7 +15,7 @@ export const VaccinationsMetric: MetricDefinition = {
   renderThermometer,
   metricName: METRIC_NAME,
   extendedMetricName: 'Percent vaccinated with 1st and 2nd shot',
-  metricNameForCompare: 'Vaccinated 1st shot (%)',
+  metricNameForCompare: 'Vaccinated 1st shot',
 };
 
 const SHORT_DESCRIPTION_LOW = 'Population given the first shot';

--- a/src/common/metrics/vaccinations.tsx
+++ b/src/common/metrics/vaccinations.tsx
@@ -5,8 +5,9 @@ import { formatPercent, formatInteger } from 'common/utils';
 import { Projections } from 'common/models/Projections';
 import { MetricDefinition } from './interfaces';
 import ExternalLink from 'components/ExternalLink';
+import { trackEvent, EventCategory, EventAction } from 'components/Analytics';
 
-const METRIC_NAME = '% Started Vaccine';
+const METRIC_NAME = 'Vaccinated';
 
 export const VaccinationsMetric: MetricDefinition = {
   renderStatus,
@@ -75,11 +76,22 @@ function renderStatus(projections: Projections): React.ReactElement {
   );
 }
 
+function trackClickVaccinationData() {
+  trackEvent(
+    EventCategory.VACCINATION,
+    EventAction.CLICK_LINK,
+    'CDC Data Tracker - Vaccinations',
+  );
+}
+
 function renderDisclaimer(): React.ReactElement {
   return (
     <Fragment>
       Vaccination data is provided by the{' '}
-      <ExternalLink href="https://covid.cdc.gov/covid-data-tracker/#vaccinations">
+      <ExternalLink
+        href="https://covid.cdc.gov/covid-data-tracker/#vaccinations"
+        onClick={trackClickVaccinationData}
+      >
         CDC
       </ExternalLink>{' '}
       or retrieved from state websites. Reporting may be delayed from the time

--- a/src/common/metrics/vaccinations.tsx
+++ b/src/common/metrics/vaccinations.tsx
@@ -14,8 +14,8 @@ export const VaccinationsMetric: MetricDefinition = {
   renderDisclaimer,
   renderThermometer,
   metricName: METRIC_NAME,
-  extendedMetricName: 'Percent Vaccinated with 1st and 2nd shot',
-  metricNameForCompare: 'Percent Started Vaccine',
+  extendedMetricName: 'Percent vaccinated with 1st and 2nd shot',
+  metricNameForCompare: 'Vaccinated 1st shot (%)',
 };
 
 const SHORT_DESCRIPTION_LOW = 'Population given the first shot';

--- a/src/components/Analytics/utils.ts
+++ b/src/components/Analytics/utils.ts
@@ -42,6 +42,7 @@ export enum EventCategory {
   FAQ = 'faq',
   METRIC_EXPLAINERS = 'metric explainers',
   EXPOSURE_NOTIFICATIONS = 'exposure notifications',
+  VACCINATION = 'vaccination',
 }
 
 /**

--- a/src/components/SignalStatus/SignalStatus.style.tsx
+++ b/src/components/SignalStatus/SignalStatus.style.tsx
@@ -2,16 +2,16 @@ import styled from 'styled-components';
 import { Box } from '@material-ui/core';
 
 export const SignalStatusWrapper = styled(Box)<{
-  condensed?: Boolean;
-  isEmbed?: Boolean;
+  $condensed?: boolean;
+  $isEmbed?: boolean;
 }>`
   ${props =>
-    props.condensed
+    props.$condensed
       ? `
     font-family: 'Source Code Pro', Menlo, Monaco, Consolas, 'Courier New',
       monospace;
     font-weight: bold;
-    font-size: ${props.isEmbed ? '13px' : '0.875rem'};
+    font-size: ${props.$isEmbed ? '13px' : '0.875rem'};
     width: 5.5rem;
     margin-left: 1rem;
     line-height: 1.25rem;

--- a/src/components/SignalStatus/SignalStatus.tsx
+++ b/src/components/SignalStatus/SignalStatus.tsx
@@ -31,15 +31,15 @@ const getIcon = function (levelInfo: LevelInfo, flipOrder?: Boolean) {
 
 const SignalStatus = (props: {
   levelInfo: LevelInfo;
-  condensed?: Boolean;
-  flipOrder?: Boolean;
-  isEmbed?: Boolean;
+  condensed?: boolean;
+  flipOrder?: boolean;
+  isEmbed?: boolean;
 }) => {
   return (
     <SignalStatusWrapper
       color={props.levelInfo.color}
-      condensed={props.condensed}
-      isEmbed={props.isEmbed}
+      $condensed={!!props.condensed}
+      $isEmbed={!!props.isEmbed}
     >
       {getIcon(props.levelInfo, props.flipOrder || false)}
       <span>{props.levelInfo.name}</span>

--- a/src/components/SummaryStats/LocationHeaderStats.tsx
+++ b/src/components/SummaryStats/LocationHeaderStats.tsx
@@ -51,6 +51,13 @@ const StatValue = (props: {
           100K
         </PrevalenceMeasure>
       )}
+      {props.metric === Metric.VACCINATIONS && (
+        <PrevalenceMeasure>
+          1ST
+          <br />
+          SHOT
+        </PrevalenceMeasure>
+      )}
     </ValueWrapper>
   );
 };

--- a/src/components/SummaryStats/LocationHeaderStats.tsx
+++ b/src/components/SummaryStats/LocationHeaderStats.tsx
@@ -192,7 +192,7 @@ const LocationHeaderStats = (props: {
               chartType={metric}
               value={props.stats[metric] as number}
               {...sharedStatProps}
-              beta={[Metric.HOSPITAL_USAGE].includes(metric)}
+              beta={[Metric.VACCINATIONS].includes(metric)}
             />
           ))}
         </SummaryStatsWrapper>

--- a/src/components/SummaryStats/SummaryStats.tsx
+++ b/src/components/SummaryStats/SummaryStats.tsx
@@ -15,6 +15,7 @@ import {
   StatValueWrapper,
 } from './SummaryStats.style';
 import SignalStatus from 'components/SignalStatus/SignalStatus';
+import { SignalStatusWrapper } from 'components/SignalStatus/SignalStatus.style';
 import * as urls from 'common/urls';
 import StatTag from 'components/SummaryStats/StatTag';
 
@@ -74,12 +75,16 @@ const SummaryStat: React.FC<{
             </StatValueText>
           </>
         )}
-        <SignalStatus
-          levelInfo={levelInfo}
-          condensed={condensed}
-          flipOrder={flipSignalStatusOrder}
-          isEmbed={isEmbed}
-        />
+        {chartType !== Metric.VACCINATIONS ? (
+          <SignalStatus
+            levelInfo={levelInfo}
+            condensed={condensed}
+            flipOrder={flipSignalStatusOrder}
+            isEmbed={isEmbed}
+          />
+        ) : (
+          <SignalStatusWrapper $condensed={condensed} $isEmbed={isEmbed} />
+        )}
       </StatValueWrapper>
     </SummaryStatWrapper>
   );


### PR DESCRIPTION
[Copy doc](https://docs.google.com/document/d/14d2VfKcl0eqTYUyvuEzR0-cxb95tmdARJ7rceaRwAvg/edit#) + comments from Igor on Slack.

### Changes
- Update the name of the vaccination metric on:
  - Location header
  - Compare
  - Location page embed
  - Vaccination chart
- Change the level of the vaccination metric to unknown so the dot is grey 
- Add tracking for clicks on the CDC link (vaccination disclaimer)
- Remove _Beta_ from ICU Capacity
- Add _Beta_ to Vaccinations
