### PR TITLE
increase target size for HI and PR

### DIFF
--- a/src/components/Map/Map.style.js
+++ b/src/components/Map/Map.style.js
@@ -2,10 +2,7 @@ import styled from 'styled-components';
 import Typography from '@material-ui/core/Typography';
 import { COLOR_MAP } from 'common/colors';
 
-// TODO(pablo): We don't need these wrapping divs anymore
 export const USMapWrapper = styled.div``;
-
-export const USCountyMapWrapper = styled.div``;
 
 export const USStateMapWrapper = styled.div`
   path:hover {

--- a/src/components/Map/USACountyMap.js
+++ b/src/components/Map/USACountyMap.js
@@ -97,6 +97,10 @@ const USACountyMap = React.memo(
                     .map(geo => {
                       const fipsCode = geo.id;
                       const state = regions.findByFipsCode(fipsCode);
+                      // This flag is used to increase an invisible border around Hawaii and Puerto Rico
+                      // to increase their effective target size
+                      const expandTapArea =
+                        state.stateCode === 'HI' || state.stateCode === 'PR';
                       // Using a custom SVG to place the northern mariana islands to increase
                       // accessibility due to the small size.
                       if (state.stateCode === 'MP') {
@@ -106,6 +110,7 @@ const USACountyMap = React.memo(
                             to={state.relativeUrl}
                             aria-label={state.fullName}
                             onClick={() => trackMapClick(state.fullName)}
+                            tabIndex="-1"
                           >
                             <MarianaIslands
                               key={geo.rsmKey}
@@ -115,6 +120,7 @@ const USACountyMap = React.memo(
                               onMouseLeave={onMouseLeave}
                               onClick={() => stateClickHandler(state.fullName)}
                               fill={getFillColor(geo)}
+                              tabIndex="-1"
                             />
                           </Link>
                         );
@@ -125,6 +131,7 @@ const USACountyMap = React.memo(
                           to={state.relativeUrl}
                           aria-label={state.fullName}
                           onClick={() => trackMapClick(state.fullName)}
+                          tabIndex="-1"
                         >
                           <Geography
                             key={geo.rsmKey}
@@ -137,7 +144,10 @@ const USACountyMap = React.memo(
                             fill={getFillColor(geo)}
                             fillOpacity={showCounties ? 0 : 1}
                             stroke="white"
+                            strokeWidth={expandTapArea ? 35 : 2}
+                            strokeOpacity={expandTapArea ? 0 : 1}
                             role="img"
+                            tabIndex="-1"
                           />
                         </Link>
                       ) : null;


### PR DESCRIPTION
Increase the target size for Hawaii and Puerto Rico in the US map. I added an huge invisible border to the paths with opacity set to `0` to make the tap size bigger (new tap areas highlighted below). 

![image](https://user-images.githubusercontent.com/114084/108139853-cd226500-7075-11eb-9cca-208a5eb0c032.png)

I also set `tabIndex=-1` on the link and paths to prevent the map from becoming a keyboard focus trap. A user trying to use `tab` to navigate the page will have to go through all the states before reaching the compare table. We provide a good way to navigate to states already, so I think it's better to skip the map completely from keyboard-navigation for now.

