### PR TITLE
analytics: remove unused tracking scripts and fix page title tracking

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -60,8 +60,8 @@
     href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;700&family=Roboto:wght@400;500;700&display=swap"
     rel="stylesheet">
 
-  <!-- Google Optimize for A/B testing-->
-  <script async src="https://www.googleoptimize.com/optimize.js?id=OPT-WT27VPR"></script>
+  <!-- Google Optimize for A/B testing: Uncomment when running experiments -->
+  <!-- <script async src="https://www.googleoptimize.com/optimize.js?id=OPT-WT27VPR"></script> -->
 
   <!-- Twitter universal website tag code -->
   <script async>

--- a/src/components/Analytics/PageviewTracker.tsx
+++ b/src/components/Analytics/PageviewTracker.tsx
@@ -44,8 +44,11 @@ function usePageTracking() {
   useEffect(() => {
     if (initialized) {
       // We only add the legacy tracker explicitly here, because by default, GA
-      // will send always send hits to the default tracker.
-      ReactGA.pageview(pathname, [legacyTracker.name]);
+      // will send always send hits to the default tracker. We add a delay to
+      // give the app time to update the page title.
+      setTimeout(() => {
+        ReactGA.pageview(pathname, [legacyTracker.name], document.title);
+      }, 200);
     }
   }, [initialized, pathname]);
 }

--- a/src/components/Analytics/PageviewTracker.tsx
+++ b/src/components/Analytics/PageviewTracker.tsx
@@ -17,7 +17,6 @@ function initializeGA() {
       ...options,
     },
   ]);
-  ReactGA.plugin.require('linkid');
 }
 
 /**

--- a/src/components/Analytics/PageviewTracker.tsx
+++ b/src/components/Analytics/PageviewTracker.tsx
@@ -48,7 +48,7 @@ function usePageTracking() {
       // give the app time to update the page title.
       setTimeout(() => {
         ReactGA.pageview(pathname, [legacyTracker.name], document.title);
-      }, 200);
+      }, 10);
     }
   }, [initialized, pathname]);
 }

--- a/src/components/Experiment/Experiment.tsx
+++ b/src/components/Experiment/Experiment.tsx
@@ -24,6 +24,9 @@ import {
  *
  * The code always defaults to version A if the experiment is not running
  * (or ended) and we still have both versions in the code.
+ *
+ * Note: The optimize script needs to be uncommented from index.html before
+ * starting experiments.
  */
 
 export enum ExperimentID {


### PR DESCRIPTION
[Trello](https://trello.com/c/KQdb7uEx/740-update-the-page-title-in-ga-every-time-we-navigate) - update the page title when tracking page views.

The page title should be tracked automatically by `ReactGA.pageview`, however, the page view event is fired before the title has time to update. This PR adds a small delay (it seems to be enough) between the change in the URL and the moment when we track the page view so it has the correct title.

I also commented out optimize and removed the linkid plugin (both unused).