### PR TITLE
Update vercel preview link in deploy-snapshot workflow

### DIFF
--- a/.github/workflows/update-snapshot.yml
+++ b/.github/workflows/update-snapshot.yml
@@ -64,7 +64,7 @@ jobs:
             * Point at new share images URL.
 
       - name: Wait for Preview URL to be live
-        run: npx wait-on -t 120000 https://covid-projections-git-bump-snapshot-${{env.RUN_ID}}.covidactnow.now.sh/compare/ || echo 'Preview URL failed to load.'
+        run: npx wait-on -t 120000 https://covid-projections-git-bump-snapshot-${{env.RUN_ID}}-covidactnow.now.sh/compare/ || echo 'Preview URL failed to load.'
 
       - name: Read slack-summary.txt
         id: slack_summary
@@ -87,6 +87,6 @@ jobs:
           args: |
             PR to update the website to snapshot ${{env.SNAPSHOT_ID}} (with updated map colors and share images) is available.
             PR: https://github.com/covid-projections/covid-projections/pull/${{env.PULL_REQUEST_NUMBER}}
-            Preview: https://covid-projections-git-bump-snapshot-${{env.RUN_ID}}.covidactnow.now.sh/
-            Compare: https://covid-projections-git-bump-snapshot-${{env.RUN_ID}}.covidactnow.now.sh/internal/compare/
+            Preview: https://covid-projections-git-bump-snapshot-${{env.RUN_ID}}-covidactnow.now.sh/
+            Compare: https://covid-projections-git-bump-snapshot-${{env.RUN_ID}}-covidactnow.now.sh/internal/compare/
             ${{steps.slack_summary.outputs.text}}


### PR DESCRIPTION
Looks like the vercel deploy link slightly changed: https://covid-projections-git-bump-snapshot-1611-555-covidactnow.vercel.app/internal/compare/ works but https://covid-projections-git-bump-snapshot-1611-555.covidactnow.vercel.app/internal/compare/ does not.  Updating the deploy snapshot workflow accordingly