### PR TITLE
Start to add Data API specific content - remove embed :'(

### DIFF
--- a/src/cms-content/learn/products-landing.json
+++ b/src/cms-content/learn/products-landing.json
@@ -1,21 +1,14 @@
 {
-  "header": "Tools",
-  "intro": "",
+  "header": "Data API",
+  "intro": "Our API provides state, county, and metro data using the most useful metrics to understand COVID’s spread and local risk. \n\nIt includes data and metrics for [cases](https://apidocs.covidactnow.org/data-definitions#cases), [vaccinations](https://apidocs.covidactnow.org/data-definitions#vaccinations), [tests](https://apidocs.covidactnow.org/data-definitions#tests), [hospitalizations](https://apidocs.covidactnow.org/data-definitions#hospitalizations), and [deaths](https://apidocs.covidactnow.org/data-definitions#deaths). The data is aggregated from a number of official sources, quality assured, and updated daily. It’s available in JSON and CSV format. \n\nTo gain access, please use this [registration form](https://apidocs.covidactnow.org/access/) to generate your unique key.",
   "productsList": [
     {
-      "productName": "API",
-      "productId": "api",
-      "productSubtitle": "Allows you to use our data",
-      "productDescription": "Looking for all the data that powers our site in a machine-readable format? You can use our API, made for ease-of-use by those wishing to programmatically ingest our data. To gain access, please use this [registration form](https://apidocs.covidactnow.org/access) to generate your unique key.\n\nNote that our data is licensed under [Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International](https://creativecommons.org/licenses/by-nc-nd/4.0/). All commercial entities wishing to access our API should contact [info@covidactnow.org](mailto:info@covidactnow.org) to acquire a commercial license. We define commercial users as any individual or entity engaged in commercial activities, such as selling goods or services. Our non-commercial users can freely download, use, share, modify, or build upon our source code.\n\nPlease also note that V1.0 of our API will be deprecated on October 5, 2020. See our [documentation](https://apidocs.covidactnow.org/migration) for migration instructions.",
-      "buttons": []
-    },
-    {
-      "productName": "Embed",
-      "productId": "embed",
-      "productSubtitle": "Allows you to embed our data into your website",
-      "productDescription": "Want to show our COVID map or risk-levels on your own website? Find the embed link at the bottom of this page. \n\n[Covid Act Now Embed- US Map](https://covidactnow.org/embed/us/)\n\nOr, you can embed the specific risk-level module for any location. Simply scroll to the bottom of that state, county or metro’s page.\n\n [Covid Act Now Embed - Dallas metro area](https://covidactnow.org/embed/us/fips/19100)"
+      "productName": "License",
+      "productId": "license",
+      "productSubtitle": "API License",
+      "productDescription": "Note that our data is licensed under [Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International](https://creativecommons.org/licenses/by-nc-nd/4.0/). All commercial entities wishing to access our API should contact [info@covidactnow.org](mailto:info@covidactnow.org) to acquire a commercial license. \n\nWe define commercial users as any individual or entity engaged in commercial activities, such as selling goods or services. Our non-commercial users can freely download, use, share, modify, or build upon our source code.\n\n"
     }
   ],
-  "metadataTitle": "Tools",
-  "metadataDescription": "Free COVID data tools — API, embeds, downloadable CSVs — to help governments and other partners."
+  "metadataTitle": "Data API",
+  "metadataDescription": "Latest Covid-19 data and metrics. Our API powers dashboards, websites, and apps. Data tracks all US states, counties, and metros."
 }

--- a/src/cms-content/learn/products-landing.json
+++ b/src/cms-content/learn/products-landing.json
@@ -1,6 +1,6 @@
 {
   "header": "Data API",
-  "intro": "Our API provides state, county, and metro data using the most useful metrics to understand COVID’s spread and local risk. \n\nIt includes data and metrics for [cases](https://apidocs.covidactnow.org/data-definitions#cases), [vaccinations](https://apidocs.covidactnow.org/data-definitions#vaccinations), [tests](https://apidocs.covidactnow.org/data-definitions#tests), [hospitalizations](https://apidocs.covidactnow.org/data-definitions#hospitalizations), and [deaths](https://apidocs.covidactnow.org/data-definitions#deaths). The data is aggregated from a number of official sources, quality assured, and updated daily. It’s available in JSON and CSV format. \n\nTo gain access, please use this [registration form](https://apidocs.covidactnow.org/access/) to generate your unique key.",
+  "intro": "Looking for all the data that powers our site in a machine-readable format? You can use our API, made for ease-of-use by those wishing to programmatically ingest our data. To gain access, please use this [registration form](https://apidocs.covidactnow.org/access/) to generate your unique key.",
   "productsList": [
     {
       "productName": "License",

--- a/src/screens/DataApi/DataApi.tsx
+++ b/src/screens/DataApi/DataApi.tsx
@@ -1,7 +1,7 @@
 import React, { Fragment } from 'react';
 import AppMetaTags from 'components/AppMetaTags/AppMetaTags';
 import PageContent from 'components/PageContent';
-import { Heading2 } from 'components/Markdown';
+import { Heading2, MarkdownContent } from 'components/Markdown';
 import { formatMetatagDate } from 'common/utils';
 import { LearnHeading1 } from '../Learn/Learn.style';
 import {
@@ -13,6 +13,7 @@ import { TocItem } from 'cms-content/utils';
 
 const {
   header,
+  intro,
   productsList,
   metadataTitle,
   metadataDescription,
@@ -41,6 +42,7 @@ const DataApi = () => {
       />
       <PageContent sidebarItems={sidebarSections}>
         <LearnHeading1>{header}</LearnHeading1>
+        <MarkdownContent source={intro} />
         {productsList.map((product: ProductsLandingSection) => (
           <DataApiSection key={product.productId}>
             <Heading2 id={product.productId}>{product.productName}</Heading2>


### PR DESCRIPTION
This updates the Data API page content.  There will be many more changes to come, but the content here comes from Tom and I.  Planning on adding more sections other than just license.  

Would like to get this in so that the renamed tools page makes more sense.