### PR TITLE
Get rid of div grouping metro name and state

### DIFF
--- a/src/components/Compare/Compare.style.tsx
+++ b/src/components/Compare/Compare.style.tsx
@@ -6,6 +6,7 @@ import { COLORS } from 'common';
 import { Metric } from 'common/metric';
 import { Level } from 'common/level';
 import { ChartLocationName } from 'components/LocationPage/ChartsHolder.style';
+import { Link } from 'react-router-dom';
 
 // TODO (Chelsi): consolidate into a theme:
 
@@ -257,6 +258,10 @@ export const TableHeadContainer = styled(TableHead)<{ $isModal?: boolean }>`
   }
 `;
 
+export const StyledLink = styled(Link)`
+  text-decoration: none;
+`;
+
 export const Population = styled.span`
   font-family: Source Code Pro;
   font-size: 0.875rem;
@@ -270,6 +275,21 @@ export const Rank = styled.span`
   color: ${COLOR_MAP.GRAY.DARK};
   font-family: Source Code Pro;
   margin-right: 0.75rem;
+`;
+
+export const LocationCellWrapper = styled.div`
+  display: flex;
+  min-width: 0;
+`;
+
+export const LocationRankWrapper = styled.div`
+  flex: 0 0 auto;
+`;
+
+export const LocationNameWrapper = styled.div`
+  flex: 1 1 auto;
+  white-space: normal;
+  text-overflow: initial;
 `;
 
 export const LocationInfoWrapper = styled.div`
@@ -314,6 +334,10 @@ export const LocationNameCell = styled.td<{
     &:first-child {
       vertical-align: top;
     }
+  }
+
+  ${LocationCellWrapper} {
+    display: flex;
   }
 `;
 

--- a/src/components/Compare/CompareTableRow.tsx
+++ b/src/components/Compare/CompareTableRow.tsx
@@ -1,15 +1,18 @@
 import React from 'react';
 import { isNumber } from 'lodash';
-import { Link } from 'react-router-dom';
 import FiberManualRecordIcon from '@material-ui/icons/FiberManualRecord';
 import {
   MetricCell,
   Row,
   MetricValue,
   Population,
+  LocationCellWrapper,
   LocationInfoWrapper,
+  LocationRankWrapper,
   LocationNameCell,
+  LocationNameWrapper,
   Rank,
+  StyledLink,
 } from 'components/Compare/Compare.style';
 import { Metric, formatValue } from 'common/metric';
 import { RankedLocationSummary } from 'common/utils/compare';
@@ -67,7 +70,7 @@ const CompareTableRow = (props: {
   const populationRoundTo = isHomepage ? 3 : 2;
 
   return (
-    <Link to={locationLink}>
+    <StyledLink to={locationLink}>
       <Row
         index={location.rank}
         $isCurrentCounty={isCurrentCounty}
@@ -77,23 +80,28 @@ const CompareTableRow = (props: {
           iconColor={location.metricsInfo.level}
           sortByPopulation={sortByPopulation}
         >
-          <div>
-            <Rank>{location.rank}</Rank>
-            <FiberManualRecordIcon />
-          </div>
-          <div>
-            <StyledRegionName
-              showStateCode={showStateCode}
-              region={location.region}
-              condensed
-            />
-            <br />
-            <LocationInfoWrapper>
-              <Population>
-                {formatEstimate(location.region.population, populationRoundTo)}
-              </Population>
-            </LocationInfoWrapper>
-          </div>
+          <LocationCellWrapper>
+            <LocationRankWrapper>
+              <Rank>{location.rank}</Rank>
+              <FiberManualRecordIcon />
+            </LocationRankWrapper>
+            <LocationNameWrapper>
+              <StyledRegionName
+                showStateCode={showStateCode}
+                region={location.region}
+                condensed
+              />
+              <br />
+              <LocationInfoWrapper>
+                <Population>
+                  {formatEstimate(
+                    location.region.population,
+                    populationRoundTo,
+                  )}
+                </Population>
+              </LocationInfoWrapper>
+            </LocationNameWrapper>
+          </LocationCellWrapper>
         </LocationNameCell>
         {metrics.map((metric: Metric, i) => {
           const metricForValue = location.metricsInfo.metrics[metric];
@@ -117,7 +125,7 @@ const CompareTableRow = (props: {
           );
         })}
       </Row>
-    </Link>
+    </StyledLink>
   );
 };
 


### PR DESCRIPTION
This PR adds wrappers to the compare table on the homepage to enable more specific styling of location cells. Within each first column cell of the table, this also enables the location name text to roll up to the first line and be immediately next to the rank element.