### PR TITLE
Vulnerabilities footer links

### DIFF
--- a/src/common/ccvi/index.ts
+++ b/src/common/ccvi/index.ts
@@ -75,12 +75,12 @@ export function getCcviLevel(score: number): CcviLevel {
  *    State --> returns a county-level state map
  *    County --> returns a neighborhood-level county map
  */
-export function getSurgoUrlByRegion(region: Region): string {
+export function getSurgoUrlByRegion(region: Region): string | null {
   const baseUrl = 'https://www.precisionforcoviddata.org/?metricId=ccvi';
   if (region instanceof State) {
     return `${baseUrl}&geoLevel=county&fipsCode=${region.fipsCode}&focusLevel=state&focusFips=${region.fipsCode}`;
   } else if (region instanceof County) {
     return `${baseUrl}&geoLevel=tract&fipsCode=${region.fipsCode}&focusLevel=county&focusFips=${region.fipsCode}`;
   }
-  return baseUrl;
+  return null;
 }

--- a/src/common/ccvi/index.ts
+++ b/src/common/ccvi/index.ts
@@ -1,5 +1,6 @@
 import { PURPLE_MAP } from 'common/colors';
 import { fail } from 'common/utils';
+import { Region, State, County } from 'common/regions';
 
 export enum CcviLevel {
   VERY_LOW,
@@ -66,4 +67,20 @@ export function getCcviLevel(score: number): CcviLevel {
     }
   }
   fail('Invalid CCVI encountered: ' + score);
+}
+
+/**
+ * For vulnerabilities module footer.
+ * Returns a Surgo URL with region-specific CCVI scores+maps:
+ *    State --> returns a county-level state map
+ *    County --> returns a neighborhood-level county map
+ */
+export function getSurgoUrlByRegion(region: Region): string {
+  const baseUrl = 'https://www.precisionforcoviddata.org/?metricId=ccvi';
+  if (region instanceof State) {
+    return `${baseUrl}&geoLevel=county&fipsCode=${region.fipsCode}&focusLevel=state&focusFips=${region.fipsCode}`;
+  } else if (region instanceof County) {
+    return `${baseUrl}&geoLevel=tract&fipsCode=${region.fipsCode}&focusLevel=county&focusFips=${region.fipsCode}`;
+  }
+  return baseUrl;
 }

--- a/src/common/ccvi/renderRegionDescription.tsx
+++ b/src/common/ccvi/renderRegionDescription.tsx
@@ -12,7 +12,7 @@ export function renderStateDescription(
     return (
       <>
         is one of the most vulnerable states, with{' '}
-        <strong>{overallScore}</strong>% of the population in a high
+        <strong>{scoreAsPercent}</strong> of the population in a high
         vulnerability area.{' '}
       </>
     );

--- a/src/common/ccvi/renderRegionDescription.tsx
+++ b/src/common/ccvi/renderRegionDescription.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { CcviLevel, getCcviLevel } from './index';
+import { formatPercent } from 'common/utils';
+
+export function renderStateDescription(
+  overallScore: number,
+): React.ReactElement {
+  const level = getCcviLevel(overallScore);
+  const scoreAsPercent = formatPercent(overallScore);
+
+  if (level === CcviLevel.VERY_HIGH) {
+    return (
+      <>
+        is one of the most vulnerable states, with{' '}
+        <strong>{overallScore}</strong>% of the population in a high
+        vulnerability area.{' '}
+      </>
+    );
+  } else if (level === CcviLevel.HIGH) {
+    return (
+      <>
+        has higher than average vulnerability compared to other states, with{' '}
+        <strong>{scoreAsPercent}</strong> of the population in a high
+        vulnerability area.
+      </>
+    );
+  } else if (level === CcviLevel.MEDIUM) {
+    return (
+      <>
+        has average vulnerability compared to other states. However,{' '}
+        <strong>{scoreAsPercent}</strong> of the population is in a high
+        vulnerability area.
+      </>
+    );
+  } else if (level === CcviLevel.LOW) {
+    return (
+      <>
+        is one of the less vulnerable states. However,{' '}
+        <strong>{scoreAsPercent}</strong> of the population is in a high
+        vulnerability area.
+      </>
+    );
+  } else {
+    return (
+      <>
+        is one of the least vulnerable states. However,{' '}
+        <strong>{scoreAsPercent}</strong> of the population is in a high
+        vulnerability area.
+      </>
+    );
+  }
+}
+
+export function renderCountyDescription(
+  overallScore: number,
+): React.ReactElement {
+  const level = getCcviLevel(overallScore);
+  const scoreAsPercent = formatPercent(overallScore);
+
+  if (level === CcviLevel.HIGH || level === CcviLevel.VERY_HIGH) {
+    return (
+      <>
+        is more vulnerable than <strong>{scoreAsPercent}</strong> of U.S.
+        counties.
+      </>
+    );
+  } else if (level === CcviLevel.MEDIUM) {
+    return <>has average vulnerability compared to other US counties.</>;
+  } else if (level === CcviLevel.LOW) {
+    return <>is one of the less vulnerable US counties.</>;
+  } else {
+    return <>is one of the least vulnerable US counties.</>;
+  }
+}

--- a/src/components/Analytics/utils.ts
+++ b/src/components/Analytics/utils.ts
@@ -52,6 +52,7 @@ export enum EventCategory {
   TOOLTIPS = 'tooltips',
   API = 'api',
   METRICS = 'metrics',
+  VULNERABILITIES = 'vulnerabilities',
 }
 
 /**

--- a/src/components/Vulnurabilities/FooterLinks/FooterLinks.stories.tsx
+++ b/src/components/Vulnurabilities/FooterLinks/FooterLinks.stories.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import FooterLinks from './FooterLinks';
+import regions from 'common/regions';
+
+export default {
+  title: 'Shared Components/VulnerabilitiesFooterLinks',
+  component: FooterLinks,
+};
+
+export const State = () => {
+  const region = regions.findByFipsCodeStrict('01');
+  return <FooterLinks region={region} />;
+};
+
+export const County = () => {
+  const region = regions.findByFipsCodeStrict('06037');
+  return <FooterLinks region={region} />;
+};

--- a/src/components/Vulnurabilities/FooterLinks/FooterLinks.style.tsx
+++ b/src/components/Vulnurabilities/FooterLinks/FooterLinks.style.tsx
@@ -1,0 +1,34 @@
+import styled from 'styled-components';
+import { COLOR_MAP, GREY_3 } from 'common/colors';
+
+export const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  font-size: 1rem;
+
+  a {
+    text-decoration: none;
+    color: ${COLOR_MAP.BLUE};
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+`;
+
+export const ListHeader = styled.span`
+  font-weight: bold;
+`;
+
+export const LinkList = styled.ul`
+  margin: 12px 0;
+  padding: 0 24px;
+
+  li {
+    &:not(:last-child) {
+      margin-bottom: 12px;
+    }
+    ::marker {
+      color: ${GREY_3};
+    }
+  }
+`;

--- a/src/components/Vulnurabilities/FooterLinks/FooterLinks.tsx
+++ b/src/components/Vulnurabilities/FooterLinks/FooterLinks.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import ExternalLink from 'components/ExternalLink';
+import { getSurgoUrlByRegion } from 'common/ccvi';
+import { Region, County } from 'common/regions';
+import { EventAction, EventCategory, trackEvent } from 'components/Analytics';
+import { Wrapper, LinkList, ListHeader } from './FooterLinks.style';
+
+const FooterLinks: React.FC<{ region: Region }> = ({ region }) => {
+  const surgoUrl = getSurgoUrlByRegion(region);
+  const surgoUrlCta =
+    region instanceof County
+      ? `${region.name}'s most vulnerable neighborhoods`
+      : `${region.name}'s most vulnerable counties`;
+
+  return (
+    <Wrapper>
+      <ListHeader>Also see:</ListHeader>
+      <LinkList>
+        <li>
+          <ExternalLink
+            href={surgoUrl}
+            onClick={() => trackLinkClick('Surgo link')}
+          >
+            {surgoUrlCta}
+          </ExternalLink>
+        </li>
+        <li>
+          <Link
+            to="/learn" // TODO - replace with article url
+            onClick={() => trackLinkClick('Vulnerable community resources')}
+          >
+            Resources for vulnerable people
+          </Link>
+        </li>
+        <li>
+          <Link
+            to="/learn" // TODO - replace with article url
+            onClick={() =>
+              trackLinkClick('Why is vulnerability data important')
+            }
+          >
+            Why vulnerability data is important for all communities
+          </Link>
+        </li>
+      </LinkList>
+    </Wrapper>
+  );
+};
+
+function trackLinkClick(label: string) {
+  trackEvent(EventCategory.VULNERABILITIES, EventAction.CLICK_LINK, label);
+}
+
+export default FooterLinks;

--- a/src/components/Vulnurabilities/FooterLinks/FooterLinks.tsx
+++ b/src/components/Vulnurabilities/FooterLinks/FooterLinks.tsx
@@ -17,14 +17,16 @@ const FooterLinks: React.FC<{ region: Region }> = ({ region }) => {
     <Wrapper>
       <ListHeader>Also see:</ListHeader>
       <LinkList>
-        <li>
-          <ExternalLink
-            href={surgoUrl}
-            onClick={() => trackLinkClick('Surgo link')}
-          >
-            {surgoUrlCta}
-          </ExternalLink>
-        </li>
+        {surgoUrl && (
+          <li>
+            <ExternalLink
+              href={surgoUrl}
+              onClick={() => trackLinkClick('Surgo link')}
+            >
+              {surgoUrlCta}
+            </ExternalLink>
+          </li>
+        )}
         <li>
           <Link
             to="/learn" // TODO - replace with article url


### PR DESCRIPTION
Adds footer link block:

![Screen Shot 2021-02-26 at 11 47 46 PM](https://user-images.githubusercontent.com/44076375/109375776-49465500-788d-11eb-9af4-2ae500c14ade.png)

To test:
`yarn storybook`
'VulnerabilitiesFooterLinks' under 'Shared Components'

Also adds utils (`renderStateDescription`, `renderCountyDescription`) to get region score description text (per 'location page copy' section of [the copy doc](https://docs.google.com/document/d/1svP2I63M6JUGuNAM1QoAa6IOC8Vd7uYluenRi8wT_Zk/edit#))