### PR TITLE
transform the header buttons into real buttons

### DIFF
--- a/src/components/LocationPage/LocationPageHeader.style.tsx
+++ b/src/components/LocationPage/LocationPageHeader.style.tsx
@@ -5,6 +5,7 @@ import { COLORS } from 'common';
 import { COLOR_MAP } from 'common/colors';
 import { Level } from 'common/level';
 import MuiWarningIcon from '@material-ui/icons/Warning';
+import Button from '@material-ui/core/Button';
 
 export const ColoredHeaderBanner = styled(Box)`
   display: flex;
@@ -163,7 +164,12 @@ export const ButtonsWrapper = styled(Box)`
   }
 `;
 
-export const HeaderButton = styled(Box)`
+export const HeaderButton = styled(Button).attrs(props => ({
+  disableRipple: true,
+  disableFocusRipple: true,
+  variant: 'outlined',
+  focusVisibleClassName: 'Button-focused',
+}))`
   font-size: 13px;
   line-height: 1.2;
   cursor: pointer;
@@ -215,6 +221,12 @@ export const HeaderButton = styled(Box)`
     &:first-child {
       margin-right: 1.5rem;
     }
+  }
+
+  &.Button-focused {
+    // Defaults to blue if we don't have a user agent color
+    outline: blue auto 1px;
+    outline: -webkit-focus-ring-color auto 1px;
   }
 `;
 

--- a/src/components/LocationPage/LocationPageHeader.style.tsx
+++ b/src/components/LocationPage/LocationPageHeader.style.tsx
@@ -191,6 +191,7 @@ export const HeaderButton = styled(Button).attrs(props => ({
 
     &:hover {
       border: 1px solid ${COLOR_MAP.BLUE};
+      background-color: white;
     }
   }
 
@@ -199,6 +200,7 @@ export const HeaderButton = styled(Button).attrs(props => ({
 
     &:hover {
       border: 1px solid ${COLOR_MAP.RED.BASE};
+      background-color: white;
     }
   }
 


### PR DESCRIPTION
Changes the location page header buttons to be real buttons instead of wrapped divs to make them accessible. I also added a focused style to match the focused state of links. The buttons can be operated with the keyboard only and have a visual indicator of focus now.

![image](https://user-images.githubusercontent.com/114084/105782824-06a9f980-5f2a-11eb-9c69-79a200a7d02e.png)
