### PR TITLE
vaccination: remove metric detail

### DIFF
--- a/src/common/metrics/vaccinations.tsx
+++ b/src/common/metrics/vaccinations.tsx
@@ -49,7 +49,7 @@ export const VACCINATIONS_LEVEL_INFO_MAP: LevelInfoMap = {
     upperLimit: 1,
     name: UNKNOWN,
     color: COLOR_MAP.GRAY.BASE,
-    detail: () => SHORT_DESCRIPTION_UNKNOWN,
+    detail: () => '',
   },
 };
 

--- a/src/common/metrics/vaccinations.tsx
+++ b/src/common/metrics/vaccinations.tsx
@@ -19,7 +19,7 @@ export const VaccinationsMetric: MetricDefinition = {
 };
 
 const SHORT_DESCRIPTION_LOW = 'Population given the first shot';
-const SHORT_DESCRIPTION_UNKNOWN = 'Insufficient data to assess';
+// const SHORT_DESCRIPTION_UNKNOWN = 'Insufficient data to assess';
 
 const UNKNOWN = 'Unknown';
 


### PR DESCRIPTION
We don't need the summary since this metric is not graded

![image](https://user-images.githubusercontent.com/114084/105405936-95441100-5be0-11eb-9d18-a30fd7251cba.png)
