### PR TITLE
better alignment for the explore labels

### DIFF
--- a/src/components/Explore/ExploreChart.tsx
+++ b/src/components/Explore/ExploreChart.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { sortBy, last } from 'lodash';
 import { Series } from './interfaces';
 import SingleLocationChart from './SingleLocationChart';
 import MultipleLocationsChart from './MultipleLocationsChart';

--- a/src/components/Explore/ExploreChart.tsx
+++ b/src/components/Explore/ExploreChart.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { sortBy, last } from 'lodash';
 import { Series } from './interfaces';
 import SingleLocationChart from './SingleLocationChart';
 import MultipleLocationsChart from './MultipleLocationsChart';
@@ -23,8 +24,8 @@ const ExploreChart: React.FC<{
   barOpacityHover,
   tooltipSubtext,
   ...otherProps
-}) =>
-  hasMultipleLocations ? (
+}) => {
+  return hasMultipleLocations ? (
     <MultipleLocationsChart {...otherProps} />
   ) : (
     <SingleLocationChart
@@ -34,5 +35,6 @@ const ExploreChart: React.FC<{
       {...otherProps}
     />
   );
+};
 
 export default ExploreChart;

--- a/src/components/Explore/MultipleLocationsChart.tsx
+++ b/src/components/Explore/MultipleLocationsChart.tsx
@@ -266,7 +266,7 @@ function formatCurrentValueLabels(
       ...labelInfoList,
       {
         x: lastPoint?.x ? getXPosition(lastPoint) : 0,
-        y: lastPoint?.y ? Math.max(getYPosition(lastPoint), currMaxY + 20) : 0,
+        y: lastPoint?.y ? Math.max(getYPosition(lastPoint), currMaxY + 14) : 0,
         label: currSeries.shortLabel,
         stroke: currSeries.params?.stroke || '#000',
       },

--- a/src/components/Explore/MultipleLocationsChart.tsx
+++ b/src/components/Explore/MultipleLocationsChart.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, Fragment } from 'react';
-import { isNumber } from 'lodash';
+import { isNumber, last, max, sortBy } from 'lodash';
 import { Group } from '@vx/group';
 import { scaleUtc, scaleLinear } from '@vx/scale';
 import { useTooltip } from '@vx/tooltip';
@@ -17,6 +17,13 @@ import { Line } from '@vx/shape';
 import DateMarker from './DateMarker';
 import GridLines from './GridLines';
 import Axes from './Axes';
+
+interface LabelInfo {
+  x: number;
+  y: number;
+  label: string;
+  stroke: string;
+}
 
 const getDate = (d: Column) => new Date(d.x);
 const getY = (d: Column) => d.y;
@@ -112,7 +119,7 @@ const MultipleLocationsChart: React.FC<{
 }> = ({
   width,
   height,
-  seriesList,
+  seriesList: unsortedSeriesList,
   isMobile,
   marginTop = 10,
   marginBottom = 30,
@@ -121,6 +128,8 @@ const MultipleLocationsChart: React.FC<{
   barOpacity,
   isMobileXs = false,
 }) => {
+  const seriesList = sortSeriesByLast(unsortedSeriesList);
+
   const dateFrom = new Date('2020-03-01');
   const dateTo = new Date();
   const maxY = getMaxBy<number>(seriesList, getY, 1);
@@ -151,6 +160,11 @@ const MultipleLocationsChart: React.FC<{
 
   const getXPosition = (d: Column) => dateScale(getDate(d)) || 0;
   const getYPosition = (d: Column) => yScale(getY(d));
+  const seriesLabels = formatCurrentValueLabels(
+    seriesList,
+    (p: Column) => innerWidth + 5,
+    getYPosition,
+  );
 
   return (
     <Styles.PositionRelative style={{ height }}>
@@ -171,20 +185,18 @@ const MultipleLocationsChart: React.FC<{
             yNumTicks={5}
           />
           <TodayMarker height={innerHeight} dateScale={dateScale} />
-          {seriesList.map((series, i) => {
-            const seriesColor = series.params?.stroke || '#000';
-            return series.data.length > 0 ? (
-              <Styles.LineLabel
-                key={`label-${series.label}`}
-                x={innerWidth + 5}
-                y={getYPosition(series.data[series.data.length - 1])}
-                fill={seriesColor}
-                fillOpacity={getSeriesOpacity(i, tooltipOpen, tooltipData)}
-              >
-                {getSeriesLabel(series, isMobileXs)}
-              </Styles.LineLabel>
-            ) : null;
-          })}
+          {seriesLabels.map((label, i) => (
+            <Styles.LineLabel
+              key={`label-${label.label}`}
+              x={label.x}
+              y={label.y}
+              fill={label.stroke}
+              fillOpacity={getSeriesOpacity(i, tooltipOpen, tooltipData)}
+            >
+              {getSeriesLabel(seriesList[i], isMobileXs)}
+            </Styles.LineLabel>
+          ))}
+
           <RectClipGroup width={innerWidth} height={innerHeight}>
             {seriesList.map(({ label, data, type, params }, i) => (
               <ChartSeries
@@ -242,4 +254,30 @@ const MultipleLocationsChart: React.FC<{
   );
 };
 
+function formatCurrentValueLabels(
+  seriesList: Series[],
+  getXPosition: (p: Column) => number,
+  getYPosition: (p: Column) => number,
+): LabelInfo[] {
+  return seriesList.reduce((labelInfoList: LabelInfo[], currSeries: Series) => {
+    const lastPoint = last(currSeries.data);
+    const currMaxY = max(labelInfoList.map(info => info.y)) || 0;
+    return [
+      ...labelInfoList,
+      {
+        x: lastPoint?.x ? getXPosition(lastPoint) : 0,
+        y: lastPoint?.y ? Math.max(getYPosition(lastPoint), currMaxY + 20) : 0,
+        label: currSeries.shortLabel,
+        stroke: currSeries.params?.stroke || '#000',
+      },
+    ];
+  }, []);
+}
+
+function sortSeriesByLast(seriesList: Series[]) {
+  return sortBy(seriesList, series => {
+    const lastPoint = last(series.data);
+    return lastPoint?.y || 0;
+  }).reverse();
+}
 export default MultipleLocationsChart;


### PR DESCRIPTION
The solution is pretty simple, it just adds a margin on the next label if the y coordinate of the current label is too close to the previous label, and keep the position otherwise. A potential drawback of this solution is that the labels could go off-screen, but since the labels are outside the `RectClipGroup`, there is some extra space below the x-axis that could be used by the labels.

**Before**
![image](https://user-images.githubusercontent.com/114084/105742062-e52c1c00-5eef-11eb-99f5-2232a90021d5.png)

**After**
![image](https://user-images.githubusercontent.com/114084/105742126-f6752880-5eef-11eb-9a57-836ea5b954ab.png)
