### PR TITLE
demo: improvements for metric charts (mobile)

### DIFF
--- a/src/components/Charts/Axis.tsx
+++ b/src/components/Charts/Axis.tsx
@@ -1,5 +1,9 @@
 import React from 'react';
-import { AxisBottom as VxAxisBottom, AxisLeft as VxAxisLeft } from '@vx/axis';
+import {
+  AxisBottom as VxAxisBottom,
+  AxisLeft as VxAxisLeft,
+  AxisRight as VxAxisRight,
+} from '@vx/axis';
 import { SharedAxisProps } from '@vx/axis/lib/types';
 import * as Style from './Charts.style';
 import { getXTickFormat, getMobileDateTicks } from './utils';
@@ -9,6 +13,12 @@ import { ScaleTime } from 'd3-scale';
 export const AxisLeft = (props: SharedAxisProps<number>) => (
   <Style.Axis>
     <VxAxisLeft {...props} hideAxisLine hideTicks hideZero />
+  </Style.Axis>
+);
+
+export const AxisRight = (props: SharedAxisProps<number>) => (
+  <Style.Axis>
+    <VxAxisRight {...props} hideAxisLine hideTicks hideZero />
   </Style.Axis>
 );
 

--- a/src/components/Charts/BoxedAnnotation.tsx
+++ b/src/components/Charts/BoxedAnnotation.tsx
@@ -29,10 +29,10 @@ export const BoxedAnnotation = ({
   return (
     <Group left={x} top={y}>
       <rect
-        y={top - padding}
-        x={left - padding}
-        width={Math.abs(width + 2 * padding)}
-        height={Math.abs(height + 2 * padding)}
+        y={top}
+        x={left - 2 * padding}
+        width={Math.abs(width + 4 * padding)}
+        height={Math.abs(height + 0 * padding)}
       />
       <text ref={textRef}>{text}</text>
     </Group>

--- a/src/components/Charts/BoxedAnnotation.tsx
+++ b/src/components/Charts/BoxedAnnotation.tsx
@@ -17,7 +17,7 @@ export const BoxedAnnotation = ({
   x,
   y,
   text,
-  padding = 4,
+  padding = 1,
 }: {
   x: number;
   y: number;

--- a/src/components/Charts/ChartCaseDensity.tsx
+++ b/src/components/Charts/ChartCaseDensity.tsx
@@ -57,7 +57,7 @@ const ChartCaseDensity: FunctionComponent<{
   capY = 500,
   width,
   height,
-  marginTop = 5,
+  marginTop = 15,
   marginBottom = 40,
   marginLeft = 10,
   marginRight = 5,
@@ -150,12 +150,7 @@ const ChartCaseDensity: FunctionComponent<{
           curve={curveMonotoneX}
         />
         <Style.LineGrid>
-          <GridRows
-            left={15}
-            width={chartWidth - 15}
-            scale={yScale}
-            tickValues={yTicks}
-          />
+          <GridRows width={chartWidth} scale={yScale} tickValues={yTicks} />
         </Style.LineGrid>
         <Style.TextAnnotation>
           <BoxedAnnotation
@@ -171,8 +166,8 @@ const ChartCaseDensity: FunctionComponent<{
           color={region.color}
           name={region.name}
           isActive={activeZone.name === region.name}
-          x={35}
-          y={yScale(0.5 * (region.valueFrom + region.valueTo))}
+          x={23}
+          y={yScale(0.5 * (region.valueFrom + region.valueFrom)) - 7}
         />
       ))}
 
@@ -181,7 +176,7 @@ const ChartCaseDensity: FunctionComponent<{
         scale={xScale}
         tickValues={dateTicks}
       />
-      <Group left={-20}>
+      <Group top={-6} left={-10}>
         <AxisRight scale={yScale} tickValues={yTicks.slice(1)} />
       </Group>
     </ChartContainer>

--- a/src/components/Charts/ChartCaseDensity.tsx
+++ b/src/components/Charts/ChartCaseDensity.tsx
@@ -73,7 +73,7 @@ const ChartCaseDensity: FunctionComponent<{
   const dates = data.map(getDate);
   const minDate = d3min(dates) || new Date('2020-01-01');
   const currDate = new Date();
-  const xScale = getUtcScale(minDate, currDate, 0, chartWidth, 15);
+  const xScale = getUtcScale(minDate, currDate, 0, chartWidth, 10);
   const [startDate, endDate] = xScale.domain();
   const dateTicks = getTimeAxisTicks(startDate, endDate);
 
@@ -152,10 +152,10 @@ const ChartCaseDensity: FunctionComponent<{
         <Style.LineGrid>
           <GridRows width={chartWidth} scale={yScale} tickValues={yTicks} />
         </Style.LineGrid>
-        <Style.TextAnnotation>
+        <Style.TextAnnotation textAnchor="end">
           <BoxedAnnotation
             x={getXCoord(lastPoint)}
-            y={getYCoord(lastPoint) + 15}
+            y={getYCoord(lastPoint)}
             text={formatDecimal(getYCaseDensity(lastPoint), 1)}
           />
         </Style.TextAnnotation>
@@ -175,6 +175,7 @@ const ChartCaseDensity: FunctionComponent<{
         innerHeight={chartHeight}
         scale={xScale}
         tickValues={dateTicks}
+        showYear
       />
       <Group top={-6} left={-10}>
         <AxisRight scale={yScale} tickValues={yTicks.slice(1)} />

--- a/src/components/Charts/ChartCaseDensity.tsx
+++ b/src/components/Charts/ChartCaseDensity.tsx
@@ -6,10 +6,11 @@ import { GridRows } from '@vx/grid';
 import { scaleLinear } from '@vx/scale';
 import { ParentSize } from '@vx/responsive';
 import { Column } from 'common/models/Projection';
+import { Group } from '@vx/group';
 import { CASE_DENSITY_LEVEL_INFO_MAP } from 'common/metrics/case_density';
 import { LevelInfoMap, Level } from 'common/level';
 import { formatUtcDate, formatDecimal } from 'common/utils';
-import { AxisLeft } from './Axis';
+import { AxisRight } from './Axis';
 import BoxedAnnotation from './BoxedAnnotation';
 import ChartContainer from './ChartContainer';
 import RectClipGroup from './RectClipGroup';
@@ -58,7 +59,7 @@ const ChartCaseDensity: FunctionComponent<{
   height,
   marginTop = 5,
   marginBottom = 40,
-  marginLeft = 40,
+  marginLeft = 10,
   marginRight = 5,
 }) => {
   const chartWidth = width - marginLeft - marginRight;
@@ -72,7 +73,7 @@ const ChartCaseDensity: FunctionComponent<{
   const dates = data.map(getDate);
   const minDate = d3min(dates) || new Date('2020-01-01');
   const currDate = new Date();
-  const xScale = getUtcScale(minDate, currDate, 0, chartWidth);
+  const xScale = getUtcScale(minDate, currDate, 0, chartWidth, 15);
   const [startDate, endDate] = xScale.domain();
   const dateTicks = getTimeAxisTicks(startDate, endDate);
 
@@ -149,12 +150,17 @@ const ChartCaseDensity: FunctionComponent<{
           curve={curveMonotoneX}
         />
         <Style.LineGrid>
-          <GridRows width={chartWidth} scale={yScale} tickValues={yTicks} />
+          <GridRows
+            left={15}
+            width={chartWidth - 15}
+            scale={yScale}
+            tickValues={yTicks}
+          />
         </Style.LineGrid>
         <Style.TextAnnotation>
           <BoxedAnnotation
-            x={getXCoord(lastPoint) + 30}
-            y={getYCoord(lastPoint)}
+            x={getXCoord(lastPoint)}
+            y={getYCoord(lastPoint) + 15}
             text={formatDecimal(getYCaseDensity(lastPoint), 1)}
           />
         </Style.TextAnnotation>
@@ -165,16 +171,19 @@ const ChartCaseDensity: FunctionComponent<{
           color={region.color}
           name={region.name}
           isActive={activeZone.name === region.name}
-          x={chartWidth - 10}
+          x={35}
           y={yScale(0.5 * (region.valueFrom + region.valueTo))}
         />
       ))}
+
       <AxisBottom
         innerHeight={chartHeight}
         scale={xScale}
         tickValues={dateTicks}
       />
-      <AxisLeft scale={yScale} tickValues={yTicks.slice(1)} />
+      <Group left={-20}>
+        <AxisRight scale={yScale} tickValues={yTicks.slice(1)} />
+      </Group>
     </ChartContainer>
   );
 };

--- a/src/components/Charts/Charts.style.ts
+++ b/src/components/Charts/Charts.style.ts
@@ -120,7 +120,7 @@ export const RegionAnnotation = styled(TextAnnotation)<{ isActive: boolean }>`
   text {
     fill: ${props =>
       props.isActive ? palette(props).background : props.color};
-    text-anchor: end;
+    // text-anchor: end;
   }
 `;
 

--- a/src/components/Charts/Charts.style.ts
+++ b/src/components/Charts/Charts.style.ts
@@ -120,7 +120,9 @@ export const RegionAnnotation = styled(TextAnnotation)<{ isActive: boolean }>`
   text {
     fill: ${props =>
       props.isActive ? palette(props).background : props.color};
-    // text-anchor: end;
+    text-anchor: start;
+    font-size: 11px;
+    text-transform: uppercase;
   }
 `;
 

--- a/src/components/Charts/Charts.style.ts
+++ b/src/components/Charts/Charts.style.ts
@@ -34,8 +34,9 @@ export const Axis = styled.g<{ exploreStroke?: string }>`
   text {
     font-family: ${charts.fontFamily};
     font-weight: 'medium';
-    font-size: 12px;
+    font-size: 11px;
     fill: ${props => palette(props).axis};
+    text-transform: uppercase;
   }
   line {
     stroke: ${props => props.exploreStroke || palette(props).axis};

--- a/src/components/Charts/MetricCharts.stories.tsx
+++ b/src/components/Charts/MetricCharts.stories.tsx
@@ -20,7 +20,7 @@ const DesktopContainer: React.FC = ({ children }) => (
 );
 
 const MobileContainer: React.FC = ({ children }) => (
-  <div style={{ border: 'dashed 1px blue', minWidth: '343px' }}>{children}</div>
+  <div style={{ minWidth: '343px' }}>{children}</div>
 );
 
 export const DailyCases = () => {
@@ -102,7 +102,7 @@ export const DailyCasesMobile = () => {
       <MetricChart
         metric={Metric.CASE_DENSITY}
         projections={projections}
-        height={400}
+        height={300}
       />
     </MobileContainer>
   );
@@ -119,7 +119,7 @@ export const ICUCapacityMobile = () => {
       <MetricChart
         metric={Metric.HOSPITAL_USAGE}
         projections={projections}
-        height={400}
+        height={300}
       />
     </MobileContainer>
   );

--- a/src/components/Charts/MetricCharts.stories.tsx
+++ b/src/components/Charts/MetricCharts.stories.tsx
@@ -1,0 +1,126 @@
+import React from 'react';
+import MetricChart from './MetricChart';
+import { Metric } from 'common/metricEnum';
+import regions from 'common/regions';
+import { useProjectionsFromRegion } from 'common/utils/model';
+
+export default {
+  title: 'Charts/Metric Chart',
+  component: MetricChart,
+};
+
+const DesktopContainer: React.FC = ({ children }) => (
+  <div style={{ margin: '0 auto', maxWidth: 900, border: 'solid 1px #ddd' }}>
+    <div
+      style={{ width: 948, marginRight: '-3rem', border: 'dashed 1px blue' }}
+    >
+      {children}
+    </div>
+  </div>
+);
+
+const MobileContainer: React.FC = ({ children }) => (
+  <div style={{ border: 'dashed 1px blue', minWidth: '343px' }}>{children}</div>
+);
+
+export const DailyCases = () => {
+  const region = regions.findByFipsCodeStrict('06');
+  const projections = useProjectionsFromRegion(region);
+  if (!projections) {
+    return null;
+  }
+  return (
+    <DesktopContainer>
+      <MetricChart
+        metric={Metric.CASE_DENSITY}
+        projections={projections}
+        height={400}
+      />
+    </DesktopContainer>
+  );
+};
+
+export const InfectionRate = () => {
+  const region = regions.findByFipsCodeStrict('06');
+  const projections = useProjectionsFromRegion(region);
+  if (!projections) {
+    return null;
+  }
+  return (
+    <DesktopContainer>
+      <MetricChart
+        metric={Metric.CASE_GROWTH_RATE}
+        projections={projections}
+        height={400}
+      />
+    </DesktopContainer>
+  );
+};
+
+export const PositiveTests = () => {
+  const region = regions.findByFipsCodeStrict('06');
+  const projections = useProjectionsFromRegion(region);
+  if (!projections) {
+    return null;
+  }
+  return (
+    <DesktopContainer>
+      <MetricChart
+        metric={Metric.POSITIVE_TESTS}
+        projections={projections}
+        height={400}
+      />
+    </DesktopContainer>
+  );
+};
+
+export const ICUCapacity = () => {
+  const region = regions.findByFipsCodeStrict('06');
+  const projections = useProjectionsFromRegion(region);
+  if (!projections) {
+    return null;
+  }
+  return (
+    <DesktopContainer>
+      <MetricChart
+        metric={Metric.HOSPITAL_USAGE}
+        projections={projections}
+        height={400}
+      />
+    </DesktopContainer>
+  );
+};
+
+export const DailyCasesMobile = () => {
+  const region = regions.findByFipsCodeStrict('06');
+  const projections = useProjectionsFromRegion(region);
+  if (!projections) {
+    return null;
+  }
+  return (
+    <MobileContainer>
+      <MetricChart
+        metric={Metric.CASE_DENSITY}
+        projections={projections}
+        height={400}
+      />
+    </MobileContainer>
+  );
+};
+
+export const ICUCapacityMobile = () => {
+  const region = regions.findByFipsCodeStrict('06');
+  const projections = useProjectionsFromRegion(region);
+  if (!projections) {
+    return null;
+  }
+  return (
+    <MobileContainer>
+      <MetricChart
+        metric={Metric.HOSPITAL_USAGE}
+        projections={projections}
+        height={400}
+      />
+    </MobileContainer>
+  );
+};


### PR DESCRIPTION
**NOTE**: This is a draft to iterate on design - please look to Daily New Cases on mobile only, the rest of the charts are broken. 

Only the Daily New Cases on mobile was changed, the rest are broken. 

- Move the y-axis values inside the charting area (to expand the charting area), each marker is above the grid line
- The level annotations are moved to the left (data from March 2020 is less relevant than more recent data)
- Made level annotations smaller and move them above their threshold
- Adjust the x-axis limit on the right side (we don't need to add months to accommodate for the level annotations anymore)