### PR TITLE
remove the blog link from the footer

### DIFF
--- a/src/components/Footer/Footer.style.tsx
+++ b/src/components/Footer/Footer.style.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 import palette from 'assets/theme/palette';
 
-export const StyledFooter = styled.div`
+export const StyledFooter = styled.footer`
   padding: 2rem 0;
   box-sizing: content-box;
   background: ${palette.black};

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -22,7 +22,7 @@ const Footer = () => {
   }
 
   return (
-    <StyledFooter role="contentinfo">
+    <StyledFooter>
       <StyledFooterInner isMapPage={isMapPage}>
         <StyledFooterContent>
           <Logo />

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import Logo from 'assets/images/footerlogoDarkWithURL';
 import { useIsEmbed } from 'common/utils/hooks';
-import ExternalLink from 'components/ExternalLink';
 import FooterSocialLinks from './FooterSocialLinks';
 import {
   StyledFooter,
@@ -13,7 +12,7 @@ import {
   StyledFooterDivider,
 } from './Footer.style';
 
-const Footer = ({ children }: { children: React.ReactNode }) => {
+const Footer = () => {
   const { pathname } = useLocation();
   const isMapPage = pathname.startsWith('/us') || pathname.startsWith('/state');
   const isEmbed = useIsEmbed();
@@ -23,37 +22,32 @@ const Footer = ({ children }: { children: React.ReactNode }) => {
   }
 
   return (
-    <div>
-      <StyledFooter>
-        <StyledFooterInner isMapPage={isMapPage}>
-          <StyledFooterContent>
-            <Logo />
-            <StyledFooterBodyNav>
-              <Link to="/">Map</Link>
-              <Link to="/learn">Learn</Link>
-              <Link to="/tools">Tools</Link>
-              <ExternalLink href="https://blog.covidactnow.org">
-                Blog
-              </ExternalLink>
-              <Link to="/about">About</Link>
-              <Link to="/contact">Contact us</Link>
-            </StyledFooterBodyNav>
-            <StyledFooterDivider />
-            <StyledFooterBodyLinks>
-              <FooterSocialLinks />
-            </StyledFooterBodyLinks>
-            <StyledFooterDivider />
-            <StyledFooterBodyLinks>
-              <Link to="/contact">Contact</Link>
-              {' ∙ '}
-              <Link to="/terms">Terms</Link>
-              {' ∙ '}
-              <a href="mailto:press@covidactnow.org">Press</a>
-            </StyledFooterBodyLinks>
-          </StyledFooterContent>
-        </StyledFooterInner>
-      </StyledFooter>
-    </div>
+    <StyledFooter role="contentinfo">
+      <StyledFooterInner isMapPage={isMapPage}>
+        <StyledFooterContent>
+          <Logo />
+          <StyledFooterBodyNav>
+            <Link to="/">Map</Link>
+            <Link to="/learn">Learn</Link>
+            <Link to="/tools">Tools</Link>
+            <Link to="/about">About</Link>
+            <Link to="/contact">Contact us</Link>
+          </StyledFooterBodyNav>
+          <StyledFooterDivider />
+          <StyledFooterBodyLinks>
+            <FooterSocialLinks />
+          </StyledFooterBodyLinks>
+          <StyledFooterDivider />
+          <StyledFooterBodyLinks>
+            <Link to="/contact">Contact</Link>
+            {' ∙ '}
+            <Link to="/terms">Terms</Link>
+            {' ∙ '}
+            <a href="mailto:press@covidactnow.org">Press</a>
+          </StyledFooterBodyLinks>
+        </StyledFooterContent>
+      </StyledFooterInner>
+    </StyledFooter>
   );
 };
 


### PR DESCRIPTION
I also changed `div` → `footer` to make it more semantic/accessible.


Note: I initially added `role="contentinfo"` to the footer, but since the footer is directly under `body` that's not necessary (see [WAI-ARIA Practices - ContentInfo](https://www.w3.org/TR/wai-aria-practices-1.2/#aria_lh_contentinfo))