### PR TITLE
vaccinations: fix the styling of cells for compare

### DIFF
--- a/src/components/Compare/CompareTableRow.tsx
+++ b/src/components/Compare/CompareTableRow.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { isNumber } from 'lodash';
 import { Link } from 'react-router-dom';
 import FiberManualRecordIcon from '@material-ui/icons/FiberManualRecord';
 import {
@@ -93,10 +94,10 @@ const CompareTableRow = (props: {
         </LocationNameCell>
         {orderedMetrics.map((metric: Metric, i) => {
           const metricForValue = location.metricsInfo.metrics[metric];
+          const metricValue = metricForValue?.value;
           const valueUnknown =
-            metricForValue && metricForValue.level === Level.UNKNOWN
-              ? true
-              : false;
+            !isNumber(metricValue) || !Number.isFinite(metricValue);
+
           return (
             <MetricCell
               key={`metric-cell-${i}`}


### PR DESCRIPTION
Changes the styling of the cells for vaccination data so they show the grey dot instead of a dot with a level. Since vaccinations are not graded, I changed the level so it's always unknown. I updated the style of the metric so unknown is based on the value of the metric, not on the level of the metric from the summary.

![image](https://user-images.githubusercontent.com/114084/105401945-9aeb2800-5bdb-11eb-82d2-ce547f2610e7.png)
