### PR TITLE
analytics: track events in FullStory

### DIFF
--- a/src/common/fullstory.ts
+++ b/src/common/fullstory.ts
@@ -26,17 +26,28 @@ function isRecordingEnabled() {
 }
 
 async function getFullStory() {
-  return isRecordingEnabled() ? import('@fullstory/browser') : null;
+  if (isRecordingEnabled()) {
+    return import('@fullstory/browser');
+  } else {
+    return null;
+  }
 }
 
-export async function initFullStory() {
-  return getFullStory().then(fs => (fs ? fs.init({ orgId: 'XEVN9' }) : null));
+export async function initFullStory(): Promise<void> {
+  const FS = await getFullStory();
+  if (FS) {
+    FS.init({ orgId: 'XEVN9' });
+  }
 }
 
-export function fullStoryTrackEvent(eventName: string, properties: any) {
-  return getFullStory().then(fs =>
-    fs ? fs.event(eventName, properties) : null,
-  );
+export async function fullStoryTrackEvent(
+  eventName: string,
+  properties: any,
+): Promise<void> {
+  const FS = await getFullStory();
+  if (FS) {
+    FS.event(eventName, properties);
+  }
 }
 
 function initStorage() {

--- a/src/components/Analytics/PageviewTracker.tsx
+++ b/src/components/Analytics/PageviewTracker.tsx
@@ -4,6 +4,7 @@ import { useLocation } from 'react-router-dom';
 import ReactGA from 'react-ga';
 import { defaultTracker, legacyTracker } from './utils';
 import { initializeAmplitude, amplitudeLogEvent } from './amplitude';
+import { fullStoryTrackEvent } from 'common/fullstory';
 
 /**
  * Initialize Google Analytics
@@ -52,6 +53,7 @@ function usePageTracking() {
         const { title } = document;
         ReactGA.pageview(pathname, [legacyTracker.name], title);
         amplitudeLogEvent('Pageview', { path: pathname, title });
+        fullStoryTrackEvent('Pageview', { path: pathname, title });
       }, 10);
     }
   }, [initialized, pathname]);

--- a/src/components/Analytics/utils.ts
+++ b/src/components/Analytics/utils.ts
@@ -1,6 +1,7 @@
 import { capitalize, words } from 'lodash';
 import ReactGA from 'react-ga';
 import { amplitudeLogEvent } from './amplitude';
+import { fullStoryTrackEvent } from 'common/fullstory';
 
 export interface Tracker {
   trackingId: string;
@@ -111,12 +112,15 @@ export function trackEvent(
     const labelProp = label ? { eventLabel: toTitleCase(label) } : {};
     const valueProp = Number.isFinite(value) ? { eventValue: value } : {};
 
-    amplitudeLogEvent(category, {
+    const eventProperties = {
       eventCategory: toTitleCase(category),
       eventAction: toTitleCase(action),
       ...labelProp,
       ...valueProp,
-    });
+    };
+
+    amplitudeLogEvent(category, eventProperties);
+    fullStoryTrackEvent(category, eventProperties);
   }
 }
 

--- a/src/components/InfoTooltip/InfoTooltip.tsx
+++ b/src/components/InfoTooltip/InfoTooltip.tsx
@@ -11,12 +11,16 @@ const InfoTooltip: React.FC<StyledTooltipProps> = props => {
   const isMobile = useBreakpoint(600);
 
   const handleOpen = () => {
-    setIsOpen(true);
-    props.trackOpenTooltip();
+    if (!isOpen) {
+      setIsOpen(true);
+      props.trackOpenTooltip();
+    }
   };
 
   const handleClose = () => {
-    setIsOpen(false);
+    if (isOpen) {
+      setIsOpen(false);
+    }
   };
 
   const idForAccessability = uuidv4();


### PR DESCRIPTION
- Cleanup `fullstory.ts` a bit (dynamic import and made the code follow a similar structure than `amplitude.ts`)
- Add tracking of events in FullStory when FS tracking is enabled
- Fixed the "open tooltip" event, it was being tracked multiple times (hover triggers multiple times when the user moves the mouse)

**Testing**
- In the Chrome console (in local dev), set the tracking flag in `localStorage` to `"true"` `localStorage.setItem('FULLSTORY_RECORD', 'true')` and reload the page
- Click around the app with the Network tab open, you should see some requests to FullStory
- Change the flag to `false` to disable recording `localStorage.setItem('FULLSTORY_RECORD', 'false')` and reload the page
- Click around the app, there shouldn't be more requests to FullStory 