### PR TITLE
Fix amount of locations shown in compare modal

### DIFF
--- a/src/components/Compare/LocationTable.tsx
+++ b/src/components/Compare/LocationTable.tsx
@@ -251,11 +251,23 @@ const LocationTable: React.FunctionComponent<{
     ? remove(sortedLocations, removePinnedIfRankedFirst)
     : sortedLocations;
 
-  const visibleLocations = !isModal
-    ? sortedLocations.slice(0, numLocationsMain)
-    : homepageScope !== HomepageLocationScope.STATE
-    ? sortedLocations.slice(0, 100)
-    : modalLocations;
+  const getVisibleLocations = () => {
+    if (!isModal) {
+      return sortedLocations.slice(0, numLocationsMain);
+    } else {
+      if (region) {
+        if (geoScope === GeoScopeFilter.COUNTRY)
+          return sortedLocations.slice(0, 100);
+        else return modalLocations;
+      } else {
+        if (homepageScope === HomepageLocationScope.STATE)
+          return modalLocations;
+        else return sortedLocations.slice(0, 100);
+      }
+    }
+  };
+
+  const visibleLocations = getVisibleLocations();
 
   const returnShowStateCode = (region?: Region): boolean => {
     if (region) {


### PR DESCRIPTION
[Trello ticket](https://trello.com/c/f5edT7a9/793-4-concerns-that-state-level-compare-charts-only-show-100-counties-when-expanded-even-though-the-copy-says-view-all-counties-in-s)

To test: 

[On prod](https://covidactnow.org/us/missouri-mo/county/jackson_county/?s=1568508), clicking 'View all counties in Missouri' below the compare table only shows the first 100 counties (rather than all 115 in the state)

[With fix](http://localhost:3000/us/missouri-mo/county/jackson_county/?s=1568508)