### PR TITLE
Make vaccine chart more forgiving of missing 2nd dose data.

### DIFF
--- a/src/components/Charts/ChartVaccinations.tsx
+++ b/src/components/Charts/ChartVaccinations.tsx
@@ -56,15 +56,16 @@ const VaccinesTooltip: React.FC<{
   subtext: string;
 }> = ({ seriesList, left, top, date }) => {
   const [seriesInitiated, seriesCompleted] = seriesList;
-  const pointCompleted = findPointByDate(seriesCompleted.data, date);
+  const pointCompleted =
+    seriesCompleted && findPointByDate(seriesCompleted.data, date);
   const pointInitiated = findPointByDate(seriesInitiated.data, date);
 
-  return pointCompleted && pointInitiated ? (
+  return pointInitiated ? (
     <Tooltip
       width={'160px'}
       top={top(pointInitiated)}
-      left={left(pointCompleted)}
-      title={formatUtcDate(new Date(pointCompleted.x), 'MMM D, YYYY')}
+      left={left(pointCompleted ? pointCompleted : pointInitiated)}
+      title={formatUtcDate(new Date(pointInitiated.x), 'MMM D, YYYY')}
     >
       <Styles.TooltipLine>
         <Styles.TooltipLabel>
@@ -76,16 +77,18 @@ const VaccinesTooltip: React.FC<{
             : '-'}
         </Styles.TooltipValue>
       </Styles.TooltipLine>
-      <Styles.TooltipLine>
-        <Styles.TooltipLabel>
-          {seriesCompleted.tooltipLabel}
-        </Styles.TooltipLabel>{' '}
-        <Styles.TooltipValue>
-          {isNumber(pointCompleted.y)
-            ? formatPercent(pointCompleted.y, 1)
-            : '-'}
-        </Styles.TooltipValue>
-      </Styles.TooltipLine>
+      {seriesCompleted && pointCompleted && (
+        <Styles.TooltipLine>
+          <Styles.TooltipLabel>
+            {seriesCompleted.tooltipLabel}
+          </Styles.TooltipLabel>{' '}
+          <Styles.TooltipValue>
+            {isNumber(pointCompleted.y)
+              ? formatPercent(pointCompleted.y, 1)
+              : '-'}
+          </Styles.TooltipValue>
+        </Styles.TooltipLine>
+      )}
     </Tooltip>
   ) : null;
 };

--- a/src/components/Charts/MetricChart.tsx
+++ b/src/components/Charts/MetricChart.tsx
@@ -86,7 +86,7 @@ function getVaccinationSeries(projection: Projection): Series[] {
         fill: '#000',
       },
     },
-  ];
+  ].filter(series => series.data.length > 0);
 }
 
 function filterNull(points: Column[]) {


### PR DESCRIPTION
If we really want to support this, well need to make additional updates to the copy, but this gets us closer and resolves the symptom reported in https://trello.com/c/gmpQgViy/859-oh-vaccine-timeseries-rendering-mixup

Before:
![image](https://user-images.githubusercontent.com/206364/107579311-c7c2a780-6ba9-11eb-95b8-178de1960c99.png)


After:
![image](https://user-images.githubusercontent.com/206364/107579347-d27d3c80-6ba9-11eb-95c0-640cb8d7082c.png)
