### PR TITLE
Edit default signup regions

### DIFF
--- a/src/components/EmailAlertsForm/utils.ts
+++ b/src/components/EmailAlertsForm/utils.ts
@@ -1,7 +1,10 @@
 import { getFirebase, firebase } from 'common/firebase';
-import { Region, County } from 'common/regions';
+import { Region, County, MetroArea } from 'common/regions';
 
 export function getDefaultRegions(region: Region): Region[] {
+  if (region instanceof MetroArea) {
+    return [region, ...region.states];
+  }
   if (region instanceof County) {
     return [region, region.state];
   } else {


### PR DESCRIPTION
Adds metro's states to default alert signup locations
[Trello ticket](https://trello.com/c/07bDUrRi/886-add-metro-states-to-the-alerts-default-signup-when-youre-on-a-metro-area)