### PR TITLE
Add "Blocked Locations" to compare.

### DIFF
--- a/src/common/metrics/case_density.tsx
+++ b/src/common/metrics/case_density.tsx
@@ -12,6 +12,7 @@ import ExternalLink from 'components/ExternalLink';
 import Thermometer from 'components/Thermometer';
 import { MetricDefinition } from './interfaces';
 import moment from 'moment';
+import { Metric } from 'common/metric';
 
 export const CaseIncidenceMetric: MetricDefinition = {
   renderStatus,
@@ -68,11 +69,8 @@ export const CASE_DENSITY_LEVEL_INFO_MAP: LevelInfoMap = {
 };
 
 function renderStatus(projections: Projections): React.ReactElement {
-  const {
-    currentCaseDensity,
-    totalPopulation,
-    currentDailyAverageCases,
-  } = projections.primary;
+  const { totalPopulation, currentDailyAverageCases } = projections.primary;
+  const currentCaseDensity = projections.getMetricValue(Metric.CASE_DENSITY);
   const locationName = projections.locationName;
   if (
     currentCaseDensity === null ||

--- a/src/common/metrics/case_growth.tsx
+++ b/src/common/metrics/case_growth.tsx
@@ -84,7 +84,7 @@ export const CASE_GROWTH_RATE_LEVEL_INFO_MAP: LevelInfoMap = {
 };
 
 function renderStatus(projections: Projections): React.ReactElement {
-  const { rt } = projections.primary;
+  const rt = projections.getMetricValue(Metric.CASE_GROWTH_RATE);
   const locationName = projections.locationName;
 
   if (rt === null) {

--- a/src/common/metrics/positive_rate.tsx
+++ b/src/common/metrics/positive_rate.tsx
@@ -85,7 +85,9 @@ export const POSITIVE_TESTS_LEVEL_INFO_MAP: LevelInfoMap = {
 };
 
 function renderStatus(projections: Projections) {
-  const { currentTestPositiveRate } = projections.primary;
+  const currentTestPositiveRate = projections.getMetricValue(
+    Metric.POSITIVE_TESTS,
+  );
   const locationName = projections.locationName;
   if (currentTestPositiveRate === null) {
     const fips = projections.fips;

--- a/src/common/models/Projection.ts
+++ b/src/common/models/Projection.ts
@@ -12,9 +12,10 @@ import {
 } from 'api/schema/RegionSummaryWithTimeseries';
 import { indexOfLastValue, lastValue } from './utils';
 import { assert } from 'common/utils';
+import { Metric } from 'common/metric';
 
 /** Stores a list of FIPS or FIPS regex patterns to disable. */
-class DisabledFips {
+class DisabledFipsList {
   constructor(private fipsPatterns: (string | RegExp)[]) {}
 
   includes(fips: string): boolean {
@@ -28,38 +29,44 @@ class DisabledFips {
   }
 }
 
-const DISABLED_CASE_DENSITY: string[] = [];
+/**
+ * Override any disabled metrics and make them reenabled. Used by internal tools.
+ */
+let overrideDisabledMetrics = false;
+export function reenableDisabledMetrics(enable: boolean): void {
+  overrideDisabledMetrics = enable;
+}
 
-const DISABLED_INFECTION_RATE = new DisabledFips([]);
-
-const DISABLED_TEST_POSITIVITY = new DisabledFips([
-  '47093', // https://trello.com/c/pmB5mGZU/883-disabled-knox-county-tn-test-positivity
-]);
-
-const DISABLED_ICU = new DisabledFips([]);
-
-//https://trello.com/c/9OCK0e3O/878-maine-vaccination-metric-data-off-by-2-decimal-places-likely-ratio-vs-percentage-bug
-const DISABLED_VACCINATIONS = new DisabledFips([
-  '23001',
-  '23003',
-  '23005',
-  '23007',
-  '23009',
-  '23011',
-  '23013',
-  '23015',
-  '23017',
-  '23019',
-  '23021',
-  '23023',
-  '23025',
-  '23027',
-  '23029',
-  '23031',
-  '30340',
-  '30620',
-  '38860',
-]);
+export const DISABLED_METRICS: { [metric in Metric]: DisabledFipsList } = {
+  [Metric.CASE_DENSITY]: new DisabledFipsList([]),
+  [Metric.CASE_GROWTH_RATE]: new DisabledFipsList([]),
+  [Metric.HOSPITAL_USAGE]: new DisabledFipsList([]),
+  [Metric.POSITIVE_TESTS]: new DisabledFipsList([
+    '47093', // https://trello.com/c/pmB5mGZU/883-disabled-knox-county-tn-test-positivity
+  ]),
+  [Metric.VACCINATIONS]: new DisabledFipsList([
+    //https://trello.com/c/9OCK0e3O/878-maine-vaccination-metric-data-off-by-2-decimal-places-likely-ratio-vs-percentage-bug
+    '23001',
+    '23003',
+    '23005',
+    '23007',
+    '23009',
+    '23011',
+    '23013',
+    '23015',
+    '23017',
+    '23019',
+    '23021',
+    '23023',
+    '23025',
+    '23027',
+    '23029',
+    '23031',
+    '30340',
+    '30620',
+    '38860',
+  ]),
+};
 
 /**
  * We truncate (or in the case of charts, switch to a dashed line) the last
@@ -171,7 +178,7 @@ export class Projection {
 
   readonly currentCumulativeDeaths: number | null;
   readonly currentCumulativeCases: number | null;
-  readonly currentCaseDensity: number | null;
+  private readonly currentCaseDensity: number | null;
   readonly currentDailyDeaths: number | null;
 
   private readonly cumulativeActualDeaths: Array<number | null>;
@@ -236,13 +243,9 @@ export class Projection {
       this.rawDailyDeaths,
     );
 
-    // TODO(https://trello.com/c/B6Z1kW8o/): Fix Tennessee Hospitalization data.
-    const hospitalizationsDisabled =
-      this.fips.length > 2 && this.fips.slice(0, 2) === '47';
-
-    this.rawHospitalizations = hospitalizationsDisabled
-      ? []
-      : actualTimeseries.map(row => row && row.hospitalBeds.currentUsageCovid);
+    this.rawHospitalizations = actualTimeseries.map(
+      row => row && row.hospitalBeds.currentUsageCovid,
+    );
     this.smoothedHospitalizations = this.smoothWithRollingAverage(
       this.rawHospitalizations,
     );
@@ -257,8 +260,7 @@ export class Projection {
       actualTimeseries.map(row => row && row.deaths),
     );
 
-    const disableRt = false;
-    this.rtRange = disableRt ? [null] : this.calcRtRange(metricsTimeseries);
+    this.rtRange = this.calcRtRange(metricsTimeseries);
     this.testPositiveRate = metricsTimeseries.map(
       row => row && row.testPositivityRatio,
     );
@@ -288,10 +290,7 @@ export class Projection {
     );
     this.caseDensityRange = this.calcCaseDensityRange();
 
-    this.currentCaseDensity =
-      metrics && !DISABLED_CASE_DENSITY.includes(this.fips)
-        ? metrics.caseDensity
-        : null;
+    this.currentCaseDensity = metrics?.caseDensity ?? null;
     this.currentDailyDeaths = lastValue(this.smoothedDailyDeaths);
 
     this.currentCumulativeDeaths = summaryWithTimeseries.actuals.deaths;
@@ -310,24 +309,41 @@ export class Projection {
     return this.dates[this.dates.length - 1];
   }
 
-  get currentTestPositiveRate(): number | null {
-    if (DISABLED_TEST_POSITIVITY.includes(this.fips)) {
-      return null;
-    }
-
-    return this.metrics && this.metrics.testPositivityRatio;
-  }
-
   get testPositiveRateSource(): string | null {
     return this.metrics?.testPositivityRatioDetails?.source || null;
   }
 
-  get rt(): number | null {
-    if (DISABLED_INFECTION_RATE.includes(this.fips)) {
+  getMetricValue(metric: Metric): number | null {
+    if (this.isMetricDisabled(metric)) {
       return null;
     }
 
-    return this.metrics && this.metrics.infectionRate;
+    switch (metric) {
+      case Metric.CASE_GROWTH_RATE:
+        return this.metrics?.infectionRate ?? null;
+      case Metric.HOSPITAL_USAGE:
+        return this.icuCapacityInfo ? this.icuCapacityInfo.metricValue : null;
+      case Metric.POSITIVE_TESTS:
+        return this.metrics?.testPositivityRatio ?? null;
+      case Metric.VACCINATIONS:
+        return this.vaccinationsInfo
+          ? this.vaccinationsInfo.ratioInitiated
+          : null;
+      case Metric.CASE_DENSITY:
+        return this.currentCaseDensity;
+      default:
+        fail('Unknown metric: ' + metric);
+    }
+  }
+
+  isMetricDisabled(metric: Metric): boolean {
+    return (
+      DISABLED_METRICS[metric].includes(this.fips) && !overrideDisabledMetrics
+    );
+  }
+
+  isMetricDisabledIgnoreOverride(metric: Metric): boolean {
+    return DISABLED_METRICS[metric].includes(this.fips);
   }
 
   private getIcuCapacityInfo(
@@ -335,17 +351,16 @@ export class Projection {
     metricsTimeseries: Array<MetricsTimeseriesRow | null>,
     actualsTimeseries: Array<ActualsTimeseriesRow | null>,
   ): ICUCapacityInfo | null {
+    if (this.isMetricDisabled(Metric.HOSPITAL_USAGE)) {
+      return null;
+    }
     // TODO(https://trello.com/c/bnwRazOo/): Something is broken where the API
     // top-level actuals don't match the current metric value. So we extract
     // them from the timeseries for now.
     const icuIndex = indexOfLastValue(
       metricsTimeseries.map(row => row?.icuCapacityRatio),
     );
-    if (
-      icuIndex != null &&
-      metrics.icuCapacityRatio !== null &&
-      !DISABLED_ICU.includes(this.fips)
-    ) {
+    if (icuIndex != null && metrics.icuCapacityRatio !== null) {
       // Make sure we don't somehow grab the wrong data, given we're pulling it from the metrics / actuals timeseries.
       assert(
         metrics.icuCapacityRatio === null ||
@@ -393,10 +408,6 @@ export class Projection {
     metrics: Metrics,
     metricsTimeseries: Array<MetricsTimeseriesRow | null>,
   ): VaccinationsInfo | null {
-    if (DISABLED_VACCINATIONS.includes(this.fips)) {
-      return null;
-    }
-
     const ratioInitiated = metrics.vaccinationsInitiatedRatio;
     const ratioVaccinated = metrics.vaccinationsCompletedRatio;
 
@@ -404,7 +415,8 @@ export class Projection {
       ratioInitiated === null ||
       ratioInitiated === undefined ||
       ratioVaccinated === null ||
-      ratioVaccinated === undefined
+      ratioVaccinated === undefined ||
+      this.isMetricDisabled(Metric.VACCINATIONS)
     ) {
       return null;
     }

--- a/src/common/models/Projections.ts
+++ b/src/common/models/Projections.ts
@@ -68,24 +68,7 @@ export class Projections {
   }
 
   getMetricValue(metric: Metric): number | null {
-    switch (metric) {
-      case Metric.CASE_GROWTH_RATE:
-        return this.primary.rt;
-      case Metric.HOSPITAL_USAGE:
-        return this.primary.icuCapacityInfo
-          ? this.primary.icuCapacityInfo.metricValue
-          : null;
-      case Metric.POSITIVE_TESTS:
-        return this.primary.currentTestPositiveRate;
-      case Metric.VACCINATIONS:
-        return this.primary.vaccinationsInfo
-          ? this.primary.vaccinationsInfo.ratioInitiated
-          : null;
-      case Metric.CASE_DENSITY:
-        return this.primary.currentCaseDensity;
-      default:
-        fail('Cannot get value of metric: ' + metric);
-    }
+    return this.primary.getMetricValue(metric);
   }
 
   getMetricValues(): { [metric in Metric]: number | null } {

--- a/src/common/models/ProjectionsPair.ts
+++ b/src/common/models/ProjectionsPair.ts
@@ -32,9 +32,9 @@ export class ProjectionsPair {
     rightMetric: number | null,
   ) {
     if (leftMetric === null) {
-      return rightMetric === null ? 0 : this.MISSING_METRIC_DIFF;
+      return rightMetric === null ? 0 : this.ADDED_METRIC_DIFF;
     } else if (rightMetric === null) {
-      return leftMetric === null ? 0 : this.ADDED_METRIC_DIFF;
+      return leftMetric === null ? 0 : this.MISSING_METRIC_DIFF;
     } else {
       return Math.abs(leftMetric - rightMetric);
     }

--- a/src/common/models/ProjectionsPair.ts
+++ b/src/common/models/ProjectionsPair.ts
@@ -14,11 +14,18 @@ export enum SortType {
 
 /** A pair of left/right projections (e.g. from two different snapshots) */
 export class ProjectionsPair {
-  static MISSING_METRIC_DIFF = 9999;
+  // Sentinel diff values that we use to push locations to the top of the list.
+  static DISABLED_METRIC_DIFF = 9999;
+  static MISSING_METRIC_DIFF = 9998;
+  static ADDED_METRIC_DIFF = 9997;
+  static LOWEST_SENTINEL_DIFF = ProjectionsPair.ADDED_METRIC_DIFF;
 
   constructor(public left: Projections, public right: Projections) {}
 
   metricDiff(metric: Metric): number {
+    if (this.left.primary.isMetricDisabledIgnoreOverride(metric)) {
+      return ProjectionsPair.DISABLED_METRIC_DIFF;
+    }
     const leftMetric = this.left.getMetricValue(metric);
     const rightMetric = this.right.getMetricValue(metric);
     return ProjectionsPair.metricValueDiff(leftMetric, rightMetric);
@@ -31,7 +38,7 @@ export class ProjectionsPair {
     if (leftMetric === null) {
       return rightMetric === null ? 0 : this.MISSING_METRIC_DIFF;
     } else if (rightMetric === null) {
-      return leftMetric === null ? 0 : this.MISSING_METRIC_DIFF + 1;
+      return leftMetric === null ? 0 : this.ADDED_METRIC_DIFF;
     } else {
       return Math.abs(leftMetric - rightMetric);
     }

--- a/src/common/models/ProjectionsSet.ts
+++ b/src/common/models/ProjectionsSet.ts
@@ -26,20 +26,28 @@ export class ProjectionsSet {
         projectionPairs.push(new ProjectionsPair(left, right));
       }
     }
-    return new ProjectionsSet(projectionPairs);
+    return new ProjectionsSet(projectionPairs, null);
   }
 
-  constructor(readonly pairs: ProjectionsPair[]) {}
+  static fromLoadingText(loadingText: string) {
+    return new ProjectionsSet([], loadingText);
+  }
+
+  constructor(
+    readonly pairs: ProjectionsPair[],
+    readonly loadingText: string | null,
+  ) {}
 
   sortBy(sortType: SortType, metric: Metric): ProjectionsSet {
     return new ProjectionsSet(
       this.pairs.sort((left, right) => left.compare(right, sortType, metric)),
+      this.loadingText,
     );
   }
 
   top(limit: number, sortType: SortType, metric: Metric) {
     const sortedSet = this.sortBy(sortType, metric);
-    return new ProjectionsSet(_.take(sortedSet.pairs, limit));
+    return new ProjectionsSet(_.take(sortedSet.pairs, limit), this.loadingText);
   }
 
   get isEmpty(): boolean {

--- a/src/common/utils/recommend.ts
+++ b/src/common/utils/recommend.ts
@@ -50,10 +50,10 @@ function getExposureRecommendation(
 
   const recommendationCopy = `**Notifications**: Add your phone to [${getStateName(
     region,
-  )}'s 
-  exposure notification system](https://g.co/ens) to receive alerts when you have been 
-  in close contact with someone who later tests positive for COVID. 
-  Your privacy is protected as your identity is not known and your location 
+  )}'s
+  exposure notification system](https://g.co/ens) to receive alerts when you have been
+  in close contact with someone who later tests positive for COVID.
+  Your privacy is protected as your identity is not known and your location
   is not tracked. `;
 
   const exposureRecommendation: Recommendation = {
@@ -168,7 +168,7 @@ export function getFedLevel(projection: Projection): FedLevel | null {
  * https://globalepidemics.org/wp-content/uploads/2020/07/pandemic_resilient_schools_briefing_72020.pdf
  */
 export function getHarvardLevel(projection: Projection): HarvardLevel {
-  const { currentCaseDensity } = projection;
+  const currentCaseDensity = projection.getMetricValue(Metric.CASE_DENSITY);
   const newCasesLevel = getLevel(Metric.CASE_DENSITY, currentCaseDensity);
 
   switch (newCasesLevel) {
@@ -268,7 +268,7 @@ function getWeeklyNewCasesPer100k(projection: Projection): number | null {
 }
 
 function getPositiveTestRate(projection: Projection) {
-  return projection.currentTestPositiveRate;
+  return projection.getMetricValue(Metric.POSITIVE_TESTS);
 }
 
 function isBetweenDates(point: Column, dateFrom: Date, dateTo: Date) {

--- a/src/screens/internal/CompareSnapshots/CompareSnapshots.style.js
+++ b/src/screens/internal/CompareSnapshots/CompareSnapshots.style.js
@@ -12,5 +12,3 @@ export const ModelSelectorContainer = styled.div`
   border-radius: 3px;
   padding: 1rem;
 `;
-
-export const ModelComparisonsContainer = styled.div``;

--- a/src/screens/internal/CompareSnapshots/CompareSnapshots.style.js
+++ b/src/screens/internal/CompareSnapshots/CompareSnapshots.style.js
@@ -5,10 +5,3 @@ export const Wrapper = styled.div`
   padding: 1rem 2rem;
   min-height: calc(100vh - 64px);
 `;
-
-export const ModelSelectorContainer = styled.div`
-  background-color: white;
-  border: 1px solid black;
-  border-radius: 3px;
-  padding: 1rem;
-`;

--- a/src/screens/internal/CompareSnapshots/CompareSnapshots.tsx
+++ b/src/screens/internal/CompareSnapshots/CompareSnapshots.tsx
@@ -1,13 +1,10 @@
 import React, { Fragment, useEffect, useState } from 'react';
-import Grid from '@material-ui/core/Grid';
 import { Wrapper } from './CompareSnapshots.style';
-import { SnapshotVersion, Api } from 'api';
-import moment from 'moment';
-import { snapshotUrl } from 'common/utils/snapshots';
 import { reenableDisabledMetrics } from 'common/models/Projection';
 import { ComparisonList } from './ComparisonList';
 import { CompareOptions, useProjectionsSet } from './utils';
 import { OptionsSelector } from './OptionsSelector';
+import { SnapshotVersions } from './SnapshotVersions';
 
 export function CompareSnapshots() {
   // We want to force all metrics to be reenabled so we can evaluate whether they're fixed.
@@ -36,22 +33,12 @@ function CompareSnapshotsBody({ options }: { options: CompareOptions }) {
   );
   projectionsSet = projectionsSet.sortBy(sortType, metric);
 
-  const leftVersion = useSnapshotVersion(leftSnapshot);
-  const rightVersion = useSnapshotVersion(rightSnapshot);
-
   return (
     <Fragment>
-      <Grid container spacing={8} style={{ margin: '1px' }}>
-        <Grid item xs={6}>
-          Left Snapshot: <b>{leftSnapshot}</b>
-          <VersionInfo version={leftVersion} />
-        </Grid>
-        <Grid item xs={6}>
-          Right Snapshot: <b>{rightSnapshot}</b>
-          <VersionInfo version={rightVersion} />
-        </Grid>
-      </Grid>
-
+      <SnapshotVersions
+        leftSnapshot={leftSnapshot}
+        rightSnapshot={rightSnapshot}
+      />
       <ComparisonList
         metric={metric}
         projectionsSet={projectionsSet}
@@ -59,44 +46,6 @@ function CompareSnapshotsBody({ options }: { options: CompareOptions }) {
       />
     </Fragment>
   );
-}
-
-const VersionInfo = function ({
-  version,
-}: {
-  version: SnapshotVersion | null;
-}) {
-  return (
-    version && (
-      <div style={{ fontSize: 'small' }}>
-        <b>Build finished:</b>{' '}
-        {moment.utc(version.timestamp).local().toDate().toString()}
-        <br />
-        <b>covid-data-model:</b>{' '}
-        {JSON.stringify(version['covid-data-model']).replace(',', ', ')}
-        <br />
-        <b>covid-data-public:</b>{' '}
-        {JSON.stringify(version['covid-data-public']).replace(',', ', ')}
-        <br />
-      </div>
-    )
-  );
-};
-
-export function useSnapshotVersion(
-  snapshot: number | null,
-): SnapshotVersion | null {
-  const [version, setVersion] = useState<SnapshotVersion | null>(null);
-  useEffect(() => {
-    setVersion(null);
-    if (snapshot !== null) {
-      new Api(snapshotUrl(snapshot)).fetchVersionInfo().then(version => {
-        setVersion(version);
-      });
-    }
-  }, [snapshot]);
-
-  return version;
 }
 
 export default CompareSnapshots;

--- a/src/screens/internal/CompareSnapshots/CompareSnapshots.tsx
+++ b/src/screens/internal/CompareSnapshots/CompareSnapshots.tsx
@@ -1,65 +1,37 @@
 import _ from 'lodash';
-import React, { useEffect, useState } from 'react';
-import { useLocation } from 'react-router';
-import { useHistory } from 'react-router-dom';
-import FormControl from '@material-ui/core/FormControl';
-import InputLabel from '@material-ui/core/InputLabel';
-import Select from '@material-ui/core/Select';
+import React, { Fragment, useEffect, useState } from 'react';
 import Grid from '@material-ui/core/Grid';
-import TextField from '@material-ui/core/TextField';
-import MenuItem from '@material-ui/core/MenuItem';
-import * as QueryString from 'query-string';
-import { assert, fail } from 'common/utils';
+import { fail } from 'common/utils';
 import {
   fetchAllStateProjections,
   fetchAllCountyProjections,
   fetchProjectionsRegion,
 } from 'common/utils/model';
-import { Wrapper, ModelSelectorContainer } from './CompareSnapshots.style';
-import { Metric, getMetricName, ALL_METRICS } from 'common/metric';
+import { Wrapper } from './CompareSnapshots.style';
+import { Metric } from 'common/metric';
 import { Projections } from 'common/models/Projections';
 import { ProjectionsSet } from 'common/models/ProjectionsSet';
 import { SortType, ProjectionsPair } from 'common/models/ProjectionsPair';
-import { SNAPSHOT_URL, SnapshotVersion, Api } from 'api';
+import { SnapshotVersion, Api } from 'api';
 import moment from 'moment';
 import { fetchSummaries } from 'common/location_summaries';
-import {
-  snapshotFromUrl,
-  fetchMainSnapshotNumber,
-  snapshotUrl,
-} from 'common/utils/snapshots';
+import { snapshotUrl } from 'common/utils/snapshots';
 import regions, { County, MetroArea, Region } from 'common/regions';
 import {
   DISABLED_METRICS,
   reenableDisabledMetrics,
 } from 'common/models/Projection';
 import { ComparisonList } from './ComparisonList';
-
-// TODO(michael): Compare page improvements:
-// * Virtualize the list so that it's not so awful slow. NOTE: I previously
-//   used react-lazyload for this, but it was buggy (sometimes would show stale
-//   charts after changing state properties)
-// * Add a chart that overlays the two series on top of each other.
-// * Show the diff value (the RMSD of the series or the delta between metric values).
-// * Automatically find the latest snapshot (probably by just incrementing the
-//   snapshot number until it 404s)
-
-enum Locations {
-  STATES_AND_INTERESTING_REGIONS,
-  STATES,
-  TOP_COUNTIES_BY_POPULATION,
-  TOP_COUNTIES_BY_DIFF,
-  TOP_METROS_BY_POPULATION,
-}
-
-const COUNTIES_LIMIT = 100;
-const METROS_LIMIT = 100;
-
-// For "interesting" regions, we take the 30 top diffs of the counties with
-// > 500k population and the 20 top diffs of metro areas.
-const INTERESTING_COUNTIES_POPULATION = 500000;
-const INTERESTING_COUNTIES_TOP_DIFFS = 30;
-const INTERESTING_METROS_TOP_DIFFS = 20;
+import {
+  COUNTIES_LIMIT,
+  INTERESTING_COUNTIES_POPULATION,
+  INTERESTING_COUNTIES_TOP_DIFFS,
+  INTERESTING_METROS_TOP_DIFFS,
+  Locations,
+  METROS_LIMIT,
+  Options,
+} from './utils';
+import { OptionsSelector } from './OptionsSelector';
 
 export function CompareSnapshots() {
   // We want to force all metrics to be reenabled so we can evaluate whether they're fixed.
@@ -68,55 +40,18 @@ export function CompareSnapshots() {
     return () => reenableDisabledMetrics(false);
   }, []);
 
-  const mainSnapshot = useMainSnapshot();
-  // TODO(michael): Is there a better React-y way to condition the bulk of a
-  // component on a hook result (without introducing a separate component)?
-  if (!mainSnapshot) {
-    return null;
-  } else {
-    return <CompareSnapshotsInner mainSnapshot={mainSnapshot} />;
-  }
+  const [options, setOptions] = useState<Options | null>(null);
+  return (
+    <Wrapper>
+      <OptionsSelector onNewOptions={setOptions} />
+      {options && <CompareSnapshotsBody options={options} />}
+    </Wrapper>
+  );
 }
 
-function CompareSnapshotsInner({ mainSnapshot }: { mainSnapshot: number }) {
-  const location = useLocation();
-  const history = useHistory();
-
-  const params = QueryString.parse(history.location.search);
-
-  const [leftSnapshot, setLeftSnapshot] = useState(
-    getParamValue(params, 'left', mainSnapshot),
-  );
-  const [rightSnapshot, setRightSnapshot] = useState(
-    getParamValue(params, 'right', snapshotFromUrl(SNAPSHOT_URL)),
-  );
-
-  // We have separate state for the input field text
-  // because we don't want to actually update our
-  // URLs (and reload all the charts) until the
-  // input field loses focus (onBlur).
-  const [leftSnapshotText, setLeftSnapshotText] = useState(
-    leftSnapshot.toString(),
-  );
-  const [rightSnapshotText, setRightSnapshotText] = useState(
-    rightSnapshot.toString(),
-  );
-
-  const [sortType, setSortType] = useState<SortType>(
-    getParamValue(params, 'sort', SortType.METRIC_DIFF),
-  );
-  const [metric, setMetric] = useState(
-    getParamValue(params, 'metric', Metric.CASE_DENSITY),
-  );
-  const [locations, setLocations] = useState(
-    getParamValue(
-      params,
-      'locations',
-      Locations.STATES_AND_INTERESTING_REGIONS,
-    ),
-  );
-
-  // Load models for all states or counties.
+function CompareSnapshotsBody({ options }: { options: Options }) {
+  // Load projections for all states or counties.
+  const { leftSnapshot, rightSnapshot, locations, metric, sortType } = options;
   let { projectionsSet, loadingText } = useProjectionsSet(
     leftSnapshot,
     rightSnapshot,
@@ -128,137 +63,8 @@ function CompareSnapshotsInner({ mainSnapshot }: { mainSnapshot: number }) {
   const leftVersion = useSnapshotVersion(leftSnapshot);
   const rightVersion = useSnapshotVersion(rightSnapshot);
 
-  function setQueryParams(newParams: {
-    left?: number;
-    right?: number;
-    sort?: number;
-    metric?: number;
-    locations?: number;
-  }) {
-    const params = {
-      left: leftSnapshot,
-      right: rightSnapshot,
-      sort: sortType,
-      metric: metric,
-      locations: locations,
-      ...newParams,
-    };
-
-    history.push({
-      ...location,
-      search: QueryString.stringify(params),
-    });
-  }
-
-  const changeLeftSnapshot = () => {
-    const left = parseInt(leftSnapshotText);
-    if (!Number.isNaN(left)) {
-      setLeftSnapshot(left);
-      setQueryParams({ left });
-    }
-  };
-
-  const changeRightSnapshot = () => {
-    const right = parseInt(rightSnapshotText);
-    if (!Number.isNaN(right)) {
-      setRightSnapshot(right);
-      setQueryParams({ right });
-    }
-  };
-
-  // TODO: Figure out correct type for event.
-  const changeSort = (event: any) => {
-    const sort = parseInt(event.target.value);
-    setSortType(sort);
-    setQueryParams({ sort });
-  };
-
-  // TODO: Figure out correct type for event.
-  const changeMetric = (event: any) => {
-    const metric = parseInt(event.target.value);
-    setMetric(metric);
-    setQueryParams({ metric });
-  };
-
-  // TODO: Figure out correct type for event.
-  const changeLocations = (event: any) => {
-    const locations = parseInt(event.target.value);
-    setLocations(locations);
-    setQueryParams({ locations });
-  };
-
   return (
-    <Wrapper>
-      <ModelSelectorContainer>
-        <FormControl style={{ width: '8rem', marginRight: '1rem' }}>
-          <TextField
-            id="compare-left"
-            label="Left Snapshot"
-            value={leftSnapshotText}
-            onChange={e => setLeftSnapshotText(e.target.value)}
-            onBlur={() => changeLeftSnapshot()}
-            onKeyPress={ev => {
-              if (ev.key === 'Enter') {
-                changeLeftSnapshot();
-                ev.preventDefault();
-              }
-            }}
-          />
-        </FormControl>
-        <FormControl style={{ width: '8rem' }}>
-          <TextField
-            id="compare-right"
-            label="Right Snapshot"
-            value={rightSnapshotText}
-            onChange={e => setRightSnapshotText(e.target.value)}
-            onBlur={() => changeRightSnapshot()}
-            onKeyPress={ev => {
-              if (ev.key === 'Enter') {
-                changeRightSnapshot();
-                ev.preventDefault();
-              }
-            }}
-          />
-        </FormControl>
-        <FormControl style={{ width: '14rem', marginLeft: '1rem' }}>
-          <InputLabel focused={false}>Show:</InputLabel>
-          <Select value={locations} onChange={changeLocations}>
-            <MenuItem value={Locations.STATES_AND_INTERESTING_REGIONS}>
-              States & Interesting Regions
-            </MenuItem>
-            <MenuItem value={Locations.STATES}>States</MenuItem>
-            <MenuItem value={Locations.TOP_COUNTIES_BY_POPULATION}>
-              Top {COUNTIES_LIMIT} Counties (by Population)
-            </MenuItem>
-            <MenuItem value={Locations.TOP_COUNTIES_BY_DIFF}>
-              Top {COUNTIES_LIMIT} Counties (by Diff)
-            </MenuItem>
-            <MenuItem value={Locations.TOP_METROS_BY_POPULATION}>
-              Top {METROS_LIMIT} Metros (by Population)
-            </MenuItem>
-          </Select>
-        </FormControl>
-        <FormControl style={{ width: '12rem', marginLeft: '1rem' }}>
-          <InputLabel focused={false}>Metric:</InputLabel>
-          <Select value={metric} onChange={changeMetric}>
-            {ALL_METRICS.map(metric => (
-              <MenuItem key={metric} value={metric}>
-                {getMetricName(metric)}
-              </MenuItem>
-            ))}
-          </Select>
-        </FormControl>
-        <FormControl style={{ width: '12rem', marginLeft: '1rem' }}>
-          <InputLabel focused={false}>Sort by:</InputLabel>
-          <Select value={sortType} onChange={changeSort}>
-            <MenuItem value={SortType.SERIES_DIFF}>Series Diff (RMSD)</MenuItem>
-            <MenuItem value={SortType.METRIC_DIFF}>Metric Diff</MenuItem>
-            <MenuItem value={SortType.POPULATION}>Population</MenuItem>
-            <MenuItem value={SortType.ALPHABETICAL}>Name</MenuItem>
-          </Select>
-        </FormControl>
-      </ModelSelectorContainer>
-
+    <Fragment>
       <Grid container spacing={8} style={{ margin: '1px' }}>
         <Grid item xs={6}>
           Left Snapshot: <b>{leftSnapshot}</b>
@@ -275,7 +81,7 @@ function CompareSnapshotsInner({ mainSnapshot }: { mainSnapshot: number }) {
         projectionsSet={projectionsSet}
         loadingText={loadingText}
       />
-    </Wrapper>
+    </Fragment>
   );
 }
 
@@ -300,18 +106,6 @@ const VersionInfo = function ({
     )
   );
 };
-
-function useMainSnapshot(): number | null {
-  const [snapshot, setSnapshot] = useState<number | null>(null);
-  useEffect(() => {
-    async function fetchData() {
-      setSnapshot(await fetchMainSnapshotNumber());
-    }
-    fetchData();
-  }, []);
-
-  return snapshot;
-}
 
 function useProjectionsSet(
   leftSnapshot: number,
@@ -518,22 +312,6 @@ async function fetchTopCountiesByDiff(
     regionDiffs.filter(rd => rd.region instanceof County),
     COUNTIES_LIMIT,
   ).map(rd => rd.region);
-}
-
-function getParamValue(
-  params: QueryString.ParsedQuery,
-  param: string,
-  defaultValue: number,
-): number {
-  let value = _.get(params, param, defaultValue);
-  if (typeof value === 'string') {
-    value = parseInt(value);
-  }
-  assert(
-    typeof value === 'number' && !Number.isNaN(value),
-    `Parameter ${param} has non-numeric value: ${value}`,
-  );
-  return value;
 }
 
 export function useSnapshotVersion(

--- a/src/screens/internal/CompareSnapshots/CompareSnapshots.tsx
+++ b/src/screens/internal/CompareSnapshots/CompareSnapshots.tsx
@@ -1,36 +1,12 @@
-import _ from 'lodash';
 import React, { Fragment, useEffect, useState } from 'react';
 import Grid from '@material-ui/core/Grid';
-import { fail } from 'common/utils';
-import {
-  fetchAllStateProjections,
-  fetchAllCountyProjections,
-  fetchProjectionsRegion,
-} from 'common/utils/model';
 import { Wrapper } from './CompareSnapshots.style';
-import { Metric } from 'common/metric';
-import { Projections } from 'common/models/Projections';
-import { ProjectionsSet } from 'common/models/ProjectionsSet';
-import { SortType, ProjectionsPair } from 'common/models/ProjectionsPair';
 import { SnapshotVersion, Api } from 'api';
 import moment from 'moment';
-import { fetchSummaries } from 'common/location_summaries';
 import { snapshotUrl } from 'common/utils/snapshots';
-import regions, { County, MetroArea, Region } from 'common/regions';
-import {
-  DISABLED_METRICS,
-  reenableDisabledMetrics,
-} from 'common/models/Projection';
+import { reenableDisabledMetrics } from 'common/models/Projection';
 import { ComparisonList } from './ComparisonList';
-import {
-  COUNTIES_LIMIT,
-  INTERESTING_COUNTIES_POPULATION,
-  INTERESTING_COUNTIES_TOP_DIFFS,
-  INTERESTING_METROS_TOP_DIFFS,
-  Locations,
-  METROS_LIMIT,
-  Options,
-} from './utils';
+import { CompareOptions, useProjectionsSet } from './utils';
 import { OptionsSelector } from './OptionsSelector';
 
 export function CompareSnapshots() {
@@ -40,7 +16,7 @@ export function CompareSnapshots() {
     return () => reenableDisabledMetrics(false);
   }, []);
 
-  const [options, setOptions] = useState<Options | null>(null);
+  const [options, setOptions] = useState<CompareOptions | null>(null);
   return (
     <Wrapper>
       <OptionsSelector onNewOptions={setOptions} />
@@ -49,7 +25,7 @@ export function CompareSnapshots() {
   );
 }
 
-function CompareSnapshotsBody({ options }: { options: Options }) {
+function CompareSnapshotsBody({ options }: { options: CompareOptions }) {
   // Load projections for all states or counties.
   const { leftSnapshot, rightSnapshot, locations, metric, sortType } = options;
   let { projectionsSet, loadingText } = useProjectionsSet(
@@ -106,213 +82,6 @@ const VersionInfo = function ({
     )
   );
 };
-
-function useProjectionsSet(
-  leftSnapshot: number,
-  rightSnapshot: number,
-  locations: Locations,
-  metric: Metric,
-): {
-  projectionsSet: ProjectionsSet;
-  loadingText: string;
-} {
-  const [projectionsSet, setProjectionsSet] = useState<ProjectionsSet>(
-    new ProjectionsSet([]),
-  );
-  const [loadingText, setLoadingText] = useState('Loading...');
-
-  useEffect(() => {
-    setLoadingText('Loading...');
-    setProjectionsSet(new ProjectionsSet([]));
-
-    async function fetchData() {
-      if (locations === Locations.STATES) {
-        setProjectionsSet(
-          ProjectionsSet.fromProjections(
-            await fetchAllStateProjections(snapshotUrl(leftSnapshot)),
-            await fetchAllStateProjections(snapshotUrl(rightSnapshot)),
-          ),
-        );
-      } else if (locations === Locations.TOP_COUNTIES_BY_POPULATION) {
-        const topCounties = regions.topCountiesByPopulation(COUNTIES_LIMIT);
-        setProjectionsSet(
-          ProjectionsSet.fromProjections(
-            await fetchRegionProjections(leftSnapshot, topCounties),
-            await fetchRegionProjections(rightSnapshot, topCounties),
-          ),
-        );
-      } else if (locations === Locations.TOP_METROS_BY_POPULATION) {
-        const topMetros = regions.topMetrosByPopulation(METROS_LIMIT);
-        setProjectionsSet(
-          ProjectionsSet.fromProjections(
-            await fetchRegionProjections(leftSnapshot, topMetros),
-            await fetchRegionProjections(rightSnapshot, topMetros),
-          ),
-        );
-      } else if (locations === Locations.TOP_COUNTIES_BY_DIFF) {
-        const topCounties = await fetchTopCountiesByDiff(
-          leftSnapshot,
-          rightSnapshot,
-          metric,
-        );
-        if (topCounties !== null) {
-          setProjectionsSet(
-            ProjectionsSet.fromProjections(
-              await fetchRegionProjections(leftSnapshot, topCounties),
-              await fetchRegionProjections(rightSnapshot, topCounties),
-            ),
-          );
-        } else {
-          // Couldn't load summary files. Just fetch all county projections and take the top diffs (slow).
-          setLoadingText(
-            'Loading (slow due to no pre-generated summary file in https://github.com/covid-projections/covid-projections/tree/develop/scripts/alert_emails/summaries)...',
-          );
-          setProjectionsSet(
-            ProjectionsSet.fromProjections(
-              await fetchAllCountyProjections(snapshotUrl(leftSnapshot)),
-              await fetchAllCountyProjections(snapshotUrl(rightSnapshot)),
-            ).top(COUNTIES_LIMIT, SortType.METRIC_DIFF, metric),
-          );
-        }
-      } else if (locations === Locations.STATES_AND_INTERESTING_REGIONS) {
-        const interestingRegions = await fetchInterestingRegions(
-          leftSnapshot,
-          rightSnapshot,
-          metric,
-        );
-        if (interestingRegions === null) {
-          // Couldn't load summary files. Just fetch all county projections and take the top diffs (slow).
-          setLoadingText(
-            `Can't load "States & Interesting Regions" since there's no pre-generated summary file in https://github.com/covid-projections/covid-projections/tree/develop/scripts/alert_emails/summaries...`,
-          );
-        } else {
-          // Start with the states.
-          let leftProjections = await fetchAllStateProjections(
-            snapshotUrl(leftSnapshot),
-          );
-          let rightProjections = await fetchAllStateProjections(
-            snapshotUrl(rightSnapshot),
-          );
-
-          leftProjections = leftProjections.concat(
-            await fetchRegionProjections(leftSnapshot, interestingRegions),
-          );
-          rightProjections = rightProjections.concat(
-            await fetchRegionProjections(rightSnapshot, interestingRegions),
-          );
-          setProjectionsSet(
-            ProjectionsSet.fromProjections(leftProjections, rightProjections),
-          );
-        }
-      } else {
-        fail('Unknown locations selection.');
-      }
-    }
-
-    fetchData();
-  }, [leftSnapshot, rightSnapshot, locations, metric]);
-
-  return { projectionsSet, loadingText };
-}
-
-async function fetchInterestingRegions(
-  leftSnapshot: number,
-  rightSnapshot: number,
-  metric: Metric,
-): Promise<Region[] | null> {
-  const regionDiffs = await fetchSortedRegionDiffs(
-    leftSnapshot,
-    rightSnapshot,
-    metric,
-  );
-  if (regionDiffs === null) {
-    return null;
-  }
-  const interestingCounties = _.takeRight(
-    regionDiffs
-      .filter(rd => rd.region instanceof County)
-      .filter(
-        rd =>
-          rd.region.population >= INTERESTING_COUNTIES_POPULATION ||
-          rd.diff >= ProjectionsPair.LOWEST_SENTINEL_DIFF,
-      ),
-    INTERESTING_COUNTIES_TOP_DIFFS,
-  );
-
-  const interestingMetros = _.takeRight(
-    regionDiffs.filter(rd => rd.region instanceof MetroArea),
-    INTERESTING_METROS_TOP_DIFFS,
-  );
-
-  return [...interestingCounties, ...interestingMetros].map(rd => rd.region);
-}
-
-function fetchRegionProjections(
-  snapshotNumber: number,
-  regions: Region[],
-): Promise<Projections[]> {
-  return Promise.all(
-    regions.map(region =>
-      fetchProjectionsRegion(region, snapshotUrl(snapshotNumber)).catch(err => {
-        console.error(err);
-        return null;
-      }),
-    ),
-  ).then(projections => projections.filter(p => p !== null) as Projections[]);
-}
-
-/**
- * Returns an array of { region, diff } pairs for all regions, indicating the
- * difference in the specified metric between the specified snapshots, ordered
- * by smallest diff to largest diff.
- */
-async function fetchSortedRegionDiffs(
-  leftSnapshot: number,
-  rightSnapshot: number,
-  metric: Metric,
-): Promise<Array<{ region: Region; diff: number }> | null> {
-  const leftSummaries = await fetchSummaries(leftSnapshot).catch(e => null);
-  const rightSummaries = await fetchSummaries(rightSnapshot).catch(e => null);
-  if (leftSummaries === null || rightSummaries === null) {
-    return null;
-  }
-
-  return regions
-    .all()
-    .map(region => {
-      const fips = region.fipsCode;
-      const leftValue = leftSummaries[fips]?.metrics?.[metric]?.value ?? null;
-      const rightValue = rightSummaries[fips]?.metrics?.[metric]?.value ?? null;
-      const isDisabled = DISABLED_METRICS[metric].includes(fips);
-      const diff = isDisabled
-        ? ProjectionsPair.DISABLED_METRIC_DIFF
-        : ProjectionsPair.metricValueDiff(leftValue, rightValue);
-      return {
-        region,
-        diff,
-      };
-    })
-    .sort((a, b) => a.diff - b.diff);
-}
-
-async function fetchTopCountiesByDiff(
-  leftSnapshot: number,
-  rightSnapshot: number,
-  metric: Metric,
-): Promise<Region[] | null> {
-  const regionDiffs = await fetchSortedRegionDiffs(
-    leftSnapshot,
-    rightSnapshot,
-    metric,
-  );
-  if (regionDiffs === null) {
-    return null;
-  }
-  return _.takeRight(
-    regionDiffs.filter(rd => rd.region instanceof County),
-    COUNTIES_LIMIT,
-  ).map(rd => rd.region);
-}
 
 export function useSnapshotVersion(
   snapshot: number | null,

--- a/src/screens/internal/CompareSnapshots/CompareSnapshots.tsx
+++ b/src/screens/internal/CompareSnapshots/CompareSnapshots.tsx
@@ -22,10 +22,14 @@ export function CompareSnapshots() {
   );
 }
 
-function CompareSnapshotsBody({ options }: { options: CompareOptions }) {
+const CompareSnapshotsBody = React.memo(function CompareSnapshotsBody({
+  options,
+}: {
+  options: CompareOptions;
+}) {
   // Load projections for all states or counties.
   const { leftSnapshot, rightSnapshot, locations, metric, sortType } = options;
-  let { projectionsSet, loadingText } = useProjectionsSet(
+  let projectionsSet = useProjectionsSet(
     leftSnapshot,
     rightSnapshot,
     locations,
@@ -39,13 +43,9 @@ function CompareSnapshotsBody({ options }: { options: CompareOptions }) {
         leftSnapshot={leftSnapshot}
         rightSnapshot={rightSnapshot}
       />
-      <ComparisonList
-        metric={metric}
-        projectionsSet={projectionsSet}
-        loadingText={loadingText}
-      />
+      <ComparisonList metric={metric} projectionsSet={projectionsSet} />
     </Fragment>
   );
-}
+});
 
 export default CompareSnapshots;

--- a/src/screens/internal/CompareSnapshots/ComparisonList.tsx
+++ b/src/screens/internal/CompareSnapshots/ComparisonList.tsx
@@ -11,14 +11,14 @@ import { Projections } from 'common/models/Projections';
 export const ComparisonList = function ({
   metric,
   projectionsSet,
-  loadingText,
 }: {
   metric: Metric;
   projectionsSet: ProjectionsSet;
-  loadingText: string;
 }) {
-  if (projectionsSet.isEmpty) {
-    return <h1>{loadingText}</h1>;
+  if (projectionsSet.loadingText) {
+    return <h1>{projectionsSet.loadingText}</h1>;
+  } else if (projectionsSet.isEmpty) {
+    return <h1>No locations match your criteria.</h1>;
   }
 
   return (
@@ -49,7 +49,7 @@ function ProjectionsCompare({
         <h2>
           {pair.locationName}
           {pair.left.primary.isMetricDisabledIgnoreOverride(metric) &&
-            ' [DISABLED]'}
+            ' [BLOCKED]'}
           :{' '}
           <small>
             <ProjectionsGradeChange pair={pair} /> | population{' '}

--- a/src/screens/internal/CompareSnapshots/ComparisonList.tsx
+++ b/src/screens/internal/CompareSnapshots/ComparisonList.tsx
@@ -1,0 +1,102 @@
+import React, { Fragment } from 'react';
+import { Metric } from 'common/metric';
+import { ProjectionsSet } from 'common/models/ProjectionsSet';
+import { ProjectionsPair } from 'common/models/ProjectionsPair';
+import { formatInteger } from 'common/utils';
+import { Grid } from '@material-ui/core';
+import { Level } from 'common/level';
+import { MetricChart } from 'components/Charts';
+import { Projections } from 'common/models/Projections';
+
+export const ComparisonList = function ({
+  metric,
+  projectionsSet,
+  loadingText,
+}: {
+  metric: Metric;
+  projectionsSet: ProjectionsSet;
+  loadingText: string;
+}) {
+  if (projectionsSet.isEmpty) {
+    return <h1>{loadingText}</h1>;
+  }
+
+  return (
+    <Fragment>
+      {projectionsSet.map(pair => (
+        <ProjectionsCompare
+          key={pair.locationName}
+          metric={metric}
+          pair={pair}
+        />
+      ))}
+    </Fragment>
+  );
+};
+
+function ProjectionsCompare({
+  metric,
+  pair,
+}: {
+  metric: Metric;
+  pair: ProjectionsPair;
+}) {
+  const localUrl = pair.locationURL.replace(/^.*covidactnow\.org/, '');
+  return (
+    <>
+      <hr />
+      <div style={{ marginLeft: '40px' }}>
+        <h2>
+          {pair.locationName}
+          {pair.left.primary.isMetricDisabledIgnoreOverride(metric) &&
+            ' [DISABLED]'}
+          :{' '}
+          <small>
+            <ProjectionsGradeChange pair={pair} /> | population{' '}
+            {formatInteger(pair.population)} | fips {pair.fips} |{' '}
+            <a href={pair.locationURL}>prod</a> <a href={localUrl}>local</a>
+          </small>
+        </h2>
+        <br />
+        <Grid container spacing={8}>
+          <Grid item xs={6}>
+            <ProjectionsChart metric={metric} projections={pair.left} />
+          </Grid>
+          <Grid item xs={6}>
+            <ProjectionsChart metric={metric} projections={pair.right} />
+          </Grid>
+        </Grid>
+      </div>
+    </>
+  );
+}
+
+function ProjectionsGradeChange({ pair }: { pair: ProjectionsPair }) {
+  if (pair.left.getAlarmLevel() !== pair.right.getAlarmLevel()) {
+    return (
+      <Fragment>
+        <ProjectionsGrade projections={pair.left} />
+        ➔
+        <ProjectionsGrade projections={pair.right} />
+      </Fragment>
+    );
+  } else {
+    return <ProjectionsGrade projections={pair.left} />;
+  }
+}
+
+function ProjectionsGrade({ projections }: { projections: Projections }) {
+  const color = projections.getAlarmLevelColor();
+  const level = Level[projections.getAlarmLevel()];
+  return <span style={{ color }}>{level}</span>;
+}
+
+const ProjectionsChart = React.memo(function ProjectionsChart({
+  metric,
+  projections,
+}: {
+  metric: Metric;
+  projections: Projections;
+}) {
+  return <MetricChart metric={metric} projections={projections} />;
+});

--- a/src/screens/internal/CompareSnapshots/OptionsSelector.style.ts
+++ b/src/screens/internal/CompareSnapshots/OptionsSelector.style.ts
@@ -1,0 +1,8 @@
+import styled from 'styled-components';
+
+export const OptionsSelectorWrapper = styled.div`
+  background-color: white;
+  border: 1px solid black;
+  border-radius: 3px;
+  padding: 1rem;
+`;

--- a/src/screens/internal/CompareSnapshots/OptionsSelector.tsx
+++ b/src/screens/internal/CompareSnapshots/OptionsSelector.tsx
@@ -1,0 +1,251 @@
+import { get as _get } from 'lodash';
+import React, { useEffect, useState } from 'react';
+import { useLocation } from 'react-router';
+import { useHistory } from 'react-router-dom';
+import * as QueryString from 'query-string';
+import { assert } from 'common/utils';
+import {
+  fetchMainSnapshotNumber,
+  snapshotFromUrl,
+  SNAPSHOT_URL,
+} from 'common/utils/snapshots';
+import { SortType } from 'common/models/ProjectionsPair';
+import { ALL_METRICS, getMetricName, Metric } from 'common/metric';
+import { OptionsSelectorWrapper } from './OptionsSelector.style';
+import {
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  TextField,
+} from '@material-ui/core';
+import { COUNTIES_LIMIT, Locations, METROS_LIMIT, Options } from './utils';
+
+interface OptionsSelectorProps {
+  onNewOptions: (options: Options) => void;
+}
+
+export function OptionsSelector(props: OptionsSelectorProps) {
+  const mainSnapshot = useMainSnapshot();
+  // TODO(michael): Is there a better React-y way to condition the bulk of a
+  // component on a hook result (without introducing a separate component)?
+  if (!mainSnapshot) {
+    return null;
+  } else {
+    return <OptionsSelectorInner mainSnapshot={mainSnapshot} {...props} />;
+  }
+}
+
+interface OptionsSelectorInnerProps extends OptionsSelectorProps {
+  mainSnapshot: number;
+}
+
+function OptionsSelectorInner({
+  mainSnapshot,
+  onNewOptions,
+}: OptionsSelectorInnerProps) {
+  const location = useLocation();
+  const history = useHistory();
+
+  const params = QueryString.parse(history.location.search);
+
+  const [leftSnapshot, setLeftSnapshot] = useState(
+    getParamValue(params, 'left', mainSnapshot),
+  );
+  const [rightSnapshot, setRightSnapshot] = useState(
+    getParamValue(params, 'right', snapshotFromUrl(SNAPSHOT_URL)),
+  );
+
+  // We have separate state for the input field text because we don't want to
+  // actually update our URLs (and reload all the charts) until the input field
+  // loses focus (onBlur).
+  const [leftSnapshotText, setLeftSnapshotText] = useState(
+    leftSnapshot.toString(),
+  );
+  const [rightSnapshotText, setRightSnapshotText] = useState(
+    rightSnapshot.toString(),
+  );
+
+  const [sortType, setSortType] = useState<SortType>(
+    getParamValue(params, 'sort', SortType.METRIC_DIFF),
+  );
+  const [metric, setMetric] = useState(
+    getParamValue(params, 'metric', Metric.CASE_DENSITY),
+  );
+  const [locations, setLocations] = useState(
+    getParamValue(
+      params,
+      'locations',
+      Locations.STATES_AND_INTERESTING_REGIONS,
+    ),
+  );
+
+  useEffect(() => {
+    onNewOptions({
+      leftSnapshot,
+      rightSnapshot,
+      sortType,
+      metric,
+      locations,
+    });
+  }, [leftSnapshot, rightSnapshot, sortType, metric, locations, onNewOptions]);
+
+  function setQueryParams(newParams: {
+    left?: number;
+    right?: number;
+    sort?: number;
+    metric?: number;
+    locations?: number;
+  }) {
+    const params = {
+      left: leftSnapshot,
+      right: rightSnapshot,
+      sort: sortType,
+      metric: metric,
+      locations: locations,
+      ...newParams,
+    };
+
+    history.push({
+      ...location,
+      search: QueryString.stringify(params),
+    });
+  }
+
+  const changeLeftSnapshot = () => {
+    const left = parseInt(leftSnapshotText);
+    if (!Number.isNaN(left)) {
+      setLeftSnapshot(left);
+      setQueryParams({ left });
+    }
+  };
+
+  const changeRightSnapshot = () => {
+    const right = parseInt(rightSnapshotText);
+    if (!Number.isNaN(right)) {
+      setRightSnapshot(right);
+      setQueryParams({ right });
+    }
+  };
+
+  // TODO: Figure out correct type for event.
+  const changeSort = (event: any) => {
+    const sort = parseInt(event.target.value);
+    setSortType(sort);
+    setQueryParams({ sort });
+  };
+
+  // TODO: Figure out correct type for event.
+  const changeMetric = (event: any) => {
+    const metric = parseInt(event.target.value);
+    setMetric(metric);
+    setQueryParams({ metric });
+  };
+
+  // TODO: Figure out correct type for event.
+  const changeLocations = (event: any) => {
+    const locations = parseInt(event.target.value);
+    setLocations(locations);
+    setQueryParams({ locations });
+  };
+
+  return (
+    <OptionsSelectorWrapper>
+      <FormControl style={{ width: '8rem', marginRight: '1rem' }}>
+        <TextField
+          id="compare-left"
+          label="Left Snapshot"
+          value={leftSnapshotText}
+          onChange={e => setLeftSnapshotText(e.target.value)}
+          onBlur={() => changeLeftSnapshot()}
+          onKeyPress={ev => {
+            if (ev.key === 'Enter') {
+              changeLeftSnapshot();
+              ev.preventDefault();
+            }
+          }}
+        />
+      </FormControl>
+      <FormControl style={{ width: '8rem' }}>
+        <TextField
+          id="compare-right"
+          label="Right Snapshot"
+          value={rightSnapshotText}
+          onChange={e => setRightSnapshotText(e.target.value)}
+          onBlur={() => changeRightSnapshot()}
+          onKeyPress={ev => {
+            if (ev.key === 'Enter') {
+              changeRightSnapshot();
+              ev.preventDefault();
+            }
+          }}
+        />
+      </FormControl>
+      <FormControl style={{ width: '14rem', marginLeft: '1rem' }}>
+        <InputLabel focused={false}>Show:</InputLabel>
+        <Select value={locations} onChange={changeLocations}>
+          <MenuItem value={Locations.STATES_AND_INTERESTING_REGIONS}>
+            States & Interesting Regions
+          </MenuItem>
+          <MenuItem value={Locations.STATES}>States</MenuItem>
+          <MenuItem value={Locations.TOP_COUNTIES_BY_POPULATION}>
+            Top {COUNTIES_LIMIT} Counties (by Population)
+          </MenuItem>
+          <MenuItem value={Locations.TOP_COUNTIES_BY_DIFF}>
+            Top {COUNTIES_LIMIT} Counties (by Diff)
+          </MenuItem>
+          <MenuItem value={Locations.TOP_METROS_BY_POPULATION}>
+            Top {METROS_LIMIT} Metros (by Population)
+          </MenuItem>
+        </Select>
+      </FormControl>
+      <FormControl style={{ width: '12rem', marginLeft: '1rem' }}>
+        <InputLabel focused={false}>Metric:</InputLabel>
+        <Select value={metric} onChange={changeMetric}>
+          {ALL_METRICS.map(metric => (
+            <MenuItem key={metric} value={metric}>
+              {getMetricName(metric)}
+            </MenuItem>
+          ))}
+        </Select>
+      </FormControl>
+      <FormControl style={{ width: '12rem', marginLeft: '1rem' }}>
+        <InputLabel focused={false}>Sort by:</InputLabel>
+        <Select value={sortType} onChange={changeSort}>
+          <MenuItem value={SortType.SERIES_DIFF}>Series Diff (RMSD)</MenuItem>
+          <MenuItem value={SortType.METRIC_DIFF}>Metric Diff</MenuItem>
+          <MenuItem value={SortType.POPULATION}>Population</MenuItem>
+          <MenuItem value={SortType.ALPHABETICAL}>Name</MenuItem>
+        </Select>
+      </FormControl>
+    </OptionsSelectorWrapper>
+  );
+}
+
+function getParamValue(
+  params: QueryString.ParsedQuery,
+  param: string,
+  defaultValue: number,
+): number {
+  let value = _get(params, param, defaultValue);
+  if (typeof value === 'string') {
+    value = parseInt(value);
+  }
+  assert(
+    typeof value === 'number' && !Number.isNaN(value),
+    `Parameter ${param} has non-numeric value: ${value}`,
+  );
+  return value;
+}
+
+function useMainSnapshot(): number | null {
+  const [snapshot, setSnapshot] = useState<number | null>(null);
+  useEffect(() => {
+    async function fetchData() {
+      setSnapshot(await fetchMainSnapshotNumber());
+    }
+    fetchData();
+  }, []);
+
+  return snapshot;
+}

--- a/src/screens/internal/CompareSnapshots/OptionsSelector.tsx
+++ b/src/screens/internal/CompareSnapshots/OptionsSelector.tsx
@@ -202,6 +202,9 @@ function OptionsSelectorInner({
           <MenuItem value={CompareLocations.TOP_METROS_BY_POPULATION}>
             Top {METROS_LIMIT} Metros (by Population)
           </MenuItem>
+          <MenuItem value={CompareLocations.DISABLED}>
+            Blocked Locations
+          </MenuItem>
         </Select>
       </FormControl>
       <FormControl style={{ width: '12rem', marginLeft: '1rem' }}>

--- a/src/screens/internal/CompareSnapshots/OptionsSelector.tsx
+++ b/src/screens/internal/CompareSnapshots/OptionsSelector.tsx
@@ -19,10 +19,15 @@ import {
   Select,
   TextField,
 } from '@material-ui/core';
-import { COUNTIES_LIMIT, Locations, METROS_LIMIT, Options } from './utils';
+import {
+  COUNTIES_LIMIT,
+  CompareLocations,
+  METROS_LIMIT,
+  CompareOptions,
+} from './utils';
 
 interface OptionsSelectorProps {
-  onNewOptions: (options: Options) => void;
+  onNewOptions: (options: CompareOptions) => void;
 }
 
 export function OptionsSelector(props: OptionsSelectorProps) {
@@ -76,7 +81,7 @@ function OptionsSelectorInner({
     getParamValue(
       params,
       'locations',
-      Locations.STATES_AND_INTERESTING_REGIONS,
+      CompareLocations.STATES_AND_INTERESTING_REGIONS,
     ),
   );
 
@@ -184,17 +189,17 @@ function OptionsSelectorInner({
       <FormControl style={{ width: '14rem', marginLeft: '1rem' }}>
         <InputLabel focused={false}>Show:</InputLabel>
         <Select value={locations} onChange={changeLocations}>
-          <MenuItem value={Locations.STATES_AND_INTERESTING_REGIONS}>
+          <MenuItem value={CompareLocations.STATES_AND_INTERESTING_REGIONS}>
             States & Interesting Regions
           </MenuItem>
-          <MenuItem value={Locations.STATES}>States</MenuItem>
-          <MenuItem value={Locations.TOP_COUNTIES_BY_POPULATION}>
+          <MenuItem value={CompareLocations.STATES}>States</MenuItem>
+          <MenuItem value={CompareLocations.TOP_COUNTIES_BY_POPULATION}>
             Top {COUNTIES_LIMIT} Counties (by Population)
           </MenuItem>
-          <MenuItem value={Locations.TOP_COUNTIES_BY_DIFF}>
+          <MenuItem value={CompareLocations.TOP_COUNTIES_BY_DIFF}>
             Top {COUNTIES_LIMIT} Counties (by Diff)
           </MenuItem>
-          <MenuItem value={Locations.TOP_METROS_BY_POPULATION}>
+          <MenuItem value={CompareLocations.TOP_METROS_BY_POPULATION}>
             Top {METROS_LIMIT} Metros (by Population)
           </MenuItem>
         </Select>

--- a/src/screens/internal/CompareSnapshots/SnapshotVersions.tsx
+++ b/src/screens/internal/CompareSnapshots/SnapshotVersions.tsx
@@ -1,0 +1,63 @@
+import { Grid } from '@material-ui/core';
+import { Api, SnapshotVersion } from 'api';
+import { snapshotUrl } from 'common/utils/snapshots';
+import moment from 'moment';
+import React, { useEffect, useState } from 'react';
+
+export function SnapshotVersions({
+  leftSnapshot,
+  rightSnapshot,
+}: {
+  leftSnapshot: number;
+  rightSnapshot: number;
+}) {
+  const leftVersion = useSnapshotVersion(leftSnapshot);
+  const rightVersion = useSnapshotVersion(rightSnapshot);
+
+  return (
+    <Grid container spacing={8} style={{ margin: '1px' }}>
+      <Grid item xs={6}>
+        Left Snapshot: <b>{leftSnapshot}</b>
+        <VersionInfo version={leftVersion} />
+      </Grid>
+      <Grid item xs={6}>
+        Right Snapshot: <b>{rightSnapshot}</b>
+        <VersionInfo version={rightVersion} />
+      </Grid>
+    </Grid>
+  );
+}
+
+function VersionInfo({ version }: { version: SnapshotVersion | null }) {
+  return (
+    version && (
+      <div style={{ fontSize: 'small' }}>
+        <b>Build finished:</b>{' '}
+        {moment.utc(version.timestamp).local().toDate().toString()}
+        <br />
+        <b>covid-data-model:</b>{' '}
+        {JSON.stringify(version['covid-data-model']).replace(',', ', ')}
+        <br />
+        <b>covid-data-public:</b>{' '}
+        {JSON.stringify(version['covid-data-public']).replace(',', ', ')}
+        <br />
+      </div>
+    )
+  );
+}
+
+export function useSnapshotVersion(
+  snapshot: number | null,
+): SnapshotVersion | null {
+  const [version, setVersion] = useState<SnapshotVersion | null>(null);
+  useEffect(() => {
+    setVersion(null);
+    if (snapshot !== null) {
+      new Api(snapshotUrl(snapshot)).fetchVersionInfo().then(version => {
+        setVersion(version);
+      });
+    }
+  }, [snapshot]);
+
+  return version;
+}

--- a/src/screens/internal/CompareSnapshots/utils.ts
+++ b/src/screens/internal/CompareSnapshots/utils.ts
@@ -1,5 +1,18 @@
+import { takeRight as _takeRight } from 'lodash';
+import { useEffect, useState } from 'react';
 import { Metric } from 'common/metric';
-import { SortType } from 'common/models/ProjectionsPair';
+import { ProjectionsPair, SortType } from 'common/models/ProjectionsPair';
+import { ProjectionsSet } from 'common/models/ProjectionsSet';
+import {
+  fetchAllCountyProjections,
+  fetchAllStateProjections,
+  fetchProjectionsRegion,
+} from 'common/utils/model';
+import { snapshotUrl } from 'common/utils/snapshots';
+import regions, { County, MetroArea, Region } from 'common/regions';
+import { Projections } from 'common/models/Projections';
+import { fetchSummaries } from 'common/location_summaries';
+import { DISABLED_METRICS } from 'common/models/Projection';
 
 export const COUNTIES_LIMIT = 100;
 export const METROS_LIMIT = 100;
@@ -10,7 +23,7 @@ export const INTERESTING_COUNTIES_POPULATION = 500000;
 export const INTERESTING_COUNTIES_TOP_DIFFS = 30;
 export const INTERESTING_METROS_TOP_DIFFS = 20;
 
-export enum Locations {
+export enum CompareLocations {
   STATES_AND_INTERESTING_REGIONS,
   STATES,
   TOP_COUNTIES_BY_POPULATION,
@@ -18,10 +31,223 @@ export enum Locations {
   TOP_METROS_BY_POPULATION,
 }
 
-export interface Options {
+export interface CompareOptions {
   leftSnapshot: number;
   rightSnapshot: number;
   sortType: SortType;
   metric: Metric;
-  locations: Locations;
+  locations: CompareLocations;
+}
+
+/**
+ * React hook to fetch the appropriate ProjectionsSet for the given snapshots,
+ * locations, and metric.
+ */
+export function useProjectionsSet(
+  leftSnapshot: number,
+  rightSnapshot: number,
+  locations: CompareLocations,
+  metric: Metric,
+): {
+  projectionsSet: ProjectionsSet;
+  loadingText: string;
+} {
+  const [projectionsSet, setProjectionsSet] = useState<ProjectionsSet>(
+    new ProjectionsSet([]),
+  );
+  const [loadingText, setLoadingText] = useState('Loading...');
+
+  useEffect(() => {
+    setLoadingText('Loading...');
+    setProjectionsSet(new ProjectionsSet([]));
+
+    async function fetchData() {
+      if (locations === CompareLocations.STATES) {
+        setProjectionsSet(
+          ProjectionsSet.fromProjections(
+            await fetchAllStateProjections(snapshotUrl(leftSnapshot)),
+            await fetchAllStateProjections(snapshotUrl(rightSnapshot)),
+          ),
+        );
+      } else if (locations === CompareLocations.TOP_COUNTIES_BY_POPULATION) {
+        const topCounties = regions.topCountiesByPopulation(COUNTIES_LIMIT);
+        setProjectionsSet(
+          ProjectionsSet.fromProjections(
+            await fetchRegionProjections(leftSnapshot, topCounties),
+            await fetchRegionProjections(rightSnapshot, topCounties),
+          ),
+        );
+      } else if (locations === CompareLocations.TOP_METROS_BY_POPULATION) {
+        const topMetros = regions.topMetrosByPopulation(METROS_LIMIT);
+        setProjectionsSet(
+          ProjectionsSet.fromProjections(
+            await fetchRegionProjections(leftSnapshot, topMetros),
+            await fetchRegionProjections(rightSnapshot, topMetros),
+          ),
+        );
+      } else if (locations === CompareLocations.TOP_COUNTIES_BY_DIFF) {
+        const topCounties = await fetchTopCountiesByDiff(
+          leftSnapshot,
+          rightSnapshot,
+          metric,
+        );
+        if (topCounties !== null) {
+          setProjectionsSet(
+            ProjectionsSet.fromProjections(
+              await fetchRegionProjections(leftSnapshot, topCounties),
+              await fetchRegionProjections(rightSnapshot, topCounties),
+            ),
+          );
+        } else {
+          // Couldn't load summary files. Just fetch all county projections and take the top diffs (slow).
+          setLoadingText(
+            'Loading (slow due to no pre-generated summary file in https://github.com/covid-projections/covid-projections/tree/develop/scripts/alert_emails/summaries)...',
+          );
+          setProjectionsSet(
+            ProjectionsSet.fromProjections(
+              await fetchAllCountyProjections(snapshotUrl(leftSnapshot)),
+              await fetchAllCountyProjections(snapshotUrl(rightSnapshot)),
+            ).top(COUNTIES_LIMIT, SortType.METRIC_DIFF, metric),
+          );
+        }
+      } else if (
+        locations === CompareLocations.STATES_AND_INTERESTING_REGIONS
+      ) {
+        const interestingRegions = await fetchInterestingRegions(
+          leftSnapshot,
+          rightSnapshot,
+          metric,
+        );
+        if (interestingRegions === null) {
+          // Couldn't load summary files. Just fetch all county projections and take the top diffs (slow).
+          setLoadingText(
+            `Can't load "States & Interesting Regions" since there's no pre-generated summary file in https://github.com/covid-projections/covid-projections/tree/develop/scripts/alert_emails/summaries...`,
+          );
+        } else {
+          // Start with the states.
+          let leftProjections = await fetchAllStateProjections(
+            snapshotUrl(leftSnapshot),
+          );
+          let rightProjections = await fetchAllStateProjections(
+            snapshotUrl(rightSnapshot),
+          );
+
+          leftProjections = leftProjections.concat(
+            await fetchRegionProjections(leftSnapshot, interestingRegions),
+          );
+          rightProjections = rightProjections.concat(
+            await fetchRegionProjections(rightSnapshot, interestingRegions),
+          );
+          setProjectionsSet(
+            ProjectionsSet.fromProjections(leftProjections, rightProjections),
+          );
+        }
+      } else {
+        fail('Unknown locations selection.');
+      }
+    }
+
+    fetchData();
+  }, [leftSnapshot, rightSnapshot, locations, metric]);
+
+  return { projectionsSet, loadingText };
+}
+
+async function fetchInterestingRegions(
+  leftSnapshot: number,
+  rightSnapshot: number,
+  metric: Metric,
+): Promise<Region[] | null> {
+  const regionDiffs = await fetchSortedRegionDiffs(
+    leftSnapshot,
+    rightSnapshot,
+    metric,
+  );
+  if (regionDiffs === null) {
+    return null;
+  }
+  const interestingCounties = _takeRight(
+    regionDiffs
+      .filter(rd => rd.region instanceof County)
+      .filter(
+        rd =>
+          rd.region.population >= INTERESTING_COUNTIES_POPULATION ||
+          rd.diff >= ProjectionsPair.LOWEST_SENTINEL_DIFF,
+      ),
+    INTERESTING_COUNTIES_TOP_DIFFS,
+  );
+
+  const interestingMetros = _takeRight(
+    regionDiffs.filter(rd => rd.region instanceof MetroArea),
+    INTERESTING_METROS_TOP_DIFFS,
+  );
+
+  return [...interestingCounties, ...interestingMetros].map(rd => rd.region);
+}
+
+function fetchRegionProjections(
+  snapshotNumber: number,
+  regions: Region[],
+): Promise<Projections[]> {
+  return Promise.all(
+    regions.map(region =>
+      fetchProjectionsRegion(region, snapshotUrl(snapshotNumber)).catch(err => {
+        console.error(err);
+        return null;
+      }),
+    ),
+  ).then(projections => projections.filter(p => p !== null) as Projections[]);
+}
+
+/**
+ * Returns an array of { region, diff } pairs for all regions, indicating the
+ * difference in the specified metric between the specified snapshots, ordered
+ * by smallest diff to largest diff.
+ */
+async function fetchSortedRegionDiffs(
+  leftSnapshot: number,
+  rightSnapshot: number,
+  metric: Metric,
+): Promise<Array<{ region: Region; diff: number }> | null> {
+  const leftSummaries = await fetchSummaries(leftSnapshot).catch(e => null);
+  const rightSummaries = await fetchSummaries(rightSnapshot).catch(e => null);
+  if (leftSummaries === null || rightSummaries === null) {
+    return null;
+  }
+
+  return regions
+    .all()
+    .map(region => {
+      const fips = region.fipsCode;
+      const leftValue = leftSummaries[fips]?.metrics?.[metric]?.value ?? null;
+      const rightValue = rightSummaries[fips]?.metrics?.[metric]?.value ?? null;
+      const isDisabled = DISABLED_METRICS[metric].includes(fips);
+      const diff = isDisabled
+        ? ProjectionsPair.DISABLED_METRIC_DIFF
+        : ProjectionsPair.metricValueDiff(leftValue, rightValue);
+      return {
+        region,
+        diff,
+      };
+    })
+    .sort((a, b) => a.diff - b.diff);
+}
+
+async function fetchTopCountiesByDiff(
+  leftSnapshot: number,
+  rightSnapshot: number,
+  metric: Metric,
+): Promise<Region[] | null> {
+  const regionDiffs = await fetchSortedRegionDiffs(
+    leftSnapshot,
+    rightSnapshot,
+    metric,
+  );
+  if (regionDiffs === null) {
+    return null;
+  }
+  return _takeRight(
+    regionDiffs.filter(rd => rd.region instanceof County),
+    COUNTIES_LIMIT,
+  ).map(rd => rd.region);
 }

--- a/src/screens/internal/CompareSnapshots/utils.ts
+++ b/src/screens/internal/CompareSnapshots/utils.ts
@@ -1,0 +1,27 @@
+import { Metric } from 'common/metric';
+import { SortType } from 'common/models/ProjectionsPair';
+
+export const COUNTIES_LIMIT = 100;
+export const METROS_LIMIT = 100;
+
+// For "interesting" regions, we take the 30 top diffs of the counties with
+// > 500k population and the 20 top diffs of metro areas.
+export const INTERESTING_COUNTIES_POPULATION = 500000;
+export const INTERESTING_COUNTIES_TOP_DIFFS = 30;
+export const INTERESTING_METROS_TOP_DIFFS = 20;
+
+export enum Locations {
+  STATES_AND_INTERESTING_REGIONS,
+  STATES,
+  TOP_COUNTIES_BY_POPULATION,
+  TOP_COUNTIES_BY_DIFF,
+  TOP_METROS_BY_POPULATION,
+}
+
+export interface Options {
+  leftSnapshot: number;
+  rightSnapshot: number;
+  sortType: SortType;
+  metric: Metric;
+  locations: Locations;
+}


### PR DESCRIPTION
* Cleaned up / centralized how we track disabled metrics.
* Added a "Blocked Locations" item to the "Show" list.
* Refactored the code substantially to make it easier to improve in the future.
* Tweaked sorting so that when diffs are equal (e.g. gained/lost metrics), we order higher-population locations before lower ones.