### PR TITLE
Fix missing region in aws calls

### DIFF
--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -20,8 +20,10 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: us-west-1
       - name: Invalidate CDN files.
         run: aws cloudfront create-invalidation --distribution-id EMVJ85Q1TRRQ3 --paths "/*"
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: us-west-1

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -2,8 +2,8 @@ name: Upload Site to http://staging.covidactnow.org.s3-website-us-west-1.amazona
 
 on:
   push:
-    # branches:
-    # - develop
+    branches:
+    - develop
 
 jobs:
   build-deploy:

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -2,8 +2,8 @@ name: Upload Site to http://staging.covidactnow.org.s3-website-us-west-1.amazona
 
 on:
   push:
-    branches:
-    - develop
+    # branches:
+    # - develop
 
 jobs:
   build-deploy:
@@ -20,8 +20,10 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: us-west-1
       - name: Invalidate CDN files.
         run: aws cloudfront create-invalidation --distribution-id E2V1DFIJXACO61 --paths "/*"
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: us-west-1

--- a/tools/deploy-s3.sh
+++ b/tools/deploy-s3.sh
@@ -36,7 +36,7 @@ execute () {
   aws configure set default.s3.max_concurrent_requests 30
 
   DEFAULT_OPTIONS="--acl public-read --no-progress"
-  CP_CMD="aws s3 cp --region us-west-1 --recursive ${DEFAULT_OPTIONS} ${BUILD_DIR} ${S3_PATH}"
+  CP_CMD="aws s3 cp --recursive ${DEFAULT_OPTIONS} ${BUILD_DIR} ${S3_PATH}"
 
   # static/ files are immutable, so cache for a year.
   ${CP_CMD} --exclude "*" --include "static/*" \


### PR DESCRIPTION
Removed setting the region in the shell script and simply set the region in the environment variables.

I think setting it in the environment variables makes it a bit more consistent and obvious that region should be set