### PR TITLE
remove location name on vaccination events

### DIFF
--- a/src/components/RegionVaccinationBlock/RegionVaccinationBlock.tsx
+++ b/src/components/RegionVaccinationBlock/RegionVaccinationBlock.tsx
@@ -63,7 +63,7 @@ const VaccinationBlock: React.FC<{ region: Region }> = ({ region }) => {
           <strong>When</strong> can I get vaccinated if I’m in...
           <VaccinationLinksBlock
             links={eligibilityLinks}
-            trackingLinkPrefix="Eligibility"
+            trackingLabel="Eligibility"
           />
         </Fragment>
       )}
@@ -73,7 +73,7 @@ const VaccinationBlock: React.FC<{ region: Region }> = ({ region }) => {
           <strong>Where and how</strong> do I get vaccinated if I’m in...
           <VaccinationLinksBlock
             links={vaccinationOptionsLinks}
-            trackingLinkPrefix="Options"
+            trackingLabel="Options"
           />
         </Fragment>
       )}
@@ -81,11 +81,10 @@ const VaccinationBlock: React.FC<{ region: Region }> = ({ region }) => {
   );
 };
 
-// TODO: Add tracking for these links
 const VaccinationLinksBlock: React.FC<{
   links: VaccinationLink[];
-  trackingLinkPrefix: string;
-}> = ({ links, trackingLinkPrefix }) => (
+  trackingLabel: string;
+}> = ({ links, trackingLabel }) => (
   <ButtonContainer>
     {links.map(({ label, url }) => (
       <LinkButton
@@ -93,7 +92,7 @@ const VaccinationLinksBlock: React.FC<{
         key={label}
         target="_blank"
         rel="noopener noreferrer"
-        onClick={() => trackVaccinationLink(`${trackingLinkPrefix}: ${label}`)}
+        onClick={() => trackVaccinationLink(trackingLabel)}
       >
         {label}
       </LinkButton>


### PR DESCRIPTION
[Trello](https://trello.com/c/kJpd5apB/908-google-analytics-add-a-custom-dimension-for-the-type-of-page-state-county-metro-home-etc-to-filter-search-events) - Remove location names from vaccination event labels.

The original intent of adding the location name on the events tracking interactions with the vaccination block was to be able to tell in which locations user were interacting with the links more often. That makes difficult to aggregate the events by type of link (Eligibility or Options) across all locations.

Also, there we have [Content Groups](https://support.google.com/analytics/answer/2853423?hl=en) set up for state, metro and county pages, so we can use that as secondary dimension when looking at vaccination events.

