### PR TITLE
exclude the user email address from FullStory recordings

### DIFF
--- a/src/components/Newsletter/Newsletter.js
+++ b/src/components/Newsletter/Newsletter.js
@@ -141,6 +141,7 @@ class Newsletter extends React.Component {
           />
           <InputHolder>
             <input
+              className="fs-exclude"
               ref={i => (this.emailInput = i)}
               autoComplete="Email"
               aria-label="Email"

--- a/src/components/Newsletter/Newsletter.js
+++ b/src/components/Newsletter/Newsletter.js
@@ -141,12 +141,11 @@ class Newsletter extends React.Component {
           />
           <InputHolder>
             <input
-              className="fs-exclude"
               ref={i => (this.emailInput = i)}
               autoComplete="Email"
               aria-label="Email"
               placeholder="Enter your email address"
-              className="js-cm-email-input qa-input-email"
+              className="js-cm-email-input qa-input-email fs-exclude"
               id="fieldEmail"
               maxLength="200"
               name="cm-wurhhh-wurhhh"


### PR DESCRIPTION
Adding the class `fs-exclude` to elements excludes the element from the recordings, the field will be shown as a white block with stripes on the recordings

![image](https://user-images.githubusercontent.com/114084/106022687-f6edfa80-607a-11eb-8907-52c4b3d0487b.png)
 
- [How do I protect my users' privacy in FullStory?](https://help.fullstory.com/hc/en-us/articles/360020623574-How-do-I-protect-my-users-privacy-in-FullStory-)