### PR TITLE
Updated region name to state name in notification link

### DIFF
--- a/src/common/utils/recommend.ts
+++ b/src/common/utils/recommend.ts
@@ -22,7 +22,10 @@ import { allIcons } from 'cms-content/recommendations';
 import { EventAction, EventCategory, trackEvent } from 'components/Analytics';
 import { getAbbreviatedCounty } from 'common/utils/compare';
 import { formatDecimal } from '.';
-import { showExposureNotifications } from 'components/LocationPage/Notifications';
+import {
+  getStateName,
+  showExposureNotifications,
+} from 'components/LocationPage/Notifications';
 import regions from 'common/regions';
 
 export function trackRecommendationsEvent(action: EventAction, label: string) {
@@ -45,7 +48,9 @@ function getExposureRecommendation(
     return null;
   }
 
-  const recommendationCopy = `**Notifications**: Add your phone to [${region.fullName}'s 
+  const recommendationCopy = `**Notifications**: Add your phone to [${getStateName(
+    region,
+  )}'s 
   exposure notification system](https://g.co/ens) to receive alerts when you have been 
   in close contact with someone who later tests positive for COVID. 
   Your privacy is protected as your identity is not known and your location 

--- a/src/components/LocationPage/Notifications.tsx
+++ b/src/components/LocationPage/Notifications.tsx
@@ -162,7 +162,7 @@ export function showExposureNotifications(region: Region) {
   }
 }
 
-function getStateName(region: Region) {
+export function getStateName(region: Region) {
   if (region instanceof State) {
     return region.fullName;
   } else if (region instanceof County) {


### PR DESCRIPTION
Currently the link in the "Notifications" section under "Recommended Actions" section in the locations page uses the general region name instead of state name. This PR changes the link to use state name instead.

![image](https://user-images.githubusercontent.com/46338131/105402639-85c2c900-5bdc-11eb-88c5-21c021658d3b.png)
