### PR TITLE
Add useScrollToTerm function

### DIFF
--- a/src/common/hooks/index.ts
+++ b/src/common/hooks/index.ts
@@ -3,8 +3,10 @@ import useShowPastPosition from './useShowPastPosition';
 import useBreakpoint from './useBreakpoint';
 import useGeolocation from './useGeolocation';
 import useGeolocationInExplore from './useGeolocationInExplore';
+import useScrollToElement from './useScrollToElement';
 
 export {
+  useScrollToElement,
   useScrollToTopButton,
   useShowPastPosition,
   useBreakpoint,

--- a/src/common/hooks/useScrollToElement.ts
+++ b/src/common/hooks/useScrollToElement.ts
@@ -1,0 +1,18 @@
+/* Scrolls to the specific element corresponding to the hash. 
+Example: covidactnow.org/glossary#npi will automatically scroll to the NPI section. */
+
+import { useEffect } from 'react';
+import { useLocation } from 'react-router';
+import { scrollWithOffset } from 'components/TableOfContents';
+
+export default function useScrollToElement(): void {
+  const elementToScrollTo = useLocation().hash;
+  useEffect(() => {
+    const element = elementToScrollTo
+      ? (document.querySelector(elementToScrollTo) as HTMLElement)
+      : null;
+    if (element) {
+      scrollWithOffset(element, -80);
+    }
+  }, [elementToScrollTo]);
+}

--- a/src/screens/Learn/Glossary/Glossary.tsx
+++ b/src/screens/Learn/Glossary/Glossary.tsx
@@ -14,7 +14,7 @@ import { learnPages } from 'cms-content/learn';
 import Breadcrumbs from 'components/Breadcrumbs';
 import { formatMetatagDate, formatNumericalDate } from 'common/utils';
 import ScrollToTopButton from 'components/SharedComponents/ScrollToTopButton';
-import { useScrollToTopButton } from 'common/hooks';
+import { useScrollToElement, useScrollToTopButton } from 'common/hooks';
 import Footer from 'screens/Learn/Footer/Footer';
 import ExternalLink from 'components/ExternalLink';
 
@@ -30,6 +30,15 @@ function getGlossaryFooter(): React.ReactElement {
     </Fragment>
   );
 }
+
+const GlossaryTerm: React.FC<{ term: Term }> = ({ term }) => {
+  return (
+    <Fragment key={`glossary-term-${term.termId}`}>
+      <SectionName id={term.termId}>{term.term}</SectionName>
+      <MarkdownContent source={term.definition} />
+    </Fragment>
+  );
+};
 
 const Glossary: React.FC = () => {
   const {
@@ -49,6 +58,8 @@ const Glossary: React.FC = () => {
 
   const date = formatMetatagDate();
 
+  useScrollToElement();
+
   return (
     <Fragment>
       <AppMetaTags
@@ -66,10 +77,7 @@ const Glossary: React.FC = () => {
           Last updated {formatNumericalDate(lastUpdatedDate)}
         </LastUpdatedDate>
         {terms.map((term: Term, i: number) => (
-          <Fragment key={`glossary-term-${i}`}>
-            <SectionName id={term.termId}>{term.term}</SectionName>
-            <MarkdownContent source={term.definition} />
-          </Fragment>
+          <GlossaryTerm term={term} />
         ))}
         <Footer pageSpecificCopy={getGlossaryFooter()} />
         <ScrollToTopButton


### PR DESCRIPTION
Currently, when the user navigates to a term on the glossary page _using a new tab/window_, the page doesn't scroll to the term. This PR fixes the scroll location so even when the user navigates to a term in a new tab/window, the page will automatically scroll to the term's location. Some points to consider:
- Perhaps the `useScrollToTerm` function can be placed in a common location so it can be reused elsewhere. Is `common/hooks` an appropriate place? (If this function is moved, it will be renamed accordingly).
- Glossary term is moved out of the `return` clause to acknowledge them as their own objects. @pnavarrc suggests to have the scroll-to-term functionality within each term object (correct me if I misunderstand though!), although I'm not sure whether we should be mixing an object with page navigation functionalities, and if a scroll-to-object method exists then one can just call it at appropriate points in the page?