### PR TITLE
Remove metro/non-metro dropdown from compare table

### DIFF
--- a/src/components/Compare/Filters.tsx
+++ b/src/components/Compare/Filters.tsx
@@ -1,17 +1,6 @@
-import React, { Fragment, useRef, useEffect } from 'react';
-import {
-  Grow,
-  MenuList,
-  MenuItem,
-  ClickAwayListener,
-  useMediaQuery,
-} from '@material-ui/core';
-import { useTheme } from '@material-ui/core/styles';
-import ExpandLessIcon from '@material-ui/icons/ExpandLess';
-import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
+import React, { Fragment, useEffect } from 'react';
 import {
   MetroFilter,
-  getFilterLabel,
   GeoScopeFilter,
   trackCompareEvent,
   HomepageLocationScope,
@@ -20,9 +9,6 @@ import {
   Container,
   SliderContainer,
   GeoSlider,
-  DropdownContainer,
-  MetroMenuButton,
-  MetroMenuPopper,
 } from 'components/Compare/Filters.style';
 import { EventAction } from 'components/Analytics';
 import HomepageSlider from './HomepageSlider';
@@ -82,21 +68,6 @@ const Filters = (props: {
     }
   }, [disableMetroMenu, setCountyTypeToView]);
 
-  const typeFiltersForMap = [
-    {
-      label: getFilterLabel(MetroFilter.METRO),
-      type: MetroFilter.METRO,
-    },
-    {
-      label: getFilterLabel(MetroFilter.NON_METRO),
-      type: MetroFilter.NON_METRO,
-    },
-    {
-      label: getFilterLabel(MetroFilter.ALL),
-      type: MetroFilter.ALL,
-    },
-  ];
-
   const GeoFilterLabels = {
     [GeoScopeFilter.NEARBY]: 'Nearby',
     [GeoScopeFilter.STATE]: `${props.stateId}`,
@@ -147,30 +118,6 @@ const Filters = (props: {
     }
   };
 
-  const anchorRef = useRef<HTMLButtonElement>(null);
-  const [open, setOpen] = React.useState(false);
-
-  const handleMenuToggle = () => {
-    setOpen(!open);
-  };
-
-  const handleClickAway = () => {
-    setOpen(false);
-  };
-
-  const metroMenuItemOnClick = (filterType: MetroFilter, event: any) => {
-    setCountyTypeToView(filterType);
-    trackCompareEvent(
-      EventAction.SELECT,
-      `Metro Filter: ${getFilterLabel(filterType)}`,
-    );
-    setOpen(false);
-  };
-
-  const isStatePage = !props.isHomepage && !props.county;
-  const theme = useTheme();
-  const isMobile = useMediaQuery(theme.breakpoints.down('xs'));
-
   return (
     <Fragment>
       <Container $isModal={props.isModal} $isHomepage={props.isHomepage}>
@@ -195,59 +142,6 @@ const Filters = (props: {
             />
           </SliderContainer>
         )}
-        <MetroMenuButton
-          ref={anchorRef}
-          onClick={handleMenuToggle}
-          disabled={disableMetroMenu}
-          $isMobile={isMobile}
-          disableRipple
-          $isOpen={open}
-          $isStatePage={isStatePage}
-          $isModal={props.isModal}
-        >
-          <div>
-            <span>Counties</span>
-            <span>{getFilterLabel(props.countyTypeToView)}</span>
-          </div>
-          {open ? <ExpandLessIcon /> : <ExpandMoreIcon />}
-        </MetroMenuButton>
-        <MetroMenuPopper
-          open={open}
-          anchorEl={anchorRef.current}
-          role={undefined}
-          transition
-          disablePortal
-        >
-          {({ TransitionProps, placement }) => (
-            <Grow
-              {...TransitionProps}
-              style={{
-                transformOrigin:
-                  placement === 'bottom' ? 'center top' : 'center bottom',
-              }}
-            >
-              <DropdownContainer>
-                <ClickAwayListener onClickAway={handleClickAway}>
-                  <MenuList autoFocusItem={open}>
-                    {typeFiltersForMap.map(filter => {
-                      return (
-                        <MenuItem
-                          key={filter.type}
-                          disableRipple
-                          onClick={event =>
-                            metroMenuItemOnClick(filter.type, event)
-                          }
-                        >
-                          {filter.label}
-                        </MenuItem>
-                      );
-                    })}
-                  </MenuList>
-                </ClickAwayListener>
-              </DropdownContainer>
-            </Grow>
-          )}
-        </MetroMenuPopper>
       </Container>
     </Fragment>
   );

--- a/src/components/Compare/ModalCompare.tsx
+++ b/src/components/Compare/ModalCompare.tsx
@@ -85,6 +85,8 @@ const ModalCompare = (props: {
             setHomepageSliderValue={props.setHomepageSliderValue}
           />
         )}
+        {/* Need explicit div to ensure close icon is on the right of the pop up */}
+        <div />
         <CloseIcon onClick={() => props.handleCloseModal()} />
       </ModalHeader>
       <CompareTable


### PR DESCRIPTION
This PR removes the metro/non-metro dropdown from the compare table in both the homepage and location page, including in modal view. Some considerations below:
- All unused variables as a result of the deletion are currently commented out. Once @pnavarrc and @chasulin confirm the elements to be deleted, these variables can be removed.
- Leaving the "More Info" button at the bottom of the compare table as is for now, as we may simply be replacing the content inside the pop-up.