### PR TITLE
Add embed link below each embed preview

### DIFF
--- a/src/components/Markdown/Markdown.style.ts
+++ b/src/components/Markdown/Markdown.style.ts
@@ -161,5 +161,7 @@ export const Caption = styled.figcaption`
 
 export const CenterEmbed = styled.div`
   display: flex;
+  flex-direction: column;
+  align-items: center;
   justify-content: center;
 `;

--- a/src/components/Markdown/Markdown.style.ts
+++ b/src/components/Markdown/Markdown.style.ts
@@ -165,3 +165,10 @@ export const CenterEmbed = styled.div`
   align-items: center;
   justify-content: center;
 `;
+
+export const EmbedLink = styled.span`
+  display: flex;
+  justify-content: center;
+  cursor: pointer;
+  text-decoration: underline;
+`;

--- a/src/components/Markdown/Markdown.style.ts
+++ b/src/components/Markdown/Markdown.style.ts
@@ -161,8 +161,6 @@ export const Caption = styled.figcaption`
 
 export const CenterEmbed = styled.div`
   display: flex;
-  flex-direction: column;
-  align-items: center;
   justify-content: center;
 `;
 

--- a/src/components/Markdown/MarkdownLink.tsx
+++ b/src/components/Markdown/MarkdownLink.tsx
@@ -11,10 +11,8 @@ import TwitterEmbed, { isTwitterEmbed } from './TwitterEmbed';
 import YouTubeEmbed, { isYouTubeEmbed } from './YoutubeEmbed';
 import { trackEvent, EventCategory, EventAction } from 'components/Analytics';
 import ExternalLink from 'components/ExternalLink';
-import { CenterEmbed } from './Markdown.style';
+import { CenterEmbed, EmbedLink } from './Markdown.style';
 import EmbedPreview from '../ShareBlock/EmbedPreview';
-import regions from 'common/regions';
-import { EmbedPrompt } from '../ShareBlock/ShareBlock.style';
 
 /**
  * Custom hyperlink for Markdown content. If the link is external, open it on
@@ -30,34 +28,36 @@ export const scrollWithTimeout = (element: any, offset: number) => {
   }, 600);
 };
 
+const EmbedBox: React.FC<{ href: string }> = ({ href }) => {
+  return (
+    <CenterEmbed>
+      <iframe
+        src={href}
+        title="Covid Act Now"
+        width="400"
+        height="390"
+        frameBorder="0"
+        scrolling="no"
+      />
+    </CenterEmbed>
+  );
+};
+
 const CanEmbed: React.FC<{ href: string }> = ({ href }) => {
   const [isOpen, setIsOpen] = useState(false);
-  const region =
-    href === 'https://covidactnow.org/embed/us/fips/19100'
-      ? regions.findByFipsCode('19100')!
-      : undefined;
-  return (
-    <div>
-      <CenterEmbed>
-        <iframe
-          src={href}
-          title="Covid Act Now"
-          width="400"
-          height="390"
-          frameBorder="0"
-          scrolling="no"
-        />
-        <EmbedPrompt>
-          <span onClick={() => setIsOpen(true)}>Embed on your website</span>
-        </EmbedPrompt>
-      </CenterEmbed>
-      <EmbedPreview
-        open={isOpen}
-        onClose={() => setIsOpen(false)}
-        region={region}
-      />
-    </div>
-  );
+  if (href !== 'https://covidactnow.org/embed/us/') {
+    return <EmbedBox href={href} />;
+  } else {
+    return (
+      <>
+        <EmbedBox href={href} />
+        <EmbedLink tabIndex={0} role="button" onClick={() => setIsOpen(true)}>
+          Embed on your website
+        </EmbedLink>
+        <EmbedPreview open={isOpen} onClose={() => setIsOpen(false)} />
+      </>
+    );
+  }
 };
 
 const MarkdownLink: React.FC<{

--- a/src/components/Markdown/MarkdownLink.tsx
+++ b/src/components/Markdown/MarkdownLink.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React, { Fragment, useState } from 'react';
 import { HashLink } from 'react-router-hash-link';
 import { scrollWithOffset } from 'components/TableOfContents';
 import {
@@ -12,6 +12,10 @@ import YouTubeEmbed, { isYouTubeEmbed } from './YoutubeEmbed';
 import { trackEvent, EventCategory, EventAction } from 'components/Analytics';
 import ExternalLink from 'components/ExternalLink';
 import { CenterEmbed } from './Markdown.style';
+import EmbedPreview from '../ShareBlock/EmbedPreview';
+import regions from 'common/regions';
+import { EmbedPrompt } from '../ShareBlock/ShareBlock.style';
+
 /**
  * Custom hyperlink for Markdown content. If the link is external, open it on
  * a new tab. If the link is internal, use the HashLink component to render
@@ -24,6 +28,36 @@ export const scrollWithTimeout = (element: any, offset: number) => {
   return setTimeout(() => {
     scrollWithOffset(element, offset);
   }, 600);
+};
+
+const CanEmbed: React.FC<{ href: string }> = ({ href }) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const region =
+    href === 'https://covidactnow.org/embed/us/fips/19100'
+      ? regions.findByFipsCode('19100')!
+      : undefined;
+  return (
+    <div>
+      <CenterEmbed>
+        <iframe
+          src={href}
+          title="Covid Act Now"
+          width="400"
+          height="390"
+          frameBorder="0"
+          scrolling="no"
+        />
+        <EmbedPrompt>
+          <span onClick={() => setIsOpen(true)}>Embed on your website</span>
+        </EmbedPrompt>
+      </CenterEmbed>
+      <EmbedPreview
+        open={isOpen}
+        onClose={() => setIsOpen(false)}
+        region={region}
+      />
+    </div>
+  );
 };
 
 const MarkdownLink: React.FC<{
@@ -44,18 +78,7 @@ const MarkdownLink: React.FC<{
   }
 
   if (isInternalEmbed(href)) {
-    return (
-      <CenterEmbed>
-        <iframe
-          src={href}
-          title="Covid Act Now"
-          width="400"
-          height="390"
-          frameBorder="0"
-          scrolling="no"
-        />
-      </CenterEmbed>
-    );
+    return <CanEmbed href={href} />;
   }
 
   if (href === 'https://g.co/ens') {


### PR DESCRIPTION
This PR adds a corresponding embed link under each embed preview on the "Tools" page. This is a work-in-progress. Some notes regarding necessary revisions are attached to specific parts of the code below.