### PR TITLE
add eligibility link for PR + unit tests

### DIFF
--- a/src/cms-content/vaccines/index.test.ts
+++ b/src/cms-content/vaccines/index.test.ts
@@ -1,0 +1,16 @@
+import { sortBy } from 'lodash';
+import regions from 'common/regions';
+import { getVaccinationDataByRegion } from './index';
+
+const states = sortBy(regions.states, state => state.stateCode);
+
+describe('vaccination information', () => {
+  describe('eligibility links', () => {
+    for (const state of states) {
+      test(`${state.stateCode} has eligibility url`, () => {
+        const vaccinationData = getVaccinationDataByRegion(state);
+        expect(vaccinationData?.eligibilityInfoUrl).not.toBeFalsy();
+      });
+    }
+  });
+});

--- a/src/cms-content/vaccines/state.json
+++ b/src/cms-content/vaccines/state.json
@@ -322,6 +322,14 @@
     },
     {
       "hidden": false,
+      "stateCode": "PR",
+      "eligibilityInfoUrl": "https://www.vacunatepr.com/fases-vacunacion-covid-19",
+      "vaccinationSignupUrl": null,
+      "locationName": "Puerto Rico",
+      "fips": "72"
+    },
+    {
+      "hidden": false,
       "stateCode": "RI",
       "eligibilityInfoUrl": "https://covid.ri.gov/vaccination",
       "vaccinationSignupUrl": null,

--- a/src/components/LocationPage/ChartsHolder.tsx
+++ b/src/components/LocationPage/ChartsHolder.tsx
@@ -24,9 +24,8 @@ import {
 } from 'common/utils/recommend';
 import { mainContent } from 'cms-content/recommendations';
 import { getRecommendationsShareUrl } from 'common/urls';
-import { Region, State, County, MetroArea, getStateName } from 'common/regions';
-import RegionVaccinationBlock from 'components/RegionVaccinationBlock';
-import VaccinationEligibilityBlock from 'components/VaccinationEligibilityBlock';
+import { Region, State, getStateName } from 'common/regions';
+import VaccinationBlock from 'components/VaccinationBlock';
 
 // TODO: 180 is rough accounting for the navbar and searchbar;
 // could make these constants so we don't have to manually update
@@ -137,11 +136,6 @@ const ChartsHolder = ({ projections, region, chartId }: ChartsHolderProps) => {
     projections.getMetricValues(),
   );
 
-  const isSingleStateMetro =
-    region instanceof MetroArea && region.isSingleStateMetro;
-  const showVaccinationEligibilityBlock =
-    region instanceof State || region instanceof County || isSingleStateMetro;
-
   // TODO(pablo): Create separate refs for signup and share
   return (
     <>
@@ -156,11 +150,7 @@ const ChartsHolder = ({ projections, region, chartId }: ChartsHolderProps) => {
           region={region}
         />
         <MainContentInner>
-          {showVaccinationEligibilityBlock ? (
-            <VaccinationEligibilityBlock region={region} />
-          ) : (
-            <RegionVaccinationBlock region={region} />
-          )}
+          <VaccinationBlock region={region} />
         </MainContentInner>
         <MainContentInner>
           <CompareMain

--- a/src/components/LocationPage/ChartsHolder.tsx
+++ b/src/components/LocationPage/ChartsHolder.tsx
@@ -24,14 +24,7 @@ import {
 } from 'common/utils/recommend';
 import { mainContent } from 'cms-content/recommendations';
 import { getRecommendationsShareUrl } from 'common/urls';
-import {
-  Region,
-  State,
-  County,
-  MetroArea,
-  getStateName,
-  getFormattedStateCode,
-} from 'common/regions';
+import { Region, State, County, MetroArea, getStateName } from 'common/regions';
 import RegionVaccinationBlock from 'components/RegionVaccinationBlock';
 import VaccinationEligibilityBlock from 'components/VaccinationEligibilityBlock';
 
@@ -149,9 +142,6 @@ const ChartsHolder = ({ projections, region, chartId }: ChartsHolderProps) => {
   const showVaccinationEligibilityBlock =
     region instanceof State || region instanceof County || isSingleStateMetro;
 
-  // TODO(https://trello.com/c/wXEmHdtr/): Blocking PR for now.
-  const hideVaccineBlocks = getFormattedStateCode(region)?.includes('PR');
-
   // TODO(pablo): Create separate refs for signup and share
   return (
     <>
@@ -165,17 +155,13 @@ const ChartsHolder = ({ projections, region, chartId }: ChartsHolderProps) => {
           isMobile={isMobile}
           region={region}
         />
-
-        {!hideVaccineBlocks && (
-          <MainContentInner>
-            {showVaccinationEligibilityBlock ? (
-              <VaccinationEligibilityBlock region={region} />
-            ) : (
-              <RegionVaccinationBlock region={region} />
-            )}
-          </MainContentInner>
-        )}
-
+        <MainContentInner>
+          {showVaccinationEligibilityBlock ? (
+            <VaccinationEligibilityBlock region={region} />
+          ) : (
+            <RegionVaccinationBlock region={region} />
+          )}
+        </MainContentInner>
         <MainContentInner>
           <CompareMain
             stateName={getStateName(region) || region.name} // rename prop

--- a/src/components/VaccinationBlock/VaccinationBlock.tsx
+++ b/src/components/VaccinationBlock/VaccinationBlock.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { Region, MetroArea } from 'common/regions';
+import { getVaccineInfoByFips } from 'cms-content/vaccines/phases';
+import RegionVaccinationBlock from 'components/RegionVaccinationBlock';
+import VaccinationEligibilityBlock from 'components/VaccinationEligibilityBlock';
+import ErrorBoundary from 'components/ErrorBoundary';
+
+const VaccinationBlock: React.FC<{ region: Region }> = ({ region }) => {
+  const vaccineInfo = getVaccineInfoByFips(region.fipsCode);
+
+  const isMultiStateMetro =
+    region instanceof MetroArea && region.states.length > 1;
+
+  // We only have vaccination phases information for states, so we show only the vaccination
+  // links for multi-state metro areas or when we don't have vaccination info
+  const showVaccinationLinks = isMultiStateMetro || !vaccineInfo;
+
+  return (
+    <ErrorBoundary>
+      {showVaccinationLinks ? (
+        <RegionVaccinationBlock region={region} />
+      ) : (
+        <VaccinationEligibilityBlock region={region} />
+      )}
+    </ErrorBoundary>
+  );
+};
+
+export default VaccinationBlock;

--- a/src/components/VaccinationBlock/index.ts
+++ b/src/components/VaccinationBlock/index.ts
@@ -1,0 +1,1 @@
+export { default } from './VaccinationBlock';


### PR DESCRIPTION
This PR adds an eligibility URL for Puerto Rico (using the link from the [CDC: How Do I Get a Vaccine? section](https://www.cdc.gov/vaccines/covid-19/index.html). The target link shows the vaccination phases for Puerto Rico (in Spanish).

I also added unit tests to check that we have the eligibility URL for all the states, and removed the hardcoded check that was hiding that section specifically for Puerto Rico. The tests will show up per state, that way if one ever fails, we will know the state that needs to be fixed:

```
 PASS  src/cms-content/vaccines/index.test.
  vaccination information
    eligibility links
      ✓ AK has eligibility url (2ms)
      ✓ AL has eligibility url
      ✓ AR has eligibility url
      ...
```

We should add tests for the vaccination phases as well, but we might restructure the CMS so all the vaccination information is in one place, so I think it makes more sense to add tests then.