### PR TITLE
Add vaccination phases internal page

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -9,6 +9,7 @@ import { ThemeProvider as ScThemeProvider } from 'styled-components';
 import LocationPage from 'screens/LocationPage';
 import Embed from 'screens/Embed/Embed';
 import AllStates from 'screens/internal/AllStates/AllStates';
+import VaccinationPhases from 'screens/internal/VaccinationPhases/VaccinationPhases';
 import CompareSnapshots from 'screens/internal/CompareSnapshots/CompareSnapshots';
 import ExportImage from 'screens/internal/ShareImage/ChartExportImage';
 import ShareImage from 'screens/internal/ShareImage/ShareImage';
@@ -238,6 +239,13 @@ export default function App() {
                   <Route
                     path="/internal/compare"
                     component={CompareSnapshots}
+                  />
+
+                  {/** Internal endpoint for viewing all vaccination phase data **/}
+                  <Route
+                    exact
+                    path="/internal/vaccine-eligibility"
+                    component={VaccinationPhases}
                   />
 
                   {/** Internal endpoints we use to generate the content that we

--- a/src/assets/theme/typography.tsx
+++ b/src/assets/theme/typography.tsx
@@ -30,7 +30,7 @@ const typographyOptions: TypographyOptions = {
   },
   h4: {
     fontSize: '1.75rem',
-    // margin: '2rem 0 1.5rem',
+    margin: '2rem 0 1.5rem',
     fontWeight: 700,
   },
   h5: {
@@ -46,6 +46,7 @@ const typographyOptions: TypographyOptions = {
     fontWeight: 700,
     fontSize: '1.125rem',
     lineHeight: '1.75rem',
+    margin: '1.5rem 0',
   },
   subtitle1: {
     color: palette.text.primary,
@@ -63,7 +64,7 @@ const typographyOptions: TypographyOptions = {
   body1: {
     color: palette.text.primary,
     fontSize: '1rem',
-    // letterSpacing: '-0.05px',
+    letterSpacing: '-0.05px',
     lineHeight: '1.6',
   },
   body2: {
@@ -72,7 +73,7 @@ const typographyOptions: TypographyOptions = {
     '@media (min-width:600px)': {
       fontSize: '1rem',
     },
-    // letterSpacing: '-0.04px',
+    letterSpacing: '-0.04px',
     lineHeight: '1.4rem',
   },
   // @ts-ignore This seems like a bug?

--- a/src/assets/theme/typography.tsx
+++ b/src/assets/theme/typography.tsx
@@ -30,7 +30,7 @@ const typographyOptions: TypographyOptions = {
   },
   h4: {
     fontSize: '1.75rem',
-    margin: '2rem 0 1.5rem',
+    // margin: '2rem 0 1.5rem',
     fontWeight: 700,
   },
   h5: {
@@ -46,7 +46,6 @@ const typographyOptions: TypographyOptions = {
     fontWeight: 700,
     fontSize: '1.125rem',
     lineHeight: '1.75rem',
-    margin: '1.5rem 0',
   },
   subtitle1: {
     color: palette.text.primary,
@@ -64,7 +63,7 @@ const typographyOptions: TypographyOptions = {
   body1: {
     color: palette.text.primary,
     fontSize: '1rem',
-    letterSpacing: '-0.05px',
+    // letterSpacing: '-0.05px',
     lineHeight: '1.6',
   },
   body2: {
@@ -73,7 +72,7 @@ const typographyOptions: TypographyOptions = {
     '@media (min-width:600px)': {
       fontSize: '1rem',
     },
-    letterSpacing: '-0.04px',
+    // letterSpacing: '-0.04px',
     lineHeight: '1.4rem',
   },
   // @ts-ignore This seems like a bug?

--- a/src/screens/internal/VaccinationPhases/VaccinationPhases.tsx
+++ b/src/screens/internal/VaccinationPhases/VaccinationPhases.tsx
@@ -14,7 +14,7 @@ interface StateVaccineDataProps {
   regionData: RegionVaccinePhaseInfo;
 }
 
-const PipeDelimatedRow = ({
+const PipeDelimitedRow = ({
   children,
 }: {
   children: (React.ReactElement | string | undefined)[];
@@ -40,7 +40,7 @@ const PipeDelimatedRow = ({
 };
 
 const StateHeader = ({ regionData }: StateVaccineDataProps) => (
-  <PipeDelimatedRow>
+  <PipeDelimitedRow>
     <Typography variant="body1">FIPS: {regionData.fips}</Typography>
     <ExternalLink href={regionData.eligibilityInfoUrl}>
       Eligibility URL
@@ -55,7 +55,7 @@ const StateHeader = ({ regionData }: StateVaccineDataProps) => (
     >
       Good RX
     </ExternalLink>
-  </PipeDelimatedRow>
+  </PipeDelimitedRow>
 );
 
 const VaccinePhaseGroup = ({ data }: { data: RegionPhaseGroup }) => {
@@ -68,7 +68,7 @@ const VaccinePhaseGroup = ({ data }: { data: RegionPhaseGroup }) => {
         </Typography>
       </Grid>
       <Grid item xs={12}>
-        <PipeDelimatedRow>
+        <PipeDelimitedRow>
           {data.currentlyEligible ? (
             <Typography color="secondary">Currently Eligible</Typography>
           ) : (
@@ -82,7 +82,7 @@ const VaccinePhaseGroup = ({ data }: { data: RegionPhaseGroup }) => {
               </ExternalLink>
             </Grid>
           )}
-        </PipeDelimatedRow>
+        </PipeDelimitedRow>
       </Grid>
       <Grid container item xs={12}>
         <Grid item xs={12}>

--- a/src/screens/internal/VaccinationPhases/VaccinationPhases.tsx
+++ b/src/screens/internal/VaccinationPhases/VaccinationPhases.tsx
@@ -70,7 +70,7 @@ const VaccinePhaseGroup = ({ data }: { data: RegionPhaseGroup }) => {
       <Grid item xs={12}>
         <PipeDelimatedRow>
           {data.currentlyEligible ? (
-            <Typography color="textPrimary">Currently Eligible</Typography>
+            <Typography color="secondary">Currently Eligible</Typography>
           ) : (
             <Typography color="error">Not eligible</Typography>
           )}

--- a/src/screens/internal/VaccinationPhases/VaccinationPhases.tsx
+++ b/src/screens/internal/VaccinationPhases/VaccinationPhases.tsx
@@ -60,7 +60,7 @@ const StateHeader = ({ regionData }: StateVaccineDataProps) => (
 
 const VaccinePhaseGroup = ({ data }: { data: RegionPhaseGroup }) => {
   return (
-    <Grid container spacing={1}>
+    <Grid container>
       <Grid item xs={12}>
         <Typography variant="h6">
           Phase {data.phase}
@@ -84,31 +84,6 @@ const VaccinePhaseGroup = ({ data }: { data: RegionPhaseGroup }) => {
           )}
         </PipeDelimatedRow>
       </Grid>
-      {/*
-      <Grid container item xs={12}>
-        <Grid item xs={12}>
-          {data.currentlyEligible ? (
-            <Typography variant="body1" color="textPrimary">
-              Currently Eligible
-            </Typography>
-          ) : (
-            <Typography variant="body1" color="error">
-              Not eligible
-            </Typography>
-          )}
-        </Grid>
-
-        <Grid item xs={12}>
-          <Typography variant="body1">Start Date: {data.startDate}</Typography>
-        </Grid>
-        {data.expandedDefinitionUrl && (
-          <Grid item xs={12}>
-            <ExternalLink href={data.expandedDefinitionUrl}>
-              Detailed information
-            </ExternalLink>
-          </Grid>
-        )}
-      </Grid> */}
       <Grid container item xs={12}>
         <Grid item xs={12}>
           <Typography>Description:</Typography>{' '}

--- a/src/screens/internal/VaccinationPhases/VaccinationPhases.tsx
+++ b/src/screens/internal/VaccinationPhases/VaccinationPhases.tsx
@@ -4,10 +4,10 @@ import {
   RegionPhaseGroup,
   stateVaccinationPhases,
 } from 'cms-content/vaccines/phases';
-import { Grid, Typography } from '@material-ui/core';
+import { Container, Grid, Typography } from '@material-ui/core';
 import ExternalLink from 'components/ExternalLink';
 import { MarkdownContent } from 'components/Markdown';
-import PageContent from 'components/PageContent';
+
 import { sortBy } from 'lodash';
 
 interface StateVaccineDataProps {
@@ -119,7 +119,7 @@ const VaccinationPhases = () => {
   const data = sortBy(stateVaccinationPhases, item => item.locationName);
 
   return (
-    <PageContent sidebarItems={[]}>
+    <Container maxWidth="md">
       <Grid container>
         <Grid item xs={12}>
           <Typography variant="h2">State Vaccination Phases</Typography>
@@ -130,7 +130,7 @@ const VaccinationPhases = () => {
           ))}
         </Grid>
       </Grid>
-    </PageContent>
+    </Container>
   );
 };
 

--- a/src/screens/internal/VaccinationPhases/VaccinationPhases.tsx
+++ b/src/screens/internal/VaccinationPhases/VaccinationPhases.tsx
@@ -62,7 +62,7 @@ const VaccinePhaseGroup = ({ data }: { data: RegionPhaseGroup }) => {
   return (
     <Grid container>
       <Grid item xs={12}>
-        <Typography variant="h6">
+        <Typography variant="h6" style={{ margin: 0 }}>
           Phase {data.phase}
           {data.tier && <>, tier{data.tier}</>}
         </Typography>
@@ -99,7 +99,9 @@ const StateVaccinationData = ({ regionData }: StateVaccineDataProps) => {
   return (
     <Grid container spacing={2}>
       <Grid item xs={12}>
-        <Typography variant="h4">{regionData.locationName}</Typography>
+        <Typography variant="h4" style={{ margin: 0 }}>
+          {regionData.locationName}
+        </Typography>
       </Grid>
       <Grid item xs={12}>
         <StateHeader regionData={regionData} />

--- a/src/screens/internal/VaccinationPhases/VaccinationPhases.tsx
+++ b/src/screens/internal/VaccinationPhases/VaccinationPhases.tsx
@@ -1,0 +1,162 @@
+import React from 'react';
+import {
+  RegionVaccinePhaseInfo,
+  RegionPhaseGroup,
+  stateVaccinationPhases,
+} from 'cms-content/vaccines/phases';
+import { Grid, Typography } from '@material-ui/core';
+import ExternalLink from 'components/ExternalLink';
+import { MarkdownContent } from 'components/Markdown';
+import PageContent from 'components/PageContent';
+import { sortBy } from 'lodash';
+
+interface StateVaccineDataProps {
+  regionData: RegionVaccinePhaseInfo;
+}
+
+const PipeDelimatedRow = ({
+  children,
+}: {
+  children: (React.ReactElement | string | undefined)[];
+}) => {
+  return (
+    <Grid container xs={12} spacing={1}>
+      {children.map((child, idx) => {
+        if (!child) {
+          return null;
+        }
+        if (idx === 0) {
+          return <Grid item>{child}</Grid>;
+        }
+        return (
+          <>
+            <Grid item>|</Grid>
+            <Grid item>{child}</Grid>
+          </>
+        );
+      })}
+    </Grid>
+  );
+};
+
+const StateHeader = ({ regionData }: StateVaccineDataProps) => (
+  <PipeDelimatedRow>
+    <Typography variant="body1">FIPS: {regionData.fips}</Typography>
+    <ExternalLink href={regionData.eligibilityInfoUrl}>
+      Eligibility URL
+    </ExternalLink>
+    <Typography variant="body1">
+      Email alert version: {regionData.emailAlertVersion}
+    </Typography>
+    <ExternalLink
+      href={`https://www.goodrx.com/covid-19/${regionData.locationName
+        .replace(' ', '')
+        .toLowerCase()}`}
+    >
+      Good RX
+    </ExternalLink>
+  </PipeDelimatedRow>
+);
+
+const VaccinePhaseGroup = ({ data }: { data: RegionPhaseGroup }) => {
+  return (
+    <Grid container spacing={1}>
+      <Grid item xs={12}>
+        <Typography variant="h6">
+          Phase {data.phase}
+          {data.tier && <>, tier{data.tier}</>}
+        </Typography>
+      </Grid>
+      <Grid item xs={12}>
+        <PipeDelimatedRow>
+          {data.currentlyEligible ? (
+            <Typography color="textPrimary">Currently Eligible</Typography>
+          ) : (
+            <Typography color="error">Not eligible</Typography>
+          )}
+          <Typography>Start Date: {data.startDate ?? '--'}</Typography>
+          {data.expandedDefinitionUrl && (
+            <Grid item xs={12}>
+              <ExternalLink href={data.expandedDefinitionUrl}>
+                Detailed information
+              </ExternalLink>
+            </Grid>
+          )}
+        </PipeDelimatedRow>
+      </Grid>
+      {/*
+      <Grid container item xs={12}>
+        <Grid item xs={12}>
+          {data.currentlyEligible ? (
+            <Typography variant="body1" color="textPrimary">
+              Currently Eligible
+            </Typography>
+          ) : (
+            <Typography variant="body1" color="error">
+              Not eligible
+            </Typography>
+          )}
+        </Grid>
+
+        <Grid item xs={12}>
+          <Typography variant="body1">Start Date: {data.startDate}</Typography>
+        </Grid>
+        {data.expandedDefinitionUrl && (
+          <Grid item xs={12}>
+            <ExternalLink href={data.expandedDefinitionUrl}>
+              Detailed information
+            </ExternalLink>
+          </Grid>
+        )}
+      </Grid> */}
+      <Grid container item xs={12}>
+        <Grid item xs={12}>
+          <Typography>Description:</Typography>{' '}
+        </Grid>
+        <Grid item xs={12}>
+          <MarkdownContent source={data.description}></MarkdownContent>
+        </Grid>
+      </Grid>
+    </Grid>
+  );
+};
+const StateVaccinationData = ({ regionData }: StateVaccineDataProps) => {
+  return (
+    <Grid container spacing={2}>
+      <Grid item xs={12}>
+        <Typography variant="h4">{regionData.locationName}</Typography>
+      </Grid>
+      <Grid item xs={12}>
+        <StateHeader regionData={regionData} />
+      </Grid>
+      <Grid container spacing={1} item xs={12}>
+        {regionData.phaseGroups.map(data => (
+          <Grid item xs={12}>
+            <VaccinePhaseGroup data={data} />
+          </Grid>
+        ))}
+      </Grid>
+    </Grid>
+  );
+};
+
+const VaccinationPhases = () => {
+  const data = sortBy(stateVaccinationPhases, item => item.locationName);
+
+  return (
+    <PageContent sidebarItems={[]}>
+      <Grid container>
+        <Grid item xs={12}>
+          <Typography variant="h2">State Vaccination Phases</Typography>
+        </Grid>
+        <Grid item xs={12}>
+          {data.map(stateData => (
+            <StateVaccinationData regionData={stateData} />
+          ))}
+        </Grid>
+      </Grid>
+    </PageContent>
+  );
+};
+
+export default VaccinationPhases;


### PR DESCRIPTION
available at `/internal/vaccine-eligibility`.

I wrote this relying less on styled components and more on the material ui system (just because I'm more familiar).  Had to override margins for typography header (which would be nice to look into in general) but otherwise fairly straightforward!

![image](https://user-images.githubusercontent.com/1422280/107426652-802b1580-6aee-11eb-81ef-7c2cc6bc533a.png)
