### PR TITLE
Directly import web-vitals functions

### DIFF
--- a/src/reportWebVitals.ts
+++ b/src/reportWebVitals.ts
@@ -1,18 +1,24 @@
 // implementation comes from a later version of create-react-app that this app was created from,
 // but the implementation seems worth reusing.
 // copied from https://github.com/facebook/create-react-app/blob/4e97dc75ad0c859fde7e2ffdaf9d5bd7d107b21a/packages/cra-template-typescript/template/src/reportWebVitals.ts
-
-import { ReportHandler } from 'web-vitals';
+// NOTE(chris): Implementation modified to directly import functions used rather than re-import
+//  in a separate bundle as web-vitals is already included in the main bundle.
+import {
+  ReportHandler,
+  getCLS,
+  getFID,
+  getFCP,
+  getLCP,
+  getTTFB,
+} from 'web-vitals';
 
 const reportWebVitals = (onPerfEntry?: ReportHandler) => {
   if (onPerfEntry && onPerfEntry instanceof Function) {
-    import('web-vitals').then(({ getCLS, getFID, getFCP, getLCP, getTTFB }) => {
-      getCLS(onPerfEntry);
-      getFID(onPerfEntry);
-      getFCP(onPerfEntry);
-      getLCP(onPerfEntry);
-      getTTFB(onPerfEntry);
-    });
+    getCLS(onPerfEntry);
+    getFID(onPerfEntry);
+    getFCP(onPerfEntry);
+    getLCP(onPerfEntry);
+    getTTFB(onPerfEntry);
   }
 };
 


### PR DESCRIPTION
Recently there have been a number of errors importing a bundle.  Looking into it, it's probably people on iOS navigating away when the bundle is being downloaded.  However, it looks like the (tiny) `web-vitals` code is already included in the main bundle as it's imported by default.