### PR TITLE
Add map image to sitemap.

### DIFF
--- a/firebase/public/googlea39d320c48a99e85.html
+++ b/firebase/public/googlea39d320c48a99e85.html
@@ -1,0 +1,1 @@
+google-site-verification: googlea39d320c48a99e85.html

--- a/scripts/generate_sitemap/utils.ts
+++ b/scripts/generate_sitemap/utils.ts
@@ -2,6 +2,7 @@ import { concat } from 'lodash';
 import { SitemapItemLoose } from 'sitemap';
 import urlJoin from 'url-join';
 import regions from '../../src/common/regions';
+import { getMapImageUrl } from '../../src/common/urls';
 import { allCaseStudies } from '../../src/cms-content/learn';
 import articles from '../../src/cms-content/articles';
 
@@ -37,8 +38,18 @@ export function getLearnPageItems(): SitemapItemLoose[] {
 }
 
 export function getTopLevelPageItems(): SitemapItemLoose[] {
-  const relativeUrlList = [
-    '/',
+  const relativeUrlList: (SitemapItemLoose | string)[] = [
+    {
+      url: '/',
+      img: [
+        {
+          url: getMapImageUrl(),
+          title: 'Realtime U.S. COVID Risk Map',
+          caption:
+            'A map of the United States colored by the risk level of each county',
+        },
+      ],
+    },
     '/donate',
     '/about',
     '/tools',
@@ -49,6 +60,10 @@ export function getTopLevelPageItems(): SitemapItemLoose[] {
   return relativeUrlList.map(createSitemapItem);
 }
 
-function createSitemapItem(url: string) {
-  return { url };
+function createSitemapItem(entry: string | SitemapItemLoose): SitemapItemLoose {
+  if (typeof entry === 'string') {
+    return { url: entry };
+  } else {
+    return entry;
+  }
 }


### PR DESCRIPTION
Also verify https://covidactnow-prod.web.app/ with Google Search Console per directions on https://developers.google.com/search/docs/advanced/sitemaps/image-sitemaps:

> In some cases, the image URL may not be on the same domain as your main site. This is fine,
> as long as both domains are verified in Search Console.

Resulting entry in the sitemap:

```
  <url>
    <loc>https://covidactnow.org/</loc>
    <image:image>
      <image:loc>https://covidactnow-prod.web.app/share/1590-530/2021-02-10-image-covid-us-map-cases.png</image:loc>
      <image:caption>A map of the United States colored by the risk level of each county</image:caption>
      <image:title>Realtime U.S. COVID Risk Map</image:title>
    </image:image>
  </url>
```