### PR TITLE
cms: allows adding embeds in the markdown blocks

### DIFF
--- a/src/cms-content/learn/products-landing.json
+++ b/src/cms-content/learn/products-landing.json
@@ -19,7 +19,7 @@
       "productName": "Embed",
       "productId": "embed",
       "productSubtitle": "Allows you to embed our data into your website",
-      "productDescription": "We want our data and modeling to be available to all who are interested, including by third parties. That’s why we’ve made our data embeddable by other publishers.\n\nRead our [blog post](https://blog.covidactnow.org/data-feeds/) for instructions for how to use our embed. Here's what it looks like live:"
+      "productDescription": "We want our data and modeling to be available to all who are interested, including by third parties. That’s why we’ve made our data embeddable by other publishers.\n\nRead our [blog post](https://blog.covidactnow.org/data-feeds/) for instructions for how to use our embed. Here's what it looks like live: \n\n [Covid Act Now Embed - Dallas metro area](https://covidactnow.org/embed/us/fips/19100)\n\n"
     }
   ],
   "metadataTitle": "Tools",

--- a/src/components/Markdown/Markdown.style.ts
+++ b/src/components/Markdown/Markdown.style.ts
@@ -154,3 +154,8 @@ export const Caption = styled.figcaption`
   font-style: italic;
   margin-bottom: 1.5rem;
 `;
+
+export const CenterEmbed = styled.div`
+  display: flex;
+  justify-content: center;
+`;

--- a/src/components/Markdown/MarkdownLink.tsx
+++ b/src/components/Markdown/MarkdownLink.tsx
@@ -1,7 +1,12 @@
 import React, { Fragment } from 'react';
 import { HashLink } from 'react-router-hash-link';
 import { scrollWithOffset } from 'components/TableOfContents';
-import { isValidURL, isInternalLink, formatInternalLink } from './utils';
+import {
+  isValidURL,
+  isInternalLink,
+  isInternalEmbed,
+  formatInternalLink,
+} from './utils';
 import TwitterEmbed, { isTwitterEmbed } from './TwitterEmbed';
 import YouTubeEmbed, { isYouTubeEmbed } from './YoutubeEmbed';
 import { trackEvent, EventCategory, EventAction } from 'components/Analytics';
@@ -37,8 +42,21 @@ const MarkdownLink: React.FC<{
     return <YouTubeEmbed embedUrl={href} />;
   }
 
-  // HACK to track clicks on the exposure notification recommendation
+  if (isInternalEmbed(href)) {
+    return (
+      <iframe
+        src={href}
+        title="Covid Act Now"
+        width="400"
+        height="440"
+        frameBorder="0"
+        scrolling="no"
+      />
+    );
+  }
+
   if (href === 'https://g.co/ens') {
+    // HACK to track clicks on the exposure notification recommendation
     return (
       <ExternalLink href={href} onClick={trackExposureClickRecommend}>
         {children}

--- a/src/components/Markdown/MarkdownLink.tsx
+++ b/src/components/Markdown/MarkdownLink.tsx
@@ -11,6 +11,7 @@ import TwitterEmbed, { isTwitterEmbed } from './TwitterEmbed';
 import YouTubeEmbed, { isYouTubeEmbed } from './YoutubeEmbed';
 import { trackEvent, EventCategory, EventAction } from 'components/Analytics';
 import ExternalLink from 'components/ExternalLink';
+import { CenterEmbed } from './Markdown.style';
 /**
  * Custom hyperlink for Markdown content. If the link is external, open it on
  * a new tab. If the link is internal, use the HashLink component to render
@@ -44,14 +45,16 @@ const MarkdownLink: React.FC<{
 
   if (isInternalEmbed(href)) {
     return (
-      <iframe
-        src={href}
-        title="Covid Act Now"
-        width="400"
-        height="440"
-        frameBorder="0"
-        scrolling="no"
-      />
+      <CenterEmbed>
+        <iframe
+          src={href}
+          title="Covid Act Now"
+          width="400"
+          height="440"
+          frameBorder="0"
+          scrolling="no"
+        />
+      </CenterEmbed>
     );
   }
 

--- a/src/components/Markdown/utils.ts
+++ b/src/components/Markdown/utils.ts
@@ -38,3 +38,7 @@ export function isValidURL(href: string): boolean {
   }
   return true;
 }
+
+export function isInternalEmbed(href: string) {
+  return href.startsWith('https://covidactnow.org/embed/');
+}

--- a/src/screens/Embed/Embed.style.js
+++ b/src/screens/Embed/Embed.style.js
@@ -24,7 +24,7 @@ export const EmbedContainer = styled(Paper)`
   justify-content: center;
   overflow: hidden;
   border-radius: 4px;
-  height: ${props => props.height || 'auto'};
+  height: ${props => props.height || `${EMBED_HEIGHT}px`};
   width: ${props => props.width || `${EMBED_WIDTH}px`};
   box-shadow: none;
 `;

--- a/src/screens/Embed/Embed.style.js
+++ b/src/screens/Embed/Embed.style.js
@@ -25,7 +25,6 @@ export const EmbedContainer = styled(Paper)`
   overflow: hidden;
   border-radius: 4px;
   height: ${props => props.height || 'auto'};
-  // height: ${props => props.height || `${EMBED_HEIGHT}px`};
   width: ${props => props.width || `${EMBED_WIDTH}px`};
   box-shadow: none;
 `;
@@ -132,7 +131,6 @@ export const EmbedWrapper = styled(Box)`
   align-items: center;
   flex-direction: column;
   border: 1px solid rgba(0, 0, 0, 0.12);
-  // margin: 12px;
   border-radius: 4px;
 
   @media screen and (min-width: 600px) {

--- a/src/screens/Embed/Embed.style.js
+++ b/src/screens/Embed/Embed.style.js
@@ -24,7 +24,8 @@ export const EmbedContainer = styled(Paper)`
   justify-content: center;
   overflow: hidden;
   border-radius: 4px;
-  height: ${props => props.height || `${EMBED_HEIGHT}px`};
+  height: ${props => props.height || 'auto'};
+  // height: ${props => props.height || `${EMBED_HEIGHT}px`};
   width: ${props => props.width || `${EMBED_WIDTH}px`};
   box-shadow: none;
 `;
@@ -131,7 +132,7 @@ export const EmbedWrapper = styled(Box)`
   align-items: center;
   flex-direction: column;
   border: 1px solid rgba(0, 0, 0, 0.12);
-  margin: 12px;
+  // margin: 12px;
   border-radius: 4px;
 
   @media screen and (min-width: 600px) {

--- a/src/screens/Tools/Tools.style.tsx
+++ b/src/screens/Tools/Tools.style.tsx
@@ -38,7 +38,3 @@ export const ToolsSection = styled.div`
     margin-bottom: 0;
   }
 `;
-
-export const EmbedExampleWrapper = styled.div`
-  margin-top: 2rem;
-`;

--- a/src/screens/Tools/Tools.tsx
+++ b/src/screens/Tools/Tools.tsx
@@ -8,11 +8,7 @@ import {
   productsLandingContent,
   ProductsLandingSection,
 } from 'cms-content/learn/tools';
-import {
-  MarkdownTools,
-  ToolsSection,
-  EmbedExampleWrapper,
-} from './Tools.style';
+import { MarkdownTools, ToolsSection } from './Tools.style';
 import { TocItem } from 'cms-content/utils';
 
 /**
@@ -42,21 +38,6 @@ export const sidebarSections: TocItem[] = [
   },
 ];
 
-const EmbedExample = () => {
-  return (
-    <EmbedExampleWrapper>
-      <iframe
-        src="https://covidactnow.org/embed/us/colorado-co"
-        title="Covid Act Now"
-        width="330"
-        height="400"
-        frameBorder="0"
-        scrolling="no"
-      />
-    </EmbedExampleWrapper>
-  );
-};
-
 const Tools = () => {
   const date = formatMetatagDate();
 
@@ -73,7 +54,6 @@ const Tools = () => {
           <ToolsSection key={product.productId}>
             <Heading2 id={product.productId}>{product.productName}</Heading2>
             <MarkdownTools source={product.productDescription} />
-            {product.productId === 'embed' && <EmbedExample />}
           </ToolsSection>
         ))}
       </PageContent>


### PR DESCRIPTION
This PR enables CMS users to add our embeds to markdown content inline by adding the URL of the embed as a link on the markdown content.

I also fixed the embed a bit because it wasn't showing the borders correctly, however, this fix will be noticeable only once we deploy this to production (we can test it by replacing the url with the local embed URL (`http://localhost:3000/embed/us/fips/19100`, for example)

