### PR TITLE
analytics: label geolocation events with region type

### DIFF
--- a/src/components/Analytics/utils.ts
+++ b/src/components/Analytics/utils.ts
@@ -49,6 +49,7 @@ export enum EventCategory {
   GEOLOCATION_CARDS = 'geolocation cards',
   TOOLTIPS = 'tooltips',
   API = 'api',
+  METRICS = 'metrics',
 }
 
 /**

--- a/src/components/LocationPage/ChartsHolder.tsx
+++ b/src/components/LocationPage/ChartsHolder.tsx
@@ -26,6 +26,7 @@ import { mainContent } from 'cms-content/recommendations';
 import { getRecommendationsShareUrl } from 'common/urls';
 import { Region, State, getStateName } from 'common/regions';
 import VaccinationEligibilityBlock from 'components/VaccinationEligibilityBlock';
+import { EventCategory, EventAction, trackEvent } from 'components/Analytics';
 
 // TODO: 180 is rough accounting for the navbar and searchbar;
 // could make these constants so we don't have to manually update
@@ -136,6 +137,33 @@ const ChartsHolder = ({ projections, region, chartId }: ChartsHolderProps) => {
     projections.getMetricValues(),
   );
 
+  const onClickAlertSignup = () => {
+    trackEvent(
+      EventCategory.ENGAGEMENT,
+      EventAction.CLICK,
+      `Location Header: Receive Alerts`,
+    );
+    scrollTo(shareBlockRef.current);
+  };
+
+  const onClickShare = () => {
+    trackEvent(
+      EventCategory.ENGAGEMENT,
+      EventAction.CLICK,
+      'Location Header: Share',
+    );
+    scrollTo(shareBlockRef.current, -372);
+  };
+
+  const onClickMetric = (metric: Metric) => {
+    trackEvent(
+      EventCategory.METRICS,
+      EventAction.CLICK,
+      `Location Header Stats: ${Metric[metric]}`,
+    );
+    scrollTo(metricRefs[metric].current);
+  };
+
   // TODO(pablo): Create separate refs for signup and share
   return (
     <>
@@ -143,9 +171,9 @@ const ChartsHolder = ({ projections, region, chartId }: ChartsHolderProps) => {
         <LocationPageHeader
           projections={projections}
           stats={projections.getMetricValues()}
-          onMetricClick={metric => scrollTo(metricRefs[metric].current)}
-          onHeaderShareClick={() => scrollTo(shareBlockRef.current, -372)}
-          onHeaderSignupClick={() => scrollTo(shareBlockRef.current)}
+          onMetricClick={metric => onClickMetric(metric)}
+          onHeaderShareClick={onClickShare}
+          onHeaderSignupClick={onClickAlertSignup}
           isMobile={isMobile}
           region={region}
         />

--- a/src/components/RegionItem/RegionItem.tsx
+++ b/src/components/RegionItem/RegionItem.tsx
@@ -32,7 +32,7 @@ const RegionItem: React.FC<{ region: Region }> = ({ region }) => {
         trackEvent(
           EventCategory.GEOLOCATION_CARDS,
           EventAction.NAVIGATE,
-          region.name,
+          region.regionType,
         );
       }}
     >


### PR DESCRIPTION
[Trello](https://trello.com/c/ukcrg893/993-track-clicks-on-geolocated-county-vs-geolocated-metro-on-homepage-to-gauge-metro-interest) - Labels the click events on GeoCards by region type instead of by region name to make it easier to compare county vs. metro areas.