### PR TITLE
Sort location search results by name (asc) then population (desc)

### DIFF
--- a/src/common/regions/utils.ts
+++ b/src/common/regions/utils.ts
@@ -22,6 +22,20 @@ export function belongsToState(county: County, stateFips: string | null) {
 const sortByPopulation = (regions: Region[]): Region[] =>
   sortBy(regions, region => -region.population);
 
+/* Sort regions by name in ascending order.
+If two regions have the same name, sort them by population in descending order. */
+function sortByNameThenPopulation(locations: Region[]) {
+  const sortedLocations = [...locations];
+  sortedLocations.sort(compareRegionsByNameAndPopulation);
+  return sortedLocations;
+}
+
+function compareRegionsByNameAndPopulation(region1: Region, region2: Region) {
+  if (region1.name === region2.name)
+    return region1.population < region2.population ? 1 : -1;
+  else return region1.name < region2.name ? -1 : 1;
+}
+
 /**
  * Returns a list of regions in the order that is most relevant given the
  * region passed as argument
@@ -35,7 +49,11 @@ export function getAutocompleteRegions(region?: Region): Region[] {
 
   // Homepage
   if (!region) {
-    return concat<Region>(states, metroAreas, counties);
+    return concat<Region>(
+      sortByNameThenPopulation(states),
+      sortByNameThenPopulation(metroAreas),
+      sortByNameThenPopulation(counties),
+    );
   }
 
   // Location pages


### PR DESCRIPTION
Currently the search bar on the homepage and location page returns location results in the following order: state, metro area, county. Each of these groups are sorted alphabetically.

This PR sorts search results within each group alphabetically, but if two locations have the same name, then it will sort these locations by population in descending order.