### PR TITLE
Vaccination disclaimer/tooltip edit

### DIFF
--- a/src/common/metrics/vaccinations.tsx
+++ b/src/common/metrics/vaccinations.tsx
@@ -102,21 +102,21 @@ function renderDisclaimer(region: Region): React.ReactElement {
   return (
     <Fragment>
       {'Learn more about '}
-      {region instanceof State ? (
-        <DisclaimerTooltip
-          title={getDataSourceTooltipContent(Metric.VACCINATIONS, region)}
-          mainCopy={'where our data comes from'}
-          trackOpenTooltip={trackOpenTooltip(
-            `Learn more: ${Metric.VACCINATIONS}`,
-          )}
-          trackCloseTooltip={trackCloseTooltip(
-            `Learn more: ${Metric.VACCINATIONS}`,
-          )}
-        />
-      ) : (
-        <>where our data comes from</>
+      {region instanceof State && (
+        <>
+          <DisclaimerTooltip
+            title={getDataSourceTooltipContent(Metric.VACCINATIONS, region)}
+            mainCopy={'where our data comes from'}
+            trackOpenTooltip={trackOpenTooltip(
+              `Learn more: ${Metric.VACCINATIONS}`,
+            )}
+            trackCloseTooltip={trackCloseTooltip(
+              `Learn more: ${Metric.VACCINATIONS}`,
+            )}
+          />
+          {' and '}
+        </>
       )}
-      {' and '}
       <DisclaimerTooltip
         title={renderTooltipContent(body)}
         mainCopy={'how we calculate our metrics'}


### PR DESCRIPTION
Under vaccinations chart on county+metro pages, there is currently no tooltip with data source info. This PR removes the "where our data comes from" piece of disclaimer copy when there is no tooltip linked.

Before:
![Screen Shot 2021-02-18 at 3 58 44 PM](https://user-images.githubusercontent.com/44076375/108420731-30410280-7202-11eb-8707-7908d52bf279.png)

After:
![Screen Shot 2021-02-18 at 3 59 29 PM](https://user-images.githubusercontent.com/44076375/108420805-4a7ae080-7202-11eb-9530-033703975ac7.png)