### PR TITLE
handle failure to write to localStorage more gracefully

### DIFF
--- a/src/common/fullstory.ts
+++ b/src/common/fullstory.ts
@@ -22,6 +22,7 @@ enum RecordSession {
 export function initFullStory() {
   initStorage();
 
+  // If we can't find the value in localStorage we won't enable recordings in FullStory
   if (localStorage.getItem(FULLSTORY_RECORD_KEY) === RecordSession.TRUE) {
     FullStory.init({ orgId: 'XEVN9' });
   }
@@ -32,8 +33,14 @@ function initStorage() {
     return;
   }
   const enableRecording = Math.random() < FULLSTORY_RECORD_PERCENT;
-  localStorage.setItem(
-    FULLSTORY_RECORD_KEY,
-    enableRecording ? RecordSession.TRUE : RecordSession.FALSE,
-  );
+  try {
+    localStorage.setItem(
+      FULLSTORY_RECORD_KEY,
+      enableRecording ? RecordSession.TRUE : RecordSession.FALSE,
+    );
+  } catch (err) {
+    // It doesn't matter if we can't write to localStorage, we only need this
+    // for 1% of the users.
+    console.warn(`Error writing to localStorage`, err);
+  }
 }

--- a/src/common/fullstory.ts
+++ b/src/common/fullstory.ts
@@ -52,28 +52,14 @@ function initStorage() {
 // From https://developer.mozilla.org/en-US/docs/Web/API/Web_Storage_API/Using_the_Web_Storage_API#testing_for_availability
 function storageAvailable(storageType: string) {
   let storage;
-  const x = '__storage_test__';
+  const testKey = '__storage_test__';
   try {
     // @ts-ignore
     storage = window[storageType];
-    storage.setItem(x, x);
-    storage.removeItem(x);
+    storage.setItem(testKey, testKey);
+    storage.removeItem(testKey);
     return true;
   } catch (e) {
-    return (
-      e instanceof DOMException &&
-      // everything except Firefox
-      (e.code === 22 ||
-        // Firefox
-        e.code === 1014 ||
-        // test name field too, because code might not be present
-        // everything except Firefox
-        e.name === 'QuotaExceededError' ||
-        // Firefox
-        e.name === 'NS_ERROR_DOM_QUOTA_REACHED') &&
-      // acknowledge QuotaExceededError only if there's something already stored
-      storage &&
-      storage.length !== 0
-    );
+    return false;
   }
 }

--- a/src/common/fullstory.ts
+++ b/src/common/fullstory.ts
@@ -20,6 +20,10 @@ enum RecordSession {
 }
 
 export function initFullStory() {
+  if (!storageAvailable('localStorage')) {
+    return;
+  }
+
   initStorage();
 
   // If we can't find the value in localStorage we won't enable recordings in FullStory
@@ -42,5 +46,34 @@ function initStorage() {
     // It doesn't matter if we can't write to localStorage, we only need this
     // for 1% of the users.
     console.warn(`Error writing to localStorage`, err);
+  }
+}
+
+// From https://developer.mozilla.org/en-US/docs/Web/API/Web_Storage_API/Using_the_Web_Storage_API#testing_for_availability
+function storageAvailable(storageType: string) {
+  let storage;
+  const x = '__storage_test__';
+  try {
+    // @ts-ignore
+    storage = window[storageType];
+    storage.setItem(x, x);
+    storage.removeItem(x);
+    return true;
+  } catch (e) {
+    return (
+      e instanceof DOMException &&
+      // everything except Firefox
+      (e.code === 22 ||
+        // Firefox
+        e.code === 1014 ||
+        // test name field too, because code might not be present
+        // everything except Firefox
+        e.name === 'QuotaExceededError' ||
+        // Firefox
+        e.name === 'NS_ERROR_DOM_QUOTA_REACHED') &&
+      // acknowledge QuotaExceededError only if there's something already stored
+      storage &&
+      storage.length !== 0
+    );
   }
 }


### PR DESCRIPTION
We write a flag to `localStorage` to determine whether or not to enable FullStory recordings. Some users block applications from writing to `localStorage` and in this case, writing to it would fail (also if the storage is full).

This PR handles that failure more gracefully, catching the error if we can't write to `localStorage`