### PR TITLE
fix association between checkbox and label for explore

### DIFF
--- a/src/components/IndigenousPopulationsFeature/IndigenousDataCheckbox.tsx
+++ b/src/components/IndigenousPopulationsFeature/IndigenousDataCheckbox.tsx
@@ -54,12 +54,15 @@ const IndigenousDataCheckbox = (props: {
           checked={chartIndigenous}
           onChange={onClickChartIndigenous}
           name="Chart Indigenous Populations"
-          id="Chart Indigenous Populations"
+          id="checkbox-indigenous-populations"
           aria-labelledby="native-american-populations-label"
         />
       </CheckboxWrapper>
       <CopyContainer>
-        <label id="native-american-populations-label">
+        <label
+          id="native-american-populations-label"
+          htmlFor="checkbox-indigenous-populations"
+        >
           <strong>
             View COVID’s impact on counties with majority Native American
             populations.


### PR DESCRIPTION
The indigenous populations checkbox for Explore wasn't fully associated with its corresponding label, which was causing that clicking on the label didn't toggle the checkbox. This PR fixes that issue.

![2021-02-17-explore-checkbox-label](https://user-images.githubusercontent.com/114084/108238503-de16b900-70fd-11eb-8b8a-f9740dce92ed.gif)

Note: `aria-labelledby` works for screen readers, but it doesn't implement the behaviour described above.