### PR TITLE
update reference to action-slack to use the full commit sha

### DIFF
--- a/.github/workflows/alert-email-report-prod.yml
+++ b/.github/workflows/alert-email-report-prod.yml
@@ -35,6 +35,6 @@ jobs:
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_DEV_ALERTS }}
           STATUS: ${{job.status}}
-        uses: Ilshidur/action-slack@fb92a78
+        uses: Ilshidur/action-slack@fb92a78a305a399cd6d8ede99d641f2b9224daf3
         with:
           args: 'Email Alerts Report finished with status: {{STATUS}}.  See report: https://docs.google.com/spreadsheets/d/12JRyyAo6Thn4nCDf8nmdAU9CTVeJhjMRjMuK6vxfJbM/edit#gid=0'

--- a/.github/workflows/send-alert-emails.yml
+++ b/.github/workflows/send-alert-emails.yml
@@ -62,7 +62,7 @@ jobs:
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           STATUS: ${{job.status}}
-        uses: Ilshidur/action-slack@fb92a78
+        uses: Ilshidur/action-slack@fb92a78a305a399cd6d8ede99d641f2b9224daf3
         with:
           args: '[${{env.FIREBASE_ENV}}] send-alert-emails failed for snapshot ${{env.SNAPSHOT_ID}} send_emails=${{env.SEND_EMAILS}}: {{STATUS}}'
       - name: Slack notification
@@ -70,6 +70,6 @@ jobs:
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           STATUS: ${{job.status}}
-        uses: Ilshidur/action-slack@fb92a78
+        uses: Ilshidur/action-slack@fb92a78a305a399cd6d8ede99d641f2b9224daf3
         with:
           args: '[${{env.FIREBASE_ENV}}] Successfully sent alerts emails for snapshot ${{env.SNAPSHOT_ID}}'

--- a/.github/workflows/update-snapshot.yml
+++ b/.github/workflows/update-snapshot.yml
@@ -78,7 +78,7 @@ jobs:
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_DAILY_DEPLOYS }}
           STATUS: ${{job.status}}
-        uses: Ilshidur/action-slack@fb92a78
+        uses: Ilshidur/action-slack@fb92a78a305a399cd6d8ede99d641f2b9224daf3
         with:
           args: 'update-snapshot failed: {{STATUS}}'
       - name: Slack notification
@@ -86,7 +86,7 @@ jobs:
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_DAILY_DEPLOYS }}
           STATUS: ${{job.status}}
-        uses: Ilshidur/action-slack@fb92a78
+        uses: Ilshidur/action-slack@fb92a78a305a399cd6d8ede99d641f2b9224daf3
         with:
           args: |
             PR to update the website to snapshot ${{env.SNAPSHOT_ID}} (with updated map colors and share images) is available.


### PR DESCRIPTION
GitHub disabled short SHA for third-party GitHub Actions, which made the workflow for [alert emails fail this morning](https://github.com/covid-projections/covid-projections/actions/runs/518909331)

The recommended way to use third-party actions is to have the full SHA hash in the action, or use the tag number if we trust the author. I updated the action to use the full hash for now.

- https://github.com/Ilshidur/action-slack/releases
- https://github.com/Ilshidur/action-slack/commit/fb92a78a305a399cd6d8ede99d641f2b9224daf3 (2.0.0 release)

See https://docs.github.com/en/actions/learn-github-actions/security-hardening-for-github-actions#using-third-party-actions for more details

