### PR TITLE
Recommendations order

### DIFF
--- a/src/common/utils/recommend.ts
+++ b/src/common/utils/recommend.ts
@@ -73,12 +73,7 @@ export function getRecommendations(
   recommendations: Recommendation[],
 ): any[] {
   const fedLevel = getFedLevel(projection);
-  const harvardLevel = getHarvardLevel(projection);
   const positiveTestRate = getPositiveTestRate(projection);
-
-  const harvardRecommendations = recommendations
-    .filter(item => item.source === RecommendationSource.HARVARD)
-    .filter(item => item.level === harvardLevel);
 
   let fedRecommendations = recommendations
     .filter(item => item.source === RecommendationSource.FED)
@@ -127,11 +122,10 @@ export function getRecommendations(
 
   const allRecommendations = [
     ...exposureRecommendations,
-    ...travelRecommendation,
     ...gatheringRecommendation,
     ...masksRecommendation,
     ...finalOtherFedRecommendations,
-    ...harvardRecommendations,
+    ...travelRecommendation,
   ];
 
   return allRecommendations.map(getIcon);


### PR DESCRIPTION
Removing school recommendation made the columns look unbalanced. This reorders the recommendations

Before-

![Screen Shot 2021-01-26 at 9 12 23 PM](https://user-images.githubusercontent.com/44076375/105932651-308f1900-601b-11eb-98e6-4683d9d4fdd0.png)

After-

<img width="978" alt="Screen Shot 2021-01-26 at 9 13 03 PM" src="https://user-images.githubusercontent.com/44076375/105932689-48669d00-601b-11eb-8ac5-1c84cf33465e.png">