### PR TITLE
Fix style on HomepageSlider

### DIFF
--- a/src/components/Compare/HomepageSlider.style.tsx
+++ b/src/components/Compare/HomepageSlider.style.tsx
@@ -6,10 +6,10 @@ import { HomepageLocationScope } from 'common/utils/compare';
 const returnSliderLabelColor = (
   filter: HomepageLocationScope,
   $isModal: boolean,
-  homepageScope: HomepageLocationScope,
+  $homepageScope: HomepageLocationScope,
 ) => {
   if (!$isModal) {
-    if (homepageScope === filter) return 'black';
+    if ($homepageScope === filter) return 'black';
     return `${COLOR_MAP.GRAY_BODY_COPY}`;
   }
   return 'white';
@@ -17,7 +17,7 @@ const returnSliderLabelColor = (
 
 export const StyledSlider = styled(Slider)<{
   $isModal: boolean;
-  homepageScope: HomepageLocationScope;
+  $homepageScope: HomepageLocationScope;
 }>`
   color: ${COLOR_MAP.BLUE};
   opacity: 1;
@@ -28,30 +28,30 @@ export const StyledSlider = styled(Slider)<{
         returnSliderLabelColor(
           HomepageLocationScope.COUNTY,
           props.$isModal,
-          props.homepageScope,
+          props.$homepageScope,
         )};
-      font-weight: ${({ homepageScope }) =>
-        homepageScope === HomepageLocationScope.COUNTY && 'bold'};
+      font-weight: ${({ $homepageScope }) =>
+        $homepageScope === HomepageLocationScope.COUNTY && 'bold'};
     }
     &:nth-child(7) {
       color: ${props =>
         returnSliderLabelColor(
           HomepageLocationScope.MSA,
           props.$isModal,
-          props.homepageScope,
+          props.$homepageScope,
         )};
-      font-weight: ${({ homepageScope }) =>
-        homepageScope === HomepageLocationScope.MSA && 'bold'};
+      font-weight: ${({ $homepageScope }) =>
+        $homepageScope === HomepageLocationScope.MSA && 'bold'};
     }
     &:nth-child(9) {
       color: ${props =>
         returnSliderLabelColor(
           HomepageLocationScope.STATE,
           props.$isModal,
-          props.homepageScope,
+          props.$homepageScope,
         )};
-      font-weight: ${({ homepageScope }) =>
-        homepageScope === HomepageLocationScope.STATE && 'bold'};
+      font-weight: ${({ $homepageScope }) =>
+        $homepageScope === HomepageLocationScope.STATE && 'bold'};
     }
   }
 `;

--- a/src/components/Compare/HomepageSlider.tsx
+++ b/src/components/Compare/HomepageSlider.tsx
@@ -33,7 +33,7 @@ const HomepageSlider: React.FC<{
         step={null}
         marks={marks}
         track={false}
-        homepageScope={homepageScope}
+        $homepageScope={homepageScope}
         $isModal={$isModal}
       />
     </SliderContainer>


### PR DESCRIPTION
homepageScope isn't a property on the underlying element, so use a `$` so it isn't propagated.  gets rid of a pesky warning.