### PR TITLE
Mobile minimap bug

### DIFF
--- a/src/screens/LocationPage/LocationPage.tsx
+++ b/src/screens/LocationPage/LocationPage.tsx
@@ -27,7 +27,7 @@ function LocationPage({ region }: LocationPageProps) {
     setMapOption(defaultMapOption);
     // Close the map on mobile on any change to a region.
     setMobileMenuOpen(false);
-  }, [defaultMapOption]);
+  }, [defaultMapOption, region]);
 
   return (
     <div>


### PR DESCRIPTION
[Trello](https://trello.com/c/0PajW6Pl/968-close-the-county-map-on-mobile-upon-navigation)
The minimap should close when you click it and navigate to a new location page. It currently doesnt. This fixes!