### PR TITLE
Add sample rate to sentry

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -22,6 +22,9 @@ Sentry.init({
   ],
   dsn:
     'https://4e1fa0b7df4d490488847bcc7966712b@o378922.ingest.sentry.io/5444052',
+  // Adding sampling to sentry errors to reduce volume. After cleaning up more sentry errors
+  // (https://trello.com/c/0LGQjmdw), should be able to remove this.
+  sampleRate: 0.5,
 });
 
 initFullStory();


### PR DESCRIPTION
We're currently bumping up against the sentry limit for number of events reported. Adding sampling for reporting until we have more bandwidth to tackle the root cause of the issues.