### PR TITLE
Metric enum into its own file

### DIFF
--- a/src/common/metric.tsx
+++ b/src/common/metric.tsx
@@ -9,20 +9,9 @@ import { fail } from 'common/utils';
 import { MetricDefinition } from './metrics/interfaces';
 import { formatDecimal, formatPercent } from 'common/utils';
 import { isNumber } from 'lodash';
+import { Metric } from './metricEnum';
 
-export enum Metric {
-  // NOTE: Always add new metrics to the end (don't reorder). For better or
-  // worse, the metric number is encoded in URLs and in our persisted summaries
-  // files (used by /internal/compare/), etc. So reordering them would break
-  // things.
-  CASE_GROWTH_RATE = 0,
-  POSITIVE_TESTS = 1,
-  HOSPITAL_USAGE = 2,
-  // CONTACT_TRACING = 3,
-  // FUTURE_PROJECTIONS = 4
-  CASE_DENSITY = 5,
-  VACCINATIONS = 6,
-}
+export { Metric };
 
 export const ALL_METRICS = [
   Metric.CASE_DENSITY,

--- a/src/common/metricEnum.ts
+++ b/src/common/metricEnum.ts
@@ -1,0 +1,13 @@
+export enum Metric {
+  // NOTE: Always add new metrics to the end (don't reorder). For better or
+  // worse, the metric number is encoded in URLs and in our persisted summaries
+  // files (used by /internal/compare/), etc. So reordering them would break
+  // things.
+  CASE_GROWTH_RATE = 0,
+  POSITIVE_TESTS = 1,
+  HOSPITAL_USAGE = 2,
+  // CONTACT_TRACING = 3,
+  // FUTURE_PROJECTIONS = 4
+  CASE_DENSITY = 5,
+  VACCINATIONS = 6,
+}


### PR DESCRIPTION
I was getting a circular dependency error in a working branch. It seems like the cause might be declaring `Metric` in `metric.ts`--where we also import everything from `common/metric/*each-individual-metric-file*`--each of which import+use `Metric`. This PR pulls the enum into its own file

<img width="534" alt="Screen Shot 2021-02-09 at 3 52 02 PM" src="https://user-images.githubusercontent.com/44076375/107426853-c1bbc080-6aee-11eb-8480-0e2bb24a5d21.png">
