### PR TITLE
Increase timeout in scrollWithTimeout

### DIFF
--- a/src/components/Markdown/MarkdownLink.tsx
+++ b/src/components/Markdown/MarkdownLink.tsx
@@ -17,7 +17,7 @@ import ExternalLink from 'components/ExternalLink';
 const scrollWithTimeout = (element: any, offset: number) => {
   return setTimeout(() => {
     scrollWithOffset(element, offset);
-  }, 350);
+  }, 400);
 };
 
 const MarkdownLink: React.FC<{


### PR DESCRIPTION
The timeout needed a bump from 350->400 in order for the scroll to work properly when page's content isn't yet lazy-loaded