### PR TITLE
update web copy for vaccination doses

### DIFF
--- a/src/common/metrics/vaccinations.tsx
+++ b/src/common/metrics/vaccinations.tsx
@@ -23,11 +23,11 @@ export const VaccinationsMetric: MetricDefinition = {
   renderThermometer,
   renderInfoTooltip,
   metricName: METRIC_NAME,
-  extendedMetricName: 'Vaccinated: 1st and 2nd shot',
-  metricNameForCompare: 'Vaccinated (1st shot)',
+  extendedMetricName: 'Vaccinated: 1st and 2nd dose',
+  metricNameForCompare: 'Vaccinated (1+ dose)',
 };
 
-const SHORT_DESCRIPTION_LOW = 'Population given the first shot';
+const SHORT_DESCRIPTION_LOW = 'Population given at least one dose';
 // const SHORT_DESCRIPTION_UNKNOWN = 'Insufficient data to assess';
 
 const UNKNOWN = 'Unknown';
@@ -88,9 +88,9 @@ function renderStatus(projections: Projections): React.ReactElement {
   return (
     <Fragment>
       In {locationName}, {peopleInitiated} people ({percentInitiated}) have
-      received the first shot and {peopleVaccinated} ({percentVaccinated}) have
-      also received the second shot. {distributedText} According to the CDC,
-      fewer than 0.001% of those who have received the first dose have
+      received at least the first dose and {peopleVaccinated} (
+      {percentVaccinated}) are fully vaccinated. {distributedText} According to
+      the CDC, fewer than 0.001% of those who have received the first dose have
       experienced a severe adverse reaction, none of them deadly.
     </Fragment>
   );

--- a/src/common/metrics/vaccinations.tsx
+++ b/src/common/metrics/vaccinations.tsx
@@ -23,7 +23,7 @@ export const VaccinationsMetric: MetricDefinition = {
   renderThermometer,
   renderInfoTooltip,
   metricName: METRIC_NAME,
-  extendedMetricName: 'Vaccinated: 1st and 2nd dose',
+  extendedMetricName: 'Percent Vaccinated',
   metricNameForCompare: 'Vaccinated (1+ dose)',
 };
 
@@ -88,10 +88,10 @@ function renderStatus(projections: Projections): React.ReactElement {
   return (
     <Fragment>
       In {locationName}, {peopleInitiated} people ({percentInitiated}) have
-      received at least the first dose and {peopleVaccinated} (
-      {percentVaccinated}) are fully vaccinated. {distributedText} According to
-      the CDC, fewer than 0.001% of those who have received the first dose have
-      experienced a severe adverse reaction, none of them deadly.
+      received at least one dose and {peopleVaccinated} ({percentVaccinated})
+      are fully vaccinated. {distributedText} According to the CDC, fewer than
+      0.001% of those who have received at least one dose have experienced a
+      severe adverse reaction, none of them deadly.
     </Fragment>
   );
 }

--- a/src/components/Banner/VaccinationsBanner.style.tsx
+++ b/src/components/Banner/VaccinationsBanner.style.tsx
@@ -52,7 +52,7 @@ export const InnerContainer = styled.div`
   @media (min-width: ${materialSMBreakpoint}) {
     align-items: flex-start;
     text-align: left;
-    max-width: 485px;
+    max-width: 520px;
   }
 `;
 
@@ -67,24 +67,4 @@ export const Body = styled.span`
   font-size: 15px;
   margin-bottom: 1.25rem;
   line-height: 1.5;
-`;
-
-export const IconWrapper = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: 50%;
-  margin-bottom: 1rem;
-
-  @media (min-width: ${materialSMBreakpoint}) {
-    margin-bottom: 0;
-    margin-right: 2.5rem;
-    background-color: white;
-    height: 104px;
-    min-width: 104px;
-  }
-`;
-
-export const Icon = styled.img`
-  height: 64px;
 `;

--- a/src/components/Banner/VaccinationsBanner.tsx
+++ b/src/components/Banner/VaccinationsBanner.tsx
@@ -47,7 +47,7 @@ const VaccinationsBannerInner: React.FC = () => {
       <Header>New vaccine data</Header>
       <Body>
         The CDC reports that {formatEstimate(totalVaccinationsInitiated, 5)}{' '}
-        Americans have received their first shot.
+        Americans have received at least one dose.
       </Body>
       <ButtonContainer>
         <Buttons />

--- a/src/components/Charts/MetricChart.tsx
+++ b/src/components/Charts/MetricChart.tsx
@@ -79,8 +79,8 @@ function getVaccinationSeries(projection: Projection): Series[] {
       type: SeriesType.LINE,
       data: filterNull(projection.getDataset('vaccinationsCompleted')),
       label: 'Vaccinations Completed',
-      shortLabel: 'Fully Vaccinated',
-      tooltipLabel: 'Fully Vaccinated',
+      shortLabel: 'Fully vaccinated',
+      tooltipLabel: 'Fully vaccinated',
       params: {
         stroke: '#000',
         fill: '#000',

--- a/src/components/Charts/MetricChart.tsx
+++ b/src/components/Charts/MetricChart.tsx
@@ -68,8 +68,8 @@ function getVaccinationSeries(projection: Projection): Series[] {
       type: SeriesType.LINE,
       data: filterNull(projection.getDataset('vaccinations')),
       label: 'vaccinationsInitiated',
-      shortLabel: '1st shot',
-      tooltipLabel: '1st shot',
+      shortLabel: '1+ dose',
+      tooltipLabel: '1+ dose',
       params: {
         stroke: '#bdbdbd',
         fill: '#bdbdbd',
@@ -79,8 +79,8 @@ function getVaccinationSeries(projection: Projection): Series[] {
       type: SeriesType.LINE,
       data: filterNull(projection.getDataset('vaccinationsCompleted')),
       label: 'Vaccinations Completed',
-      shortLabel: '2nd shot',
-      tooltipLabel: '2nd shot',
+      shortLabel: 'Fully Vaccinated',
+      tooltipLabel: 'Fully Vaccinated',
       params: {
         stroke: '#000',
         fill: '#000',

--- a/src/components/SummaryStats/LocationHeaderStats.tsx
+++ b/src/components/SummaryStats/LocationHeaderStats.tsx
@@ -52,9 +52,9 @@ const StatValue = (props: {
       )}
       {props.metric === Metric.VACCINATIONS && (
         <PrevalenceMeasure>
-          1ST
+          1+
           <br />
-          SHOT
+          DOSE
         </PrevalenceMeasure>
       )}
     </ValueWrapper>


### PR DESCRIPTION
[Trello](https://trello.com/c/PugEl67z/1000-update-vaccinations-for-jj) - Update vaccination copy in preparation for Johnson & Johnson vaccines.

The ticket doesn't detail all the necessary updates, so I changed the copy following the same language. Make sure to check:

**Home page**
- Banner copy
- Compare: Table header name

**Location pages**
- Header
- Compare: Table header name
- Chart title
- Chart description
- Chart labels

The remaining mentions to 1st and 2nd shots are in Learn or the tooltips, and will be updated via the CMS.