### PR TITLE
vaccination alerts: fetch vaccination info from Firestore

### DIFF
--- a/.github/workflows/alert-email-report-prod.yml
+++ b/.github/workflows/alert-email-report-prod.yml
@@ -18,7 +18,7 @@ jobs:
           node-version: 12.x
       - run: yarn install
       - name: Write Firebase Service Account
-        run: echo "$SERVICE_ACCOUNT" > scripts/alert_emails/google-service-account.json
+        run: echo "$SERVICE_ACCOUNT" > scripts/common/firebase/google-service-account.json
         env:
           SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_PROD }}
       - name: Write Spreadsheet Service Account

--- a/.github/workflows/send-alert-emails.yml
+++ b/.github/workflows/send-alert-emails.yml
@@ -6,15 +6,15 @@ on:
   workflow_dispatch:
     inputs:
       firebase_env:
-        description: "Environment to run against (prod, dev, or staging)"
+        description: 'Environment to run against (prod, dev, or staging)'
         required: true
         default: prod
       send_emails:
-        description: "Whether to actually send emails (true) or just do a safe dry-run (false)."
+        description: 'Whether to actually send emails (true) or just do a safe dry-run (false).'
         required: true
         default: false
       snapshot_id:
-        description: "Snapshot to send alerts for (auto uses currently deployed snapshot)."
+        description: 'Snapshot to send alerts for (auto uses currently deployed snapshot).'
         required: true
         default: auto
 
@@ -39,17 +39,17 @@ jobs:
       # Write appropriate service account file for FIREBASE_ENV.
       - name: Write Dev Service Account
         if: ${{ env.FIREBASE_ENV == 'dev' }}
-        run: echo "$SERVICE_ACCOUNT" > scripts/alert_emails/google-service-account.json
+        run: echo "$SERVICE_ACCOUNT" > scripts/common/firebase/google-service-account.json
         env:
           SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_DEV }}
       - name: Write Staging Service Account
         if: ${{ env.FIREBASE_ENV == 'staging' }}
-        run: echo "$SERVICE_ACCOUNT" > scripts/alert_emails/google-service-account.json
+        run: echo "$SERVICE_ACCOUNT" > scripts/common/firebase/google-service-account.json
         env:
           SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_STAGING }}
       - name: Write Prod Service Account
         if: ${{ env.FIREBASE_ENV == 'prod' }}
-        run: echo "$SERVICE_ACCOUNT" > scripts/alert_emails/google-service-account.json
+        run: echo "$SERVICE_ACCOUNT" > scripts/common/firebase/google-service-account.json
         env:
           SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_PROD }}
 

--- a/scripts/.gitignore
+++ b/scripts/.gitignore
@@ -2,3 +2,4 @@
 slack-summary.txt
 county-history-data.json
 vaccination_alerts/vaccination-alerts.json
+google-service-account.json

--- a/scripts/alert_emails/create_lists_to_email.ts
+++ b/scripts/alert_emails/create_lists_to_email.ts
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import fs from 'fs-extra';
 import path from 'path';
 import { GrpcStatus as FirestoreErrorCode } from '@google-cloud/firestore';
-import { getFirestore } from './firestore';
+import { getFirestore } from '../common/firebase';
 import { resolveSnapshot } from './utils';
 
 function exitWithUsage(): never {

--- a/scripts/alert_emails/firestore.ts
+++ b/scripts/alert_emails/firestore.ts
@@ -4,32 +4,6 @@ import path from 'path';
 
 const ALERTS_SUBSCRIPTIONS_COLLECTION = 'alerts-subscriptions';
 
-export function getFirestore(): FirebaseFirestore.Firestore {
-  // NOTE: An appropriate service account key should automatically exist when
-  // running in the github actions workflow.
-  const serviceAccountFile = path.join(
-    __dirname,
-    'google-service-account.json',
-  );
-  if (!fs.existsSync(serviceAccountFile)) {
-    console.error(`File not found: ${serviceAccountFile}`);
-    console.error(
-      'If you are testing locally, you can use the covidactnow-dev service account found here:',
-    );
-    console.error(
-      'https://docs.google.com/document/d/1YoZUzmy6rYXwO1VSMrHklcD7pdCCLaOkGG-1kLwZpsg/edit',
-    );
-    process.exit(-1);
-  }
-  let serviceAccount = require(serviceAccountFile);
-
-  admin.initializeApp({
-    credential: admin.credential.cert(serviceAccount),
-  });
-
-  return admin.firestore();
-}
-
 export interface Subscription {
   email: string;
   locations: string[];

--- a/scripts/alert_emails/generate_daily_alerts.ts
+++ b/scripts/alert_emails/generate_daily_alerts.ts
@@ -14,7 +14,7 @@ import { fetchMainSnapshotNumber } from '../../src/common/utils/snapshots';
 import regions from '../../src/common/regions';
 import { Alert } from './interfaces';
 import moment from 'moment';
-import { getFirestore } from './firestore';
+import { getFirestore } from '../common/firebase';
 import { SummariesMap } from '../../src/common/location_summaries';
 import { Level } from '../../src/common/level';
 import { resolveSnapshot } from './utils';

--- a/scripts/common/firebase/firestore.ts
+++ b/scripts/common/firebase/firestore.ts
@@ -1,0 +1,27 @@
+import path from 'path';
+import fs from 'fs';
+import admin from 'firebase-admin';
+
+export function getFirestore(): FirebaseFirestore.Firestore {
+  const serviceAccountFile = path.join(
+    __dirname,
+    'google-service-account.json',
+  );
+  if (!fs.existsSync(serviceAccountFile)) {
+    console.error(`File not found: ${serviceAccountFile}`);
+    console.error(
+      'If you are testing locally, you can use the covidactnow-dev service account found here:',
+    );
+    console.error(
+      'https://docs.google.com/document/d/1YoZUzmy6rYXwO1VSMrHklcD7pdCCLaOkGG-1kLwZpsg/edit',
+    );
+    process.exit(-1);
+  }
+  let serviceAccount = require(serviceAccountFile);
+
+  admin.initializeApp({
+    credential: admin.credential.cert(serviceAccount),
+  });
+
+  return admin.firestore();
+}

--- a/scripts/common/firebase/index.ts
+++ b/scripts/common/firebase/index.ts
@@ -1,0 +1,3 @@
+import { getFirestore } from './firestore';
+
+export { getFirestore };

--- a/scripts/vaccination_alerts/README.md
+++ b/scripts/vaccination_alerts/README.md
@@ -17,10 +17,11 @@ This script determines which locations have updated vaccination information by c
 ```yaml
 info:
   vaccinationInfoUpdates:
-    '11':
-      emailAlertVersion: 0
-    '12':
-      emailAlertVersion: 0
+    locations:
+      '11':
+        emailAlertVersion: 0
+      '12':
+        emailAlertVersion: 0
 ```
 
 ### From the CMS
@@ -97,8 +98,9 @@ Finally, we update the `info` collection with the latest updated date.
 ```yaml
 info:
   vaccinationInfoUpdates:
-    '11':
-      emailAlertVersion: 3 # Updated 0 -> 3
-    '12':
-      emailAlertVersion: 0
+    locations:
+      '11':
+        emailAlertVersion: 3 # Updated 0 -> 3
+      '12':
+        emailAlertVersion: 0
 ```

--- a/scripts/vaccination_alerts/README.md
+++ b/scripts/vaccination_alerts/README.md
@@ -15,13 +15,11 @@ This script determines which locations have updated vaccination information by c
 ### Firebase
 
 ```yaml
-info:
-  vaccinationInfoUpdates:
-    locations:
-      '11':
-        emailAlertVersion: 0
-      '12':
-        emailAlertVersion: 0
+vaccination-info-updates:
+  '11':
+    emailAlertVersion: 0
+  '12':
+    emailAlertVersion: 0
 ```
 
 ### From the CMS
@@ -93,14 +91,12 @@ We fetch the emails where `sentAt` is `null` from the `vaccination-alerts` colle
 
 For each pair of (email, fipsCode), we get the information for the given location in the `vaccination-alerts.json` file, render and send the email to the user. We mark the email as sent in the collection `vaccination-alerts` by setting `sentAt` with the currrent date.
 
-Finally, we update the `info` collection with the latest updated date.
+Finally, we update the `vaccination-info-updates` collection with the latest updated date.
 
 ```yaml
-info:
-  vaccinationInfoUpdates:
-    locations:
-      '11':
-        emailAlertVersion: 3 # Updated 0 -> 3
-      '12':
-        emailAlertVersion: 0
+vaccination-info-updates:
+  '11':
+    emailAlertVersion: 3
+  '12':
+    emailAlertVersion: 0
 ```

--- a/scripts/vaccination_alerts/generate-vaccine-alerts-info.ts
+++ b/scripts/vaccination_alerts/generate-vaccine-alerts-info.ts
@@ -10,14 +10,14 @@ import {
  * Generates the `vaccination-alerts.json` file with a map of locations that
  * have updated vaccination information.
  *
- * Run via: yarn vaccinations.locations
+ * Run via: yarn vaccinations-generate-alerts
  */
 
 const alertsFilePath = path.join(__dirname, 'vaccination-alerts.json');
 
 async function main() {
   const cmsInfo = getCmsVaccinationInfo();
-  const firebaseInfo = getFirebaseVaccinationInfo();
+  const firebaseInfo = await getFirebaseVaccinationInfo();
 
   const vaccinationAlertUpdates = getUpdatedVaccinationInfo(
     cmsInfo,

--- a/scripts/vaccination_alerts/utils.ts
+++ b/scripts/vaccination_alerts/utils.ts
@@ -17,7 +17,7 @@ export interface RegionVaccineVersionMap {
   [fipsCode: string]: RegionVaccineVersion;
 }
 
-const VACCINATION_VERSIONS_COLLECTION = 'info/vaccinationInfoUpdates/locations';
+const VACCINATION_VERSIONS_COLLECTION = 'vaccination-info-updates';
 
 export function getCmsVaccinationInfo(): RegionVaccinePhaseInfoMap {
   return _.chain(stateVaccinationPhases)

--- a/scripts/vaccination_alerts/utils.ts
+++ b/scripts/vaccination_alerts/utils.ts
@@ -1,4 +1,5 @@
 import _ from 'lodash';
+import { getFirestore } from '../common/firebase';
 import {
   RegionVaccinePhaseInfo,
   stateVaccinationPhases,
@@ -23,14 +24,13 @@ export function getCmsVaccinationInfo(): RegionVaccinePhaseInfoMap {
     .value();
 }
 
-// TODO: Fetch this from Firebase, return an empty object if Firebase
-// doesn't have any data.
-export function getFirebaseVaccinationInfo(): RegionVaccineVersionMap {
-  return {
-    // '29': {
-    //   emailAlertVersion: 0,
-    // },
-  };
+export async function getFirebaseVaccinationInfo(): Promise<
+  RegionVaccineVersionMap
+> {
+  const db = await getFirestore();
+  const versionDoc = await db.doc('info/vaccinationInfoUpdates').get();
+  const versionsByFips = versionDoc.data();
+  return versionsByFips || {};
 }
 
 export function getUpdatedVaccinationInfo(


### PR DESCRIPTION
This PR updates the generate-vaccination-alerts script to fetch the vaccination info version from Firebase and move the `getFirebase` function to a common location since it will be reused for vaccine alerts.