### PR TITLE
Fix email alert script: Fix day tracking and don't fail silently on errors.

### DIFF
--- a/scripts/alert_emails_report/generate-report.ts
+++ b/scripts/alert_emails_report/generate-report.ts
@@ -38,14 +38,10 @@ interface FipsCount {
 }
 
 async function main() {
-  try {
-    const db = getFirestore();
-    const subscriptions = await fetchAllAlertSubscriptions(db);
-    await updateSubscriptionsByLocation(subscriptions);
-    await updateSubscriptionsByDate(subscriptions);
-  } catch (err) {
-    console.error('Error updating subscription stats', err);
-  }
+  const db = getFirestore();
+  const subscriptions = await fetchAllAlertSubscriptions(db);
+  await updateSubscriptionsByLocation(subscriptions);
+  await updateSubscriptionsByDate(subscriptions);
 
   try {
     // TODO(michael): Get engagement stats from AWS.
@@ -104,7 +100,7 @@ async function updateSubscriptionsByDate(subscriptions: Subscription[]) {
   for (const subscription of sortedSubscriptions) {
     const subscribedAt = moment(subscription.subscribedAt);
     const days = moment(subscribedAt).diff(curDate, 'days');
-    if (days > 1) {
+    if (days >= 1) {
       dateTotals.push([curDate.add(1, 'days').format('YYYY-MM-DD'), total]);
       curDate = subscribedAt.startOf('day');
     }
@@ -172,6 +168,6 @@ function formatGroupStats(groupName: string, stats: CampaignMonitorStats) {
 if (require.main === module) {
   main().catch(err => {
     console.error(err);
-    process.exit(1);
+    process.exit(-1);
   });
 }


### PR DESCRIPTION
There was an off-by-1 error with the "subscriptions by date" tracking that I've fixed.

Also, the script was silently failing every day due to too many cells in the spreadsheet.  I deleted extra rows/columns, which seems to have fixed it, but I also changed the script so that it will fail more loudly in the future.