### PR TITLE
Tooltip style fix

### DIFF
--- a/src/components/InfoTooltip/Tooltip.style.tsx
+++ b/src/components/InfoTooltip/Tooltip.style.tsx
@@ -63,11 +63,20 @@ export const InfoIcon = styled(InfoOutlinedIcon)<{ $isOpen: boolean }>`
 
 export const StyledMarkdown = styled(MarkdownBody)`
   p,
-  a {
+  a,
+  ul,
+  li {
     color: white;
     font-size: 0.8125rem;
     line-height: 1.4;
     margin: 0;
+  }
+
+  ul {
+    margin-bottom: 0.5rem;
+    a {
+      color: white;
+    }
   }
 
   p:not(:last-child) {


### PR DESCRIPTION
Before: 
![Screen Shot 2021-03-03 at 9 59 41 PM](https://user-images.githubusercontent.com/44076375/109904820-d44b9480-7c6b-11eb-9cc2-bee9b05e031a.png)

After:
![Screen Shot 2021-03-03 at 9 59 26 PM](https://user-images.githubusercontent.com/44076375/109904831-d877b200-7c6b-11eb-946f-7d25c57879d0.png)