### PR TITLE
fixes mobile close icon

### DIFF
--- a/src/components/InfoTooltip/Tooltip.style.tsx
+++ b/src/components/InfoTooltip/Tooltip.style.tsx
@@ -20,7 +20,7 @@ const TooltipWithStyles = withStyles({
       color: 'white',
     },
     [theme.breakpoints.down('xs')]: {
-      padding: '8px 24px 20px',
+      padding: '20px 24px',
     },
   },
   arrow: {
@@ -43,7 +43,9 @@ export const StyledCloseIcon = styled(CloseIcon)`
   height: 20px;
   display: flex;
   margin-left: auto;
-  transform: translateX(16px);
+  position: absolute;
+  top: 4px;
+  right: 4px;
 
   @media (min-width: ${materialSMBreakpoint}) {
     display: none;


### PR DESCRIPTION
[Trello](https://trello.com/c/BZDZEvvZ/978-mobile-info-tooltip-x-buttons-are-mis-aligned)

Bug -- x-icon should be right aligned:

![Image from iOS](https://user-images.githubusercontent.com/44076375/109209306-5f62f100-7779-11eb-9174-4fd58e23c8c0.jpg)
