### PR TITLE
Fix tooltip analytics event tracking.

### DIFF
--- a/src/common/metrics/case_density.tsx
+++ b/src/common/metrics/case_density.tsx
@@ -145,23 +145,23 @@ function renderDisclaimer(region: Region): React.ReactElement {
       <DisclaimerTooltip
         title={getDataSourceTooltipContent(Metric.CASE_DENSITY, region)}
         mainCopy={'where our data comes from'}
-        trackOpenTooltip={trackOpenTooltip(
-          `Learn more: ${Metric.CASE_DENSITY}`,
-        )}
-        trackCloseTooltip={trackCloseTooltip(
-          `Learn more: ${Metric.CASE_DENSITY}`,
-        )}
+        trackOpenTooltip={() =>
+          trackOpenTooltip(`Learn more: ${Metric.CASE_DENSITY}`)
+        }
+        trackCloseTooltip={() =>
+          trackCloseTooltip(`Learn more: ${Metric.CASE_DENSITY}`)
+        }
       />
       {' and '}
       <DisclaimerTooltip
         title={renderTooltipContent(body)}
         mainCopy={'how we calculate our metrics'}
-        trackOpenTooltip={trackOpenTooltip(
-          `How we calculate: ${Metric.CASE_DENSITY}`,
-        )}
-        trackCloseTooltip={trackCloseTooltip(
-          `How we calculate: ${Metric.CASE_DENSITY}`,
-        )}
+        trackOpenTooltip={() =>
+          trackOpenTooltip(`How we calculate: ${Metric.CASE_DENSITY}`)
+        }
+        trackCloseTooltip={() =>
+          trackCloseTooltip(`How we calculate: ${Metric.CASE_DENSITY}`)
+        }
       />
       .
     </Fragment>
@@ -220,12 +220,12 @@ function renderInfoTooltip(): React.ReactElement {
     <InfoTooltip
       title={renderTooltipContent(body)}
       aria-label={`Show definition of ${CaseIncidenceMetric.metricName} metric`}
-      trackOpenTooltip={trackOpenTooltip(
-        `Metric definition: ${Metric.CASE_DENSITY}`,
-      )}
-      trackCloseTooltip={trackCloseTooltip(
-        `Metric definition: ${Metric.CASE_DENSITY}`,
-      )}
+      trackOpenTooltip={() =>
+        trackOpenTooltip(`Metric definition: ${Metric.CASE_DENSITY}`)
+      }
+      trackCloseTooltip={() =>
+        trackCloseTooltip(`Metric definition: ${Metric.CASE_DENSITY}`)
+      }
     />
   );
 }

--- a/src/common/metrics/case_growth.tsx
+++ b/src/common/metrics/case_growth.tsx
@@ -134,23 +134,23 @@ function renderDisclaimer(region: Region): React.ReactElement {
       <DisclaimerTooltip
         title={getDataSourceTooltipContent(Metric.CASE_GROWTH_RATE, region)}
         mainCopy={'where our data comes from'}
-        trackOpenTooltip={trackOpenTooltip(
-          `Learn more: ${Metric.CASE_GROWTH_RATE}`,
-        )}
-        trackCloseTooltip={trackCloseTooltip(
-          `Learn more: ${Metric.CASE_GROWTH_RATE}`,
-        )}
+        trackOpenTooltip={() =>
+          trackOpenTooltip(`Learn more: ${Metric.CASE_GROWTH_RATE}`)
+        }
+        trackCloseTooltip={() =>
+          trackCloseTooltip(`Learn more: ${Metric.CASE_GROWTH_RATE}`)
+        }
       />
       {' and '}
       <DisclaimerTooltip
         title={renderTooltipContent(body)}
         mainCopy={'how we calculate our metrics'}
-        trackOpenTooltip={trackOpenTooltip(
-          `How we calculate: ${Metric.CASE_GROWTH_RATE}`,
-        )}
-        trackCloseTooltip={trackCloseTooltip(
-          `How we calculate: ${Metric.CASE_GROWTH_RATE}`,
-        )}
+        trackOpenTooltip={() =>
+          trackOpenTooltip(`How we calculate: ${Metric.CASE_GROWTH_RATE}`)
+        }
+        trackCloseTooltip={() =>
+          trackCloseTooltip(`How we calculate: ${Metric.CASE_GROWTH_RATE}`)
+        }
       />
       .
     </Fragment>
@@ -202,12 +202,12 @@ function renderInfoTooltip(): React.ReactElement {
     <InfoTooltip
       title={renderTooltipContent(body)}
       aria-label={`Show definition of ${CaseGrowthMetric.metricName} metric`}
-      trackOpenTooltip={trackOpenTooltip(
-        `Metric definition: ${Metric.CASE_GROWTH_RATE}`,
-      )}
-      trackCloseTooltip={trackCloseTooltip(
-        `Metric definition: ${Metric.CASE_GROWTH_RATE}`,
-      )}
+      trackOpenTooltip={() =>
+        trackOpenTooltip(`Metric definition: ${Metric.CASE_GROWTH_RATE}`)
+      }
+      trackCloseTooltip={() =>
+        trackCloseTooltip(`Metric definition: ${Metric.CASE_GROWTH_RATE}`)
+      }
     />
   );
 }

--- a/src/common/metrics/hospitalizations.tsx
+++ b/src/common/metrics/hospitalizations.tsx
@@ -162,23 +162,23 @@ function renderDisclaimer(region: Region): React.ReactElement {
       <DisclaimerTooltip
         title={getDataSourceTooltipContent(Metric.HOSPITAL_USAGE, region)}
         mainCopy={'where our data comes from'}
-        trackOpenTooltip={trackOpenTooltip(
-          `Learn more: ${Metric.HOSPITAL_USAGE}`,
-        )}
-        trackCloseTooltip={trackCloseTooltip(
-          `Learn more: ${Metric.HOSPITAL_USAGE}`,
-        )}
+        trackOpenTooltip={() =>
+          trackOpenTooltip(`Learn more: ${Metric.HOSPITAL_USAGE}`)
+        }
+        trackCloseTooltip={() =>
+          trackCloseTooltip(`Learn more: ${Metric.HOSPITAL_USAGE}`)
+        }
       />
       {' and '}
       <DisclaimerTooltip
         title={renderTooltipContent(body)}
         mainCopy={'how we calculate our metrics'}
-        trackOpenTooltip={trackOpenTooltip(
-          `How we calculate: ${Metric.HOSPITAL_USAGE}`,
-        )}
-        trackCloseTooltip={trackCloseTooltip(
-          `How we calculate: ${Metric.HOSPITAL_USAGE}`,
-        )}
+        trackOpenTooltip={() =>
+          trackOpenTooltip(`How we calculate: ${Metric.HOSPITAL_USAGE}`)
+        }
+        trackCloseTooltip={() =>
+          trackCloseTooltip(`How we calculate: ${Metric.HOSPITAL_USAGE}`)
+        }
       />
       .
     </Fragment>
@@ -237,12 +237,12 @@ function renderInfoTooltip(): React.ReactElement {
     <InfoTooltip
       title={renderTooltipContent(body)}
       aria-label={`Show definition of ${ICUCapacityUsed.metricName} metric`}
-      trackOpenTooltip={trackOpenTooltip(
-        `Metric definition: ${Metric.HOSPITAL_USAGE}`,
-      )}
-      trackCloseTooltip={trackCloseTooltip(
-        `Metric definition: ${Metric.HOSPITAL_USAGE}`,
-      )}
+      trackOpenTooltip={() =>
+        trackOpenTooltip(`Metric definition: ${Metric.HOSPITAL_USAGE}`)
+      }
+      trackCloseTooltip={() =>
+        trackCloseTooltip(`Metric definition: ${Metric.HOSPITAL_USAGE}`)
+      }
     />
   );
 }

--- a/src/common/metrics/positive_rate.tsx
+++ b/src/common/metrics/positive_rate.tsx
@@ -161,23 +161,23 @@ function renderDisclaimer(region: Region): React.ReactElement {
       <DisclaimerTooltip
         title={getDataSourceTooltipContent(Metric.POSITIVE_TESTS, region)}
         mainCopy={'where our data comes from'}
-        trackOpenTooltip={trackOpenTooltip(
-          `Learn more: ${Metric.POSITIVE_TESTS}`,
-        )}
-        trackCloseTooltip={trackCloseTooltip(
-          `Learn more: ${Metric.POSITIVE_TESTS}`,
-        )}
+        trackOpenTooltip={() =>
+          trackOpenTooltip(`Learn more: ${Metric.POSITIVE_TESTS}`)
+        }
+        trackCloseTooltip={() =>
+          trackCloseTooltip(`Learn more: ${Metric.POSITIVE_TESTS}`)
+        }
       />
       {' and '}
       <DisclaimerTooltip
         title={renderTooltipContent(body)}
         mainCopy={'how we calculate our metrics'}
-        trackOpenTooltip={trackOpenTooltip(
-          `How we calculate: ${Metric.POSITIVE_TESTS}`,
-        )}
-        trackCloseTooltip={trackCloseTooltip(
-          `How we calculate: ${Metric.POSITIVE_TESTS}`,
-        )}
+        trackOpenTooltip={() =>
+          trackOpenTooltip(`How we calculate: ${Metric.POSITIVE_TESTS}`)
+        }
+        trackCloseTooltip={() =>
+          trackCloseTooltip(`How we calculate: ${Metric.POSITIVE_TESTS}`)
+        }
       />
       .
     </Fragment>
@@ -235,12 +235,12 @@ function renderInfoTooltip(): React.ReactElement {
     <InfoTooltip
       title={renderTooltipContent(body)}
       aria-label={`Show definition of ${PositiveTestRateMetric.metricName} metric`}
-      trackOpenTooltip={trackOpenTooltip(
-        `Metric definition: ${Metric.POSITIVE_TESTS}`,
-      )}
-      trackCloseTooltip={trackCloseTooltip(
-        `Metric definition: ${Metric.POSITIVE_TESTS}`,
-      )}
+      trackOpenTooltip={() =>
+        trackOpenTooltip(`Metric definition: ${Metric.POSITIVE_TESTS}`)
+      }
+      trackCloseTooltip={() =>
+        trackCloseTooltip(`Metric definition: ${Metric.POSITIVE_TESTS}`)
+      }
     />
   );
 }

--- a/src/common/metrics/vaccinations.tsx
+++ b/src/common/metrics/vaccinations.tsx
@@ -107,12 +107,12 @@ function renderDisclaimer(region: Region): React.ReactElement {
           <DisclaimerTooltip
             title={getDataSourceTooltipContent(Metric.VACCINATIONS, region)}
             mainCopy={'where our data comes from'}
-            trackOpenTooltip={trackOpenTooltip(
-              `Learn more: ${Metric.VACCINATIONS}`,
-            )}
-            trackCloseTooltip={trackCloseTooltip(
-              `Learn more: ${Metric.VACCINATIONS}`,
-            )}
+            trackOpenTooltip={() =>
+              trackOpenTooltip(`Learn more: ${Metric.VACCINATIONS}`)
+            }
+            trackCloseTooltip={() =>
+              trackCloseTooltip(`Learn more: ${Metric.VACCINATIONS}`)
+            }
           />
           {' and '}
         </>
@@ -120,12 +120,12 @@ function renderDisclaimer(region: Region): React.ReactElement {
       <DisclaimerTooltip
         title={renderTooltipContent(body)}
         mainCopy={'how we calculate our metrics'}
-        trackOpenTooltip={trackOpenTooltip(
-          `How we calculate: ${Metric.VACCINATIONS}`,
-        )}
-        trackCloseTooltip={trackCloseTooltip(
-          `How we calculate: ${Metric.VACCINATIONS}`,
-        )}
+        trackOpenTooltip={() =>
+          trackOpenTooltip(`How we calculate: ${Metric.VACCINATIONS}`)
+        }
+        trackCloseTooltip={() =>
+          trackCloseTooltip(`How we calculate: ${Metric.VACCINATIONS}`)
+        }
       />
       .
     </Fragment>
@@ -144,12 +144,12 @@ function renderInfoTooltip(): React.ReactElement {
     <InfoTooltip
       title={renderTooltipContent(body)}
       aria-label={`Show definition of ${VaccinationsMetric.metricName} metric`}
-      trackOpenTooltip={trackOpenTooltip(
-        `How we calculate: ${Metric.VACCINATIONS}`,
-      )}
-      trackCloseTooltip={trackCloseTooltip(
-        `How we calculate: ${Metric.VACCINATIONS}`,
-      )}
+      trackOpenTooltip={() =>
+        trackOpenTooltip(`How we calculate: ${Metric.VACCINATIONS}`)
+      }
+      trackCloseTooltip={() =>
+        trackCloseTooltip(`How we calculate: ${Metric.VACCINATIONS}`)
+      }
     />
   );
 }

--- a/src/components/InfoTooltip/DisclaimerTooltip.tsx
+++ b/src/components/InfoTooltip/DisclaimerTooltip.tsx
@@ -26,7 +26,7 @@ const DisclaimerTooltip: React.FC<StyledTooltipProps> = props => {
         <StyledSpan
           tabIndex={0}
           role="button"
-          onClick={() => tooltipAnchorOnClick(isMobile, setIsOpen)}
+          onClick={() => tooltipAnchorOnClick(isMobile, () => setIsOpen(true))}
         >
           {props.mainCopy}
         </StyledSpan>

--- a/src/components/InfoTooltip/InfoTooltip.tsx
+++ b/src/components/InfoTooltip/InfoTooltip.tsx
@@ -9,14 +9,24 @@ const InfoTooltip: React.FC<StyledTooltipProps> = props => {
   const [isOpen, setIsOpen] = useState(false);
   const isMobile = useBreakpoint(600);
 
+  const handleOpen = () => {
+    setIsOpen(true);
+    props.trackOpenTooltip();
+  };
+
+  const handleClose = () => {
+    setIsOpen(false);
+    props.trackCloseTooltip();
+  };
+
   return (
     <>
       <StyledTooltip
-        onOpen={() => setIsOpen(true)}
-        onClose={() => setIsOpen(false)}
+        onOpen={handleOpen}
+        onClose={handleClose}
         title={
           <>
-            <StyledCloseIcon role="button" onClick={() => setIsOpen(false)} />
+            <StyledCloseIcon role="button" onClick={handleClose} />
             {props.title}
           </>
         }
@@ -27,7 +37,7 @@ const InfoTooltip: React.FC<StyledTooltipProps> = props => {
           $isOpen={isOpen}
           tabIndex={0}
           role="button"
-          onClick={() => tooltipAnchorOnClick(isMobile, setIsOpen)}
+          onClick={() => tooltipAnchorOnClick(isMobile, handleOpen)}
         />
       </StyledTooltip>
       <DescriptionDiv content={props.title} />

--- a/src/components/InfoTooltip/index.tsx
+++ b/src/components/InfoTooltip/index.tsx
@@ -8,8 +8,8 @@ import { EventAction, EventCategory, trackEvent } from 'components/Analytics';
 export { InfoTooltip, DisclaimerTooltip };
 
 export type StyledTooltipProps = Omit<TooltipProps, 'children'> & {
-  trackOpenTooltip: any;
-  trackCloseTooltip: any;
+  trackOpenTooltip: () => void;
+  trackCloseTooltip: () => void;
   mainCopy?: string;
 };
 
@@ -17,14 +17,11 @@ export function renderTooltipContent(body: string): React.ReactElement {
   return <StyledMarkdown source={body} />;
 }
 
-export function tooltipAnchorOnClick(
-  isMobile: boolean,
-  setIsOpen: React.Dispatch<React.SetStateAction<boolean>>,
-) {
+export function tooltipAnchorOnClick(isMobile: boolean, onClick: () => void) {
   if (!isMobile) {
     return null;
   } else {
-    setIsOpen(true);
+    onClick();
   }
 }
 

--- a/src/components/LocationPage/LocationPageHeader.tsx
+++ b/src/components/LocationPage/LocationPageHeader.tsx
@@ -42,8 +42,8 @@ function renderInfoTooltip(): React.ReactElement {
     <InfoTooltip
       title={renderTooltipContent(body)}
       aria-label={`Description of risk levels`}
-      trackOpenTooltip={trackOpenTooltip('Location page header')}
-      trackCloseTooltip={trackCloseTooltip('Location page header')}
+      trackOpenTooltip={() => trackOpenTooltip('Location page header')}
+      trackCloseTooltip={() => trackCloseTooltip('Location page header')}
     />
   );
 }


### PR DESCRIPTION
We were calling trackOpenTooltip() and trackCloseTooltip() immediately on page
load, instead of when the tooltip was actually opened/closed, causing ~22 (I think) GA
events to be fired on page load.

![image](https://user-images.githubusercontent.com/206364/108607786-66ec5980-7377-11eb-832c-95ad12085a85.png)
