### PR TITLE
a11y: fix the double-focus bug on banner buttons

### DIFF
--- a/src/components/Banner/VaccinationsBanner.style.tsx
+++ b/src/components/Banner/VaccinationsBanner.style.tsx
@@ -2,6 +2,7 @@ import styled from 'styled-components';
 import MuiButton from '@material-ui/core/Button';
 import { materialSMBreakpoint } from 'assets/theme/sizes';
 import { COLOR_MAP } from 'common/colors';
+import LinkButton from 'components/LinkButton';
 
 export const Wrapper = styled.div`
   background-color: ${COLOR_MAP.LIGHTGRAY_BG};
@@ -17,9 +18,7 @@ export const Wrapper = styled.div`
   }
 `;
 
-export const CompareButton = styled(MuiButton).attrs(props => ({
-  disableRipple: true,
-  disableFocusRipple: true,
+export const CompareButton = styled(LinkButton).attrs(props => ({
   variant: 'contained',
 }))`
   background-color: ${COLOR_MAP.BLUE};
@@ -31,9 +30,7 @@ export const CompareButton = styled(MuiButton).attrs(props => ({
   }
   `;
 
-export const SearchButton = styled(MuiButton).attrs(props => ({
-  disableRipple: true,
-  disableFocusRipple: true,
+export const SearchButton = styled(LinkButton).attrs(props => ({
   variant: 'text',
 }))`
   background-color: ${COLOR_MAP.LIGHTGRAY_BG};

--- a/src/components/Banner/VaccinationsBanner.style.tsx
+++ b/src/components/Banner/VaccinationsBanner.style.tsx
@@ -1,5 +1,4 @@
 import styled from 'styled-components';
-import MuiButton from '@material-ui/core/Button';
 import { materialSMBreakpoint } from 'assets/theme/sizes';
 import { COLOR_MAP } from 'common/colors';
 import LinkButton from 'components/LinkButton';

--- a/src/components/Banner/VaccinationsBanner.tsx
+++ b/src/components/Banner/VaccinationsBanner.tsx
@@ -1,5 +1,4 @@
 import React, { Fragment } from 'react';
-import { HashLink } from 'react-router-hash-link';
 import { ButtonContainer } from './Banner.style';
 import { trackEvent, EventAction, EventCategory } from 'components/Analytics';
 import {
@@ -17,38 +16,24 @@ import { scrollWithOffset } from 'components/TableOfContents';
 const Buttons: React.FC = () => {
   return (
     <Fragment>
-      <HashLink
+      <CompareButton
         to="#compare"
         scroll={(element: HTMLElement) => scrollWithOffset(element, -80)}
+        trackingCategory={EventCategory.VACCINATION}
+        trackingAction={EventAction.CLICK}
+        trackingLabel="Banner: Compare states"
       >
-        <CompareButton
-          onClick={() => {
-            trackEvent(
-              EventCategory.VACCINATION,
-              EventAction.CLICK,
-              'Banner: Compare states',
-            );
-          }}
-        >
-          Compare states
-        </CompareButton>
-      </HashLink>
-      <HashLink
+        Compare states
+      </CompareButton>
+      <SearchButton
         to="#search"
         scroll={(element: HTMLElement) => scrollWithOffset(element, -80)}
+        trackingCategory={EventCategory.VACCINATION}
+        trackingAction={EventAction.CLICK}
+        trackingLabel="Banner: See my state"
       >
-        <SearchButton
-          onClick={() => {
-            trackEvent(
-              EventCategory.VACCINATION,
-              EventAction.CLICK,
-              'Banner: See my state',
-            );
-          }}
-        >
-          See my state
-        </SearchButton>
-      </HashLink>
+        See my state
+      </SearchButton>
     </Fragment>
   );
 };

--- a/src/components/Banner/VaccinationsBanner.tsx
+++ b/src/components/Banner/VaccinationsBanner.tsx
@@ -1,6 +1,6 @@
 import React, { Fragment } from 'react';
 import { ButtonContainer } from './Banner.style';
-import { trackEvent, EventAction, EventCategory } from 'components/Analytics';
+import { EventAction, EventCategory } from 'components/Analytics';
 import {
   Wrapper,
   InnerContainer,


### PR DESCRIPTION
The banner buttons were implemented as a button inside a link, which caused both elements to have a tab stop when navigating using the keyboard. Now that the `LinkButton` component supports `HashLink`, we can replace the implementation, which avoids the double <kbd>tab</kbd> problem.

