### PR TITLE
Re-Enable TN and WA ICU Data

### DIFF
--- a/src/common/models/Projection.ts
+++ b/src/common/models/Projection.ts
@@ -34,10 +34,7 @@ const DISABLED_INFECTION_RATE = new DisabledFips([]);
 
 const DISABLED_TEST_POSITIVITY = new DisabledFips([]);
 
-const DISABLED_ICU = new DisabledFips([
-  '47', // https://trello.com/c/aEd07i5Y/701-disabled-tn-icu-headroom
-  '53', // https://trello.com/c/1IkmUuhw/
-]);
+const DISABLED_ICU = new DisabledFips([]);
 
 const DISABLED_VACCINATIONS = new DisabledFips([
   /39.../, // https://trello.com/c/J3M0Ksb5/827-ohio-county-vaccinations-are-not-cumulative


### PR DESCRIPTION
We blocked state level TN and WA ICU data due to reporting anamolies in January. Those anomalies have resolved themselves.

See
- https://trello.com/c/dcas02sS/764-disabled-tennessee-icu-capacity-used-suspicious-drop-off-at-tail
- https://trello.com/c/1IkmUuhw/755-disabled-washington-icu-capacity-used-spiked-up-25-to-96-despite-declining-covid-icu-hospitalizations