### PR TITLE
Info tooltip content in CMS

### DIFF
--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -790,17 +790,17 @@ collections:
                   - label: Updated at
                     name: updatedAt
                     widget: datetime
-  - label: Info Popups
-    name: infoPopups
-    description: Content for information popups on the location page (short metric explainers, location page header info)
+  - label: Info Tooltips
+    name: infoTooltips
+    description: Content for information tooltips (short metric explainers, location page header info)
     format: json
     files:
-      - name: Info Popups
-        label: Info Popups
-        file: src/cms-content/info-popups.json
+      - name: Info Tooltips
+        label: Info Tooltips
+        file: src/cms-content/info-tooltips.json
         fields:
-          - label: Popup
-            name: popup
+          - label: Tooltip
+            name: tooltip
             widget: list
             fields:
               - label: Title
@@ -809,6 +809,9 @@ collections:
               - label: Id
                 name: id
                 widget: string
-              - label: Content
-                name: content
+              - label: Body
+                name: body
+                widget: markdown
+              - label: CTA
+                name: cta
                 widget: markdown

--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -4,7 +4,7 @@
 backend:
   name: github
   repo: covid-projections/covid-projections
-  branch: cms-content-entry
+  branch: casulin/info-popup-content-cms
   base_url: https://api.netlify.com
 
 media_folder: 'public/images_cms'
@@ -790,4 +790,25 @@ collections:
                   - label: Updated at
                     name: updatedAt
                     widget: datetime
-
+  - label: Info Popups
+    name: infoPopups
+    description: Content for information popups on the location page (short metric explainers, location page header info)
+    format: json
+    files:
+      - name: Info Popups
+        label: Info Popups
+        file: src/cms-content/info-popups.json
+        fields:
+          - label: Popup
+            name: popup
+            widget: list
+            fields:
+              - label: Title
+                name: title
+                widget: string
+              - label: Id
+                name: id
+                widget: string
+              - label: Content
+                name: content
+                widget: markdown

--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -4,7 +4,7 @@
 backend:
   name: github
   repo: covid-projections/covid-projections
-  branch: casulin/info-popup-content-cms
+  branch: cms-content-entry
   base_url: https://api.netlify.com
 
 media_folder: 'public/images_cms'

--- a/src/cms-content/info-tooltips.json
+++ b/src/cms-content/info-tooltips.json
@@ -1,0 +1,40 @@
+{
+  "tooltip": [
+    {
+      "title": "Location page header",
+      "id": "location-page-header",
+      "body": "A state or county’s overall risk level takes into account three metrics: daily new cases per 100K (incidence), infection rate (Rt), and test positivity. Each metric is graded green, yellow, orange, or red. A region’s overall risk level reflects the highest risk level across all three metrics. For instance, if daily new cases and test positivity are both yellow, but infection growth is orange, then the overall risk level is orange.",
+      "cta": "[Keep reading to learn more about how we determine risk levels and key metrics.](/covid-risk-levels-metrics)"
+    },
+    {
+      "title": "Daily new cases",
+      "id": "daily-new-cases",
+      "body": "When calculating daily new cases, we look at the average cases per 100,000 people in a location, which is calculated as a seven-day average of daily new cases, divided by the population, divided by 100,000. When estimating the number of people who will become infected in the course of a year, we rely on the CDC’s estimate that confirmed cases represent as few as 10% of overall infections.",
+      "cta": "[Keep reading to learn more about our daily new cases methodology and thresholds.](/covid-risk-levels-metrics#daily-new-cases)"
+    },
+    {
+      "title": "Infection rate",
+      "id": "infection-rate",
+      "body": "Also known as R(t) or “R-effective,” infection rate is important because it estimates how fast COVID is spreading right now. For example, if the R(t) is 3, it indicates that one infected person will most likely infect three other people, and those three people will each go on to infect three more people. Daily new cases may be low, but if infection rate is high, then we know that daily new cases will be high in the near future.",
+      "cta": "[Keep reading to learn more about the infection rate metric.](/covid-risk-levels-metrics#infection-rate)"
+    },
+    {
+      "title": "Positive test rate",
+      "id": "positive-test-rate",
+      "body": "Positive test rate body copy.",
+      "cta": "[Positive test rate CTA.](/covid-risk-levels-metrics#positive-test-rate)"
+    },
+    {
+      "title": "ICU capacity used",
+      "id": "icu-capacity-used",
+      "body": "ICU capacity used body copy.",
+      "cta": "[ICU capacity used CTA.](/covid-risk-levels-metrics#icu-capacity-used)"
+    },
+    {
+      "title": "Percent vaccinated",
+      "id": "percent-vaccinated",
+      "body": "Percent vaccinated body copy.",
+      "cta": "[Percent vaccinated CTA.](/covid-risk-levels-metrics#percent-vaccinated)"
+    }
+  ]
+}

--- a/src/cms-content/infoTooltips/index.ts
+++ b/src/cms-content/infoTooltips/index.ts
@@ -1,0 +1,8 @@
+import { Markdown } from '../utils';
+
+export interface InfoTooltip {
+  title: string;
+  id: string;
+  content: Markdown;
+  cta: Markdown;
+}

--- a/src/cms-content/infoTooltips/index.ts
+++ b/src/cms-content/infoTooltips/index.ts
@@ -3,6 +3,6 @@ import { Markdown } from '../utils';
 export interface InfoTooltip {
   title: string;
   id: string;
-  content: Markdown;
+  body: Markdown;
   cta: Markdown;
 }


### PR DESCRIPTION
Uses copy from [figma](https://www.figma.com/file/085lLFwjpkg8JUB05LSUnb/Learn-Product?node-id=121%3A5208) + dummy copy for metrics that aren't in mocks