### PR TITLE
fix alignment for compare on the location page

### DIFF
--- a/src/components/LocationPage/ChartsHolder.tsx
+++ b/src/components/LocationPage/ChartsHolder.tsx
@@ -151,12 +151,14 @@ const ChartsHolder = ({ projections, region, chartId }: ChartsHolderProps) => {
         <MainContentInner>
           <RegionVaccinationBlock region={region} />
         </MainContentInner>
-        <CompareMain
-          stateName={getStateName(region) || region.name} // rename prop
-          locationsViewable={6}
-          stateId={(region as State).stateCode || undefined}
-          region={region}
-        />
+        <MainContentInner>
+          <CompareMain
+            stateName={getStateName(region) || region.name} // rename prop
+            locationsViewable={6}
+            stateId={(region as State).stateCode || undefined}
+            region={region}
+          />
+        </MainContentInner>
         <MainContentInner>
           <Recommend
             introCopy={recommendationsIntro}

--- a/src/components/RegionVaccinationBlock/RegionVaccinationBlock.style.ts
+++ b/src/components/RegionVaccinationBlock/RegionVaccinationBlock.style.ts
@@ -3,6 +3,10 @@ import MuiChevronRightIcon from '@material-ui/icons/ChevronRight';
 import styled from 'styled-components';
 import { COLOR_MAP } from 'common/colors';
 
+export const Container = styled.div`
+  margin-bottom: 21px;
+`;
+
 export const Heading2 = styled.h2`
   font-family: Roboto;
   font-style: normal;

--- a/src/components/RegionVaccinationBlock/RegionVaccinationBlock.tsx
+++ b/src/components/RegionVaccinationBlock/RegionVaccinationBlock.tsx
@@ -60,18 +60,26 @@ const VaccinationBlock: React.FC<{ region: Region }> = ({ region }) => {
         .
       </Paragraph>
       {eligibilityLinks.length > 0 && (
-        <VaccinationLinksBlock
-          title="When can I get vaccinated if I’m in..."
-          links={eligibilityLinks}
-          trackingLinkPrefix="Eligibility"
-        />
+        <Fragment>
+          <Heading3>
+            <strong>When</strong> can I get vaccinated if I’m in...
+          </Heading3>
+          <VaccinationLinksBlock
+            links={eligibilityLinks}
+            trackingLinkPrefix="Eligibility"
+          />
+        </Fragment>
       )}
       {vaccinationOptionsLinks.length > 0 && (
-        <VaccinationLinksBlock
-          title="Where and how do I get vaccinated if I’m in..."
-          links={vaccinationOptionsLinks}
-          trackingLinkPrefix="Options"
-        />
+        <Fragment>
+          <Heading3>
+            <strong>Where and how</strong> do I get vaccinated if I’m in...
+          </Heading3>
+          <VaccinationLinksBlock
+            links={vaccinationOptionsLinks}
+            trackingLinkPrefix="Options"
+          />
+        </Fragment>
       )}
     </Container>
   );
@@ -79,28 +87,22 @@ const VaccinationBlock: React.FC<{ region: Region }> = ({ region }) => {
 
 // TODO: Add tracking for these links
 const VaccinationLinksBlock: React.FC<{
-  title: string;
   links: VaccinationLink[];
   trackingLinkPrefix: string;
-}> = ({ title, links, trackingLinkPrefix }) => (
-  <Fragment>
-    <Heading3>{title}</Heading3>
-    <ButtonContainer>
-      {links.map(({ label, url }) => (
-        <LinkButton
-          href={url}
-          key={label}
-          target="_blank"
-          rel="noopener noreferrer"
-          onClick={() =>
-            trackVaccinationLink(`${trackingLinkPrefix}: ${label}`)
-          }
-        >
-          {label}
-        </LinkButton>
-      ))}
-    </ButtonContainer>
-  </Fragment>
+}> = ({ links, trackingLinkPrefix }) => (
+  <ButtonContainer>
+    {links.map(({ label, url }) => (
+      <LinkButton
+        href={url}
+        key={label}
+        target="_blank"
+        rel="noopener noreferrer"
+        onClick={() => trackVaccinationLink(`${trackingLinkPrefix}: ${label}`)}
+      >
+        {label}
+      </LinkButton>
+    ))}
+  </ButtonContainer>
 );
 
 export default VaccinationBlock;

--- a/src/components/RegionVaccinationBlock/RegionVaccinationBlock.tsx
+++ b/src/components/RegionVaccinationBlock/RegionVaccinationBlock.tsx
@@ -11,6 +11,7 @@ import {
   ButtonContainer,
   Heading2,
   Paragraph,
+  Container,
 } from './RegionVaccinationBlock.style';
 import {
   getVaccinationRegions,
@@ -45,7 +46,7 @@ const VaccinationBlock: React.FC<{ region: Region }> = ({ region }) => {
     .filter((link): link is VaccinationLink => link !== null);
 
   return (
-    <Fragment>
+    <Container>
       <Heading2>Vaccines</Heading2>
       <Paragraph>
         Below are government resources to help you get vaccinated. If something
@@ -72,7 +73,7 @@ const VaccinationBlock: React.FC<{ region: Region }> = ({ region }) => {
           trackingLinkPrefix="Options"
         />
       )}
-    </Fragment>
+    </Container>
   );
 };
 


### PR DESCRIPTION
Reported by Igor - fixes an issue that was causing the compare table to not have padding on mobile (location page)

![image](https://user-images.githubusercontent.com/114084/106214939-b9759400-6184-11eb-98ad-f4dadcf3b612.png)
