### PR TITLE
implement LinkButton component

### DIFF
--- a/src/components/Analytics/utils.ts
+++ b/src/components/Analytics/utils.ts
@@ -44,6 +44,7 @@ export enum EventCategory {
   EXPOSURE_NOTIFICATIONS = 'exposure notifications',
   SEARCH = 'search',
   VACCINATION = 'vaccination',
+  NONE = 'none', // use NONE for development
 }
 
 /**
@@ -77,7 +78,9 @@ export function trackEvent(
   value?: number,
   nonInteraction?: boolean,
 ) {
-  ReactGA.event({ category, action, label, value, nonInteraction });
+  if (category !== EventCategory.NONE) {
+    ReactGA.event({ category, action, label, value, nonInteraction });
+  }
 }
 
 export function trackSaveImage(category: EventCategory, label: string) {

--- a/src/components/AppBar/DonateButton.style.ts
+++ b/src/components/AppBar/DonateButton.style.ts
@@ -1,45 +1,37 @@
 import styled from 'styled-components';
-import MuiButton from '@material-ui/core/Button';
 import { COLOR_MAP } from 'common/colors';
 import { mobileBreakpoint } from 'assets/theme/sizes';
+import LinkButton from 'components/LinkButton';
 
-const DonateButtonBase = styled(MuiButton).attrs(props => ({
-  disableRipple: true,
-  disableFocusRipple: true,
+const DonateButtonBase = styled(LinkButton).attrs(props => ({
   variant: 'contained',
-}))``;
-
-export const StyledDonateButton = styled(DonateButtonBase)`
-  background-color: white;
+}))`
   margin: auto 0;
   display: inline-flex;
-  border: 2px solid ${COLOR_MAP.GRAY.LIGHT};
-  color: ${COLOR_MAP.PURPLE};
   box-shadow: none;
-
-  &:hover {
-    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.12);
-  }
 
   @media (min-width: ${mobileBreakpoint}) {
     margin-left: 2rem;
   }
 `;
 
+export const StyledDonateButtonA = styled(DonateButtonBase)`
+  background-color: white;
+  color: ${COLOR_MAP.PURPLE};
+  border: 2px solid ${COLOR_MAP.GRAY.LIGHT};
+
+  &:hover {
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.12);
+  }
+`;
+
 export const StyledDonateButtonB = styled(DonateButtonBase)`
-  margin: auto 0;
-  display: inline-flex;
   background-color: ${COLOR_MAP.PURPLE};
   color: white;
-  box-shadow: none;
 
   &:hover {
     background-color: ${COLOR_MAP.PURPLE};
-    color: white; */
-  }
-
-  @media (min-width: ${mobileBreakpoint}) {
-    margin-left: 2rem;
+    color: white;
   }
 `;
 

--- a/src/components/AppBar/DonateButton.tsx
+++ b/src/components/AppBar/DonateButton.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
 import useScrollPosition from '@react-hook/window-scroll';
 import { Fade } from '@material-ui/core';
 import {

--- a/src/components/AppBar/DonateButton.tsx
+++ b/src/components/AppBar/DonateButton.tsx
@@ -1,6 +1,4 @@
 import React from 'react';
-import useScrollPosition from '@react-hook/window-scroll';
-import { Fade } from '@material-ui/core';
 import {
   DonateButtonWrapper,
   StyledDonateButtonA,
@@ -18,23 +16,6 @@ const trackingProps = {
   trackingCategory: EventCategory.DONATE,
   trackingAction: EventAction.CLICK,
   trackingLabel: 'AppBar donate button',
-};
-
-export const DonateButtonWithFade = () => {
-  // uses https://www.npmjs.com/package/@react-hook/window-scroll :
-  const scrollY = useScrollPosition();
-  // 170 approximates the height of the donation banner:
-  const isPassedBanner = scrollY > 170;
-
-  return (
-    <Fade in={isPassedBanner} timeout={150}>
-      <DonateButtonWrapper>
-        <StyledDonateButtonA to="/donate" {...trackingProps}>
-          Donate
-        </StyledDonateButtonA>
-      </DonateButtonWrapper>
-    </Fade>
-  );
 };
 
 export const DonateButton = () => (

--- a/src/components/AppBar/DonateButton.tsx
+++ b/src/components/AppBar/DonateButton.tsx
@@ -3,11 +3,11 @@ import { Link } from 'react-router-dom';
 import useScrollPosition from '@react-hook/window-scroll';
 import { Fade } from '@material-ui/core';
 import {
-  StyledDonateButton as StyledDonateButtonA,
   DonateButtonWrapper,
+  StyledDonateButtonA,
   StyledDonateButtonB,
 } from './DonateButton.style';
-import { EventAction, EventCategory, trackEvent } from 'components/Analytics';
+import { EventAction, EventCategory } from 'components/Analytics';
 import {
   Experiment,
   ExperimentID,
@@ -15,10 +15,11 @@ import {
   VariantID,
 } from 'components/Experiment';
 
-function trackClickDonate() {
-  const trackLabel = 'AppBar donate button';
-  trackEvent(EventCategory.DONATE, EventAction.CLICK, trackLabel);
-}
+const trackingProps = {
+  trackingCategory: EventCategory.DONATE,
+  trackingAction: EventAction.CLICK,
+  trackingLabel: 'AppBar donate button',
+};
 
 export const DonateButtonWithFade = () => {
   // uses https://www.npmjs.com/package/@react-hook/window-scroll :
@@ -29,11 +30,9 @@ export const DonateButtonWithFade = () => {
   return (
     <Fade in={isPassedBanner} timeout={150}>
       <DonateButtonWrapper>
-        <Link to="/donate">
-          <StyledDonateButtonA onClick={trackClickDonate}>
-            Donate
-          </StyledDonateButtonA>
-        </Link>
+        <StyledDonateButtonA to="/donate" {...trackingProps}>
+          Donate
+        </StyledDonateButtonA>
       </DonateButtonWrapper>
     </Fade>
   );
@@ -41,19 +40,17 @@ export const DonateButtonWithFade = () => {
 
 export const DonateButton = () => (
   <DonateButtonWrapper>
-    <Link to="/donate">
-      <Experiment id={ExperimentID.DONATE_BTN_COLOR}>
-        <Variant id={VariantID.A}>
-          <StyledDonateButtonA onClick={trackClickDonate}>
-            Donate
-          </StyledDonateButtonA>
-        </Variant>
-        <Variant id={VariantID.B}>
-          <StyledDonateButtonB onClick={trackClickDonate}>
-            Donate
-          </StyledDonateButtonB>
-        </Variant>
-      </Experiment>
-    </Link>
+    <Experiment id={ExperimentID.DONATE_BTN_COLOR}>
+      <Variant id={VariantID.A}>
+        <StyledDonateButtonA to="/donate" {...trackingProps}>
+          Donate
+        </StyledDonateButtonA>
+      </Variant>
+      <Variant id={VariantID.B}>
+        <StyledDonateButtonB to="/donate" {...trackingProps}>
+          Donate
+        </StyledDonateButtonB>
+      </Variant>
+    </Experiment>
   </DonateButtonWrapper>
 );

--- a/src/components/LinkButton/LinkButton.stories.tsx
+++ b/src/components/LinkButton/LinkButton.stories.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import LinkButton from './LinkButton';
+import InfoOutlinedIcon from '@material-ui/icons/InfoOutlined';
+import { EventCategory } from 'components/Analytics';
+
+export default {
+  title: 'Building Blocks/LinkButton',
+  component: LinkButton,
+  argTypes: {
+    trackingCategory: EventCategory.NONE,
+    trackingLabel: 'Label',
+  },
+};
+
+export const InternalLink = (args: any) => (
+  <LinkButton to="/donate" {...args}>
+    Donate
+  </LinkButton>
+);
+
+export const ExternalLink = (args: any) => (
+  <LinkButton {...args} href="https://covidactnow.org">
+    Covid Act Now
+  </LinkButton>
+);
+
+export const Contained = (args: any) => (
+  <LinkButton {...args} href="https://covidactnow.org" variant="contained">
+    Contained
+  </LinkButton>
+);
+
+export const Outlined = (args: any) => (
+  <LinkButton {...args} href="https://covidactnow.org" variant="outlined">
+    Outlined
+  </LinkButton>
+);
+
+export const Text = (args: any) => (
+  <LinkButton {...args} href="https://covidactnow.org" variant="text">
+    Text Button
+  </LinkButton>
+);
+
+export const WithIcon = (args: any) => (
+  <LinkButton
+    {...args}
+    href="https://covidactnow.org"
+    variant="contained"
+    startIcon={<InfoOutlinedIcon />}
+  >
+    With Icon
+  </LinkButton>
+);

--- a/src/components/LinkButton/LinkButton.style.ts
+++ b/src/components/LinkButton/LinkButton.style.ts
@@ -1,0 +1,12 @@
+import MuiButton from '@material-ui/core/Button';
+import styled from 'styled-components';
+
+export const StyledButton = styled(MuiButton).attrs(props => ({
+  disableRipple: true,
+  disableFocusRipple: true,
+}))`
+  &.Mui-focusVisible {
+    outline: blue auto 1px;
+    outline: -webkit-focus-ring-color auto 1px;
+  }
+`;

--- a/src/components/LinkButton/LinkButton.style.ts
+++ b/src/components/LinkButton/LinkButton.style.ts
@@ -1,7 +1,7 @@
 import MuiButton from '@material-ui/core/Button';
 import styled from 'styled-components';
 
-export const StyledButton = styled(MuiButton).attrs(props => ({
+export const BaseButton = styled(MuiButton).attrs(props => ({
   disableRipple: true,
   disableFocusRipple: true,
 }))`

--- a/src/components/LinkButton/LinkButton.tsx
+++ b/src/components/LinkButton/LinkButton.tsx
@@ -1,0 +1,60 @@
+import React, { ComponentProps, DetailedHTMLProps } from 'react';
+import { Link, LinkProps } from 'react-router-dom';
+import { assert } from 'common/utils';
+import { StyledButton } from './LinkButton.style';
+import { EventAction, EventCategory, trackEvent } from 'components/Analytics';
+
+type AnchorLinkType = DetailedHTMLProps<
+  React.AnchorHTMLAttributes<HTMLAnchorElement>,
+  HTMLAnchorElement
+>;
+
+type StyledButtonProps = ComponentProps<typeof StyledButton>;
+
+type ExternalLinkButtonProps = StyledButtonProps & AnchorLinkType;
+
+type InternalLinkButtonProps = StyledButtonProps & LinkProps;
+
+interface TrackingProps {
+  trackingCategory: EventCategory;
+  trackingAction?: EventAction;
+  trackingLabel: string;
+}
+
+export type LinkButtonProps = InternalLinkButtonProps | ExternalLinkButtonProps;
+
+const LinkButton: React.FC<LinkButtonProps & TrackingProps> = props => {
+  assert(
+    props.href || props.to,
+    "LinkButton needs either 'to' or 'href' as props",
+  );
+
+  const isInternalLink = props.to;
+  const { trackingAction, trackingCategory, trackingLabel } = props;
+
+  const onClick = (ev: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
+    const action =
+      trackingAction || isInternalLink
+        ? EventAction.NAVIGATE
+        : EventAction.CLICK_LINK;
+    if (trackingCategory && trackingLabel) {
+      trackEvent(trackingCategory, action, trackingLabel);
+    }
+    props.onClick && props.onClick(ev);
+  };
+
+  if (isInternalLink) {
+    return <StyledButton {...props} component={Link} onClick={onClick} />;
+  } else {
+    return (
+      <StyledButton
+        {...props}
+        target="_blank"
+        rel="noopener noreferrer"
+        onClick={onClick}
+      />
+    );
+  }
+};
+
+export default LinkButton;

--- a/src/components/LinkButton/LinkButton.tsx
+++ b/src/components/LinkButton/LinkButton.tsx
@@ -1,7 +1,7 @@
 import React, { ComponentProps, DetailedHTMLProps } from 'react';
 import { Link, LinkProps } from 'react-router-dom';
 import { assert } from 'common/utils';
-import { StyledButton } from './LinkButton.style';
+import { BaseButton } from './LinkButton.style';
 import { EventAction, EventCategory, trackEvent } from 'components/Analytics';
 
 type AnchorLinkType = DetailedHTMLProps<
@@ -9,7 +9,7 @@ type AnchorLinkType = DetailedHTMLProps<
   HTMLAnchorElement
 >;
 
-type StyledButtonProps = ComponentProps<typeof StyledButton>;
+type StyledButtonProps = ComponentProps<typeof BaseButton>;
 
 type ExternalLinkButtonProps = StyledButtonProps & AnchorLinkType;
 
@@ -44,10 +44,10 @@ const LinkButton: React.FC<LinkButtonProps & TrackingProps> = props => {
   };
 
   if (isInternalLink) {
-    return <StyledButton {...props} component={Link} onClick={onClick} />;
+    return <BaseButton {...props} component={Link} onClick={onClick} />;
   } else {
     return (
-      <StyledButton
+      <BaseButton
         {...props}
         target="_blank"
         rel="noopener noreferrer"

--- a/src/components/LinkButton/index.ts
+++ b/src/components/LinkButton/index.ts
@@ -1,0 +1,4 @@
+import LinkButton from './LinkButton';
+export * from './LinkButton';
+
+export default LinkButton;


### PR DESCRIPTION
Implements a reusable LinkButton component. We use links that look like buttons in a couple of places in the app, and we keep re-implementing them each time.

### Features
- Don't have double focus (accessibility)
- Handle internal and external links (passing `to` or `href` respectively)
- The type of its props match the types of Material UI button + either Link (from `react-router-dom`) or an anchor element. This allows the button to take any props that a Material UI button would expect.

### Styling
- Disabled ripple effect (but they can be re-enabled with props)
- Have a focus outline for accessibility
- Don't have much extra styling, that way we can style them for each use case.

The `Donate` button was updated to be based on this new component.