### PR TITLE
vaccination block: remove special case for states

### DIFF
--- a/src/components/RegionVaccinationBlock/RegionVaccinationBlock.tsx
+++ b/src/components/RegionVaccinationBlock/RegionVaccinationBlock.tsx
@@ -1,20 +1,3 @@
-import React from 'react';
 import VaccinationBlock from './VaccinationBlock';
-import StateVaccinationBlock from './StateVaccinationBlock';
-import { fail } from 'common/utils';
-import { Region, County, State, MetroArea } from 'common/regions';
 
-const RegionVaccinationBox: React.FC<{ region: Region }> = ({ region }) => {
-  if (region instanceof County || region instanceof MetroArea) {
-    return <VaccinationBlock region={region} />;
-  } else if (region instanceof State) {
-    return <StateVaccinationBlock region={region} />;
-  } else {
-    fail(
-      `RegionVaccinationBox: missing implementation for region with fips ${region.fipsCode}`,
-    );
-    return null;
-  }
-};
-
-export default RegionVaccinationBox;
+export default VaccinationBlock;

--- a/src/components/RegionVaccinationBlock/index.ts
+++ b/src/components/RegionVaccinationBlock/index.ts
@@ -1,3 +1,3 @@
-import RegionVaccinationBlock from './RegionVaccinationBlock';
+import VaccinationBlock from './VaccinationBlock';
 
-export default RegionVaccinationBlock;
+export default VaccinationBlock;


### PR DESCRIPTION
This PR removes the special case for states. I'm keeping the component just in case, but will remove and rename after we launch.