### PR TITLE
Fix vaccine ratio/pct mixup

### DIFF
--- a/src/common/metrics/vaccinations.tsx
+++ b/src/common/metrics/vaccinations.tsx
@@ -61,9 +61,9 @@ function renderStatus(projections: Projections): React.ReactElement {
   const { locationName } = projections;
 
   const peopleInitiated = formatInteger(info.peopleInitiated);
-  const percentInitiated = formatPercent(info.percentInitiated, 1);
+  const percentInitiated = formatPercent(info.ratioInitiated, 1);
   const peopleVaccinated = formatInteger(info.peopleVaccinated);
-  const percentVaccinated = formatPercent(info.percentVaccinated, 1);
+  const percentVaccinated = formatPercent(info.ratioVaccinated, 1);
 
   return (
     <Fragment>

--- a/src/common/models/Projection.ts
+++ b/src/common/models/Projection.ts
@@ -112,14 +112,14 @@ export interface ICUCapacityInfo {
 }
 
 export interface VaccinationsInfo {
-  percentCompletedSeries: Array<number | null>;
-  percentInitiatedSeries: Array<number | null>;
+  ratioCompletedSeries: Array<number | null>;
+  ratioInitiatedSeries: Array<number | null>;
 
   peopleInitiated: number;
-  percentInitiated: number;
+  ratioInitiated: number;
 
   peopleVaccinated: number;
-  percentVaccinated: number;
+  ratioVaccinated: number;
 }
 
 /**
@@ -254,10 +254,10 @@ export class Projection {
       metricsTimeseries,
     );
     this.vaccinations =
-      this.vaccinationsInfo?.percentInitiatedSeries ||
+      this.vaccinationsInfo?.ratioInitiatedSeries ||
       this.dates.map(date => null);
     this.vaccinationsCompleted =
-      this.vaccinationsInfo?.percentCompletedSeries ||
+      this.vaccinationsInfo?.ratioCompletedSeries ||
       this.dates.map(date => null);
 
     this.caseDensityByCases = metricsTimeseries.map(
@@ -374,24 +374,22 @@ export class Projection {
       return null;
     }
 
-    const percentInitiated = metrics.vaccinationsInitiatedRatio;
-    const percentVaccinated = metrics.vaccinationsCompletedRatio;
+    const ratioInitiated = metrics.vaccinationsInitiatedRatio;
+    const ratioVaccinated = metrics.vaccinationsCompletedRatio;
 
     if (
-      percentInitiated === null ||
-      percentInitiated === undefined ||
-      percentVaccinated === null ||
-      percentVaccinated === undefined
+      ratioInitiated === null ||
+      ratioInitiated === undefined ||
+      ratioVaccinated === null ||
+      ratioVaccinated === undefined
     ) {
       return null;
     }
 
     const peopleVaccinated =
-      actuals.vaccinationsCompleted ??
-      (percentVaccinated / 100.0) * this.totalPopulation;
+      actuals.vaccinationsCompleted ?? ratioVaccinated * this.totalPopulation;
     const peopleInitiated =
-      actuals.vaccinationsInitiated ??
-      (percentInitiated / 100.0) * this.totalPopulation;
+      actuals.vaccinationsInitiated ?? ratioInitiated * this.totalPopulation;
 
     const vaccinationsCompletedSeries = metricsTimeseries.map(
       row => row?.vaccinationsCompletedRatio || null,
@@ -403,10 +401,10 @@ export class Projection {
     return {
       peopleVaccinated,
       peopleInitiated,
-      percentInitiated,
-      percentVaccinated,
-      percentCompletedSeries: vaccinationsCompletedSeries,
-      percentInitiatedSeries: vaccinationsInitiatedSeries,
+      ratioInitiated,
+      ratioVaccinated,
+      ratioCompletedSeries: vaccinationsCompletedSeries,
+      ratioInitiatedSeries: vaccinationsInitiatedSeries,
     };
   }
 

--- a/src/common/models/Projections.ts
+++ b/src/common/models/Projections.ts
@@ -79,7 +79,7 @@ export class Projections {
         return this.primary.currentTestPositiveRate;
       case Metric.VACCINATIONS:
         return this.primary.vaccinationsInfo
-          ? this.primary.vaccinationsInfo.percentInitiated
+          ? this.primary.vaccinationsInfo.ratioInitiated
           : null;
       case Metric.CASE_DENSITY:
         return this.primary.currentCaseDensity;


### PR DESCRIPTION
Fix for https://github.com/covid-projections/covid-projections/pull/2634

This PR removes the extraneous conversion from a ratio (0-1) to percent (0-100) and renames the variables from percent... to ratio...

It fixes the incorrect vaccinated count currently seen at https://covidactnow.org/us/tennessee-tn/county/shelby_county/chart/6/

## Tested 

Ran `yarn` and `yarn start` and checked http://localhost:3000/us/tennessee-tn/county/shelby_county/chart/6 has text "In Shelby County, Tennessee, 33,226 people (3.5%) have received the first shot ..."