### PR TITLE
Fix compare bug + alignment

### DIFF
--- a/src/components/Compare/Filters.style.tsx
+++ b/src/components/Compare/Filters.style.tsx
@@ -21,7 +21,7 @@ export const Container = styled.div<{
 }>`
   display: flex;
   margin: ${({ $isModal }) => $isModal && '1rem auto 0'};
-  padding: ${({ $isModal }) => ($isModal ? '0 0 0 1.75rem' : '0.75rem 1rem')};
+  padding: ${({ $isModal }) => ($isModal ? '0 0 0 1.75rem' : '0.75rem 0')};
   justify-content: ${({ $isHomepage, $isModal }) =>
     $isHomepage && $isModal && 'center'};
   flex-direction: column;
@@ -34,12 +34,12 @@ export const Container = styled.div<{
   }
 `;
 
-export const SliderContainer = styled.div`
+export const SliderContainer = styled.div<{ $isModal: boolean }>`
   width: 200px;
-  margin-left: 1.75rem;
+  margin-left: ${({ $isModal }) => !$isModal && '1.75rem'};
 
   @media (min-width: 600px) {
-    margin-left: 1.5rem;
+    margin-left: ${({ $isModal }) => !$isModal && '2rem'};
   }
 `;
 
@@ -110,7 +110,7 @@ export const MetroMenuButton = styled(Button)<{
   width: 200px;
   border-radius: ${({ $isOpen }) => ($isOpen ? '4px 4px 0 0' : '4px')};
   font-family: Roboto;
-  margin: ${({ $isStatePage }) => !$isStatePage && '1rem 0 .5rem'};
+  margin: ${({ $isStatePage }) => !$isStatePage && '.75rem 0'};
   padding: 0.375rem 0.75rem;
 
   &:hover {

--- a/src/components/Compare/Filters.tsx
+++ b/src/components/Compare/Filters.tsx
@@ -183,7 +183,7 @@ const Filters = (props: {
           />
         )}
         {props.county && (
-          <SliderContainer>
+          <SliderContainer $isModal={props.isModal}>
             <GeoSlider
               onChange={sliderHandleChange}
               value={sliderValue}

--- a/src/components/Compare/HomepageSlider.tsx
+++ b/src/components/Compare/HomepageSlider.tsx
@@ -26,7 +26,7 @@ const HomepageSlider: React.FC<{
   $isModal: boolean;
 }> = ({ onChange, homepageScope, homepageSliderValue, $isModal }) => {
   return (
-    <SliderContainer>
+    <SliderContainer $isModal={$isModal}>
       <StyledSlider
         onChange={onChange}
         value={homepageSliderValue}

--- a/src/components/Compare/LocationTable.tsx
+++ b/src/components/Compare/LocationTable.tsx
@@ -245,7 +245,7 @@ const LocationTable: React.FunctionComponent<{
   // In the modal, if the rank of the pinned-location-row is #1, we remove
   // the location's inline row, so as to not have the location listed twice consecutively:
   const removePinnedIfRankedFirst = (location: SummaryForCompare) =>
-    location.region.fipsCode === pinnedLocation?.region.fipsCode;
+    location.region.fipsCode !== pinnedLocation?.region.fipsCode;
 
   const modalLocations = hideInlineLocation
     ? remove(sortedLocations, removePinnedIfRankedFirst)


### PR DESCRIPTION
A previous bug fix to the compare modal introduced a new one. When the pinned row is ranked #1, no other locations are populating the modal (image below). This fixes.

![Screen Shot 2021-02-17 at 5 54 09 PM](https://user-images.githubusercontent.com/44076375/108279010-eb599500-7149-11eb-9324-883a95b98c04.png)

Also, alignment of the compare filters looked a bit off. This addresses that.

Before:
<img width="304" alt="Screen Shot 2021-02-17 at 5 47 42 PM" src="https://user-images.githubusercontent.com/44076375/108279032-f4e2fd00-7149-11eb-8b6b-1a026ac8cc37.png">

After:
<img width="379" alt="Screen Shot 2021-02-17 at 5 47 46 PM" src="https://user-images.githubusercontent.com/44076375/108279063-ff04fb80-7149-11eb-9bb2-3854a62af51c.png">
