### PR TITLE
vaccination: update the styles to work for the dark theme

### DIFF
--- a/src/components/Charts/Charts.style.ts
+++ b/src/components/Charts/Charts.style.ts
@@ -178,7 +178,7 @@ export const LegendLabel = styled.span`
 export const VaccinationLabel = styled.text.attrs(props => ({ dx: 8 }))`
   font-family: Roboto;
   font-size: 13px;
-  color: #4f4f4f;
+  fill: ${props => palette(props).annotation || '#4f4f4f'};
   dominant-baseline: middle;
 `;
 

--- a/src/components/Explore/Explore.style.ts
+++ b/src/components/Explore/Explore.style.ts
@@ -157,8 +157,6 @@ function brightenStroke(colorHex: string) {
   }
 }
 
-// stroke: ${props =>
-//   props.stroke ? props.stroke : palette(props).foreground};
 export const MainSeriesLine = styled.g`
   line,
   path {

--- a/src/components/Explore/Explore.style.ts
+++ b/src/components/Explore/Explore.style.ts
@@ -148,12 +148,25 @@ export const PositionRelative = styled.div`
   margin: 0;
 `;
 
+// TODO(pablo): Hack to invert the colors for the vaccination chart
+function brightenStroke(colorHex: string) {
+  if (colorHex === '#000' || colorHex === '#000000') {
+    return '#fff';
+  } else {
+    return brightenColor(colorHex, 1);
+  }
+}
+
+// stroke: ${props =>
+//   props.stroke ? props.stroke : palette(props).foreground};
 export const MainSeriesLine = styled.g`
   line,
   path {
     fill: none;
     stroke: ${props =>
-      props.stroke ? props.stroke : palette(props).foreground};
+      palette(props).isDarkMode
+        ? brightenStroke(props.stroke || '#fff')
+        : props.stroke || '#000'};
     stroke-linecap: round;
     stroke-width: 3px;
   }

--- a/src/screens/internal/ShareImage/ChartExportImage.tsx
+++ b/src/screens/internal/ShareImage/ChartExportImage.tsx
@@ -24,7 +24,7 @@ import { SCREENSHOT_CLASS } from 'components/Screenshot';
 import { useRegionFromParams } from 'common/regions';
 
 const ExportChartImage = () => {
-  let { metric: metricString } = useParams();
+  let { metric: metricString } = useParams<{ metric: string }>();
   const region = useRegionFromParams();
   const projections = useProjectionsFromRegion(region);
   const lastUpdated = useModelLastUpdatedDate();


### PR DESCRIPTION
The sharing image has black background, this PR updates the styles of the lines and labels for the vaccination chart so they are lighter when using the dark theme.

To see this image we need to go to `/internal/share-image/states/:stateId/chart/6`, see [Florida](https://covid-projections-git-pablo-vaccination-sharing.covidactnow.now.sh/internal/share-image/states/fl/chart/6), for example

![image](https://user-images.githubusercontent.com/114084/105423413-4c00bb00-5bfa-11eb-8af1-1056f637639f.png)

The code that makes colors lighter doesn't work with black, so I hacked it a bit to cover this case. Will implement a better solution post launch!