### PR TITLE
Fixes markdown links, pt. 2

### DIFF
--- a/src/components/Markdown/utils.ts
+++ b/src/components/Markdown/utils.ts
@@ -1,5 +1,13 @@
+/**
+ * Checks if href is an internal CAN URL, while making sure the check
+ * doesn't return true for apidocs.covidactnow.org, blog.covidactnow.org
+ */
 export function isInternalUrlWithCan(href: string) {
-  return href.includes('covidactnow.org');
+  return (
+    href.startsWith('covidactnow.org') ||
+    href.startsWith('www.covidactnow.org') ||
+    href.startsWith('https://covidactnow.org')
+  );
 }
 
 export function isInternalLink(href: string) {


### PR DESCRIPTION
#2539 added an `isInternalUrlWithCan` util, which broke markdown links that include covidactnow.org but aren't actually internal links (ie. apidocs.covidactnow.org, blog.covidactnow.org...). This PR fixes