### PR TITLE
Disclaimer cleanup, vaccinations provenance fix

### DIFF
--- a/src/common/metric.tsx
+++ b/src/common/metric.tsx
@@ -10,8 +10,6 @@ import { MetricDefinition } from './metrics/interfaces';
 import { formatDecimal, formatPercent } from 'common/utils';
 import { isNumber } from 'lodash';
 import { Metric } from 'common/metricEnum';
-import { Region } from 'common/regions';
-import { Sources } from 'api/schema/RegionSummaryWithTimeseries';
 
 export const ALL_METRICS = [
   Metric.CASE_DENSITY,
@@ -63,15 +61,6 @@ export function getMetricDefinition(metric: Metric) {
     fail('unknown metric');
   }
   return metricDefinitions[metric];
-}
-
-export function getMetricDisclaimer(
-  metric: Metric,
-  region: Region,
-  provenance?: Sources,
-) {
-  const metricDefinition = getMetricDefinition(metric);
-  return metricDefinition.renderDisclaimer(region, provenance);
 }
 
 export function getMetricStatusText(metric: Metric, projections: Projections) {

--- a/src/common/metrics/vaccinations.tsx
+++ b/src/common/metrics/vaccinations.tsx
@@ -103,10 +103,16 @@ function renderDisclaimer(
 ): React.ReactElement {
   const { body } = metricToTooltipMap[Metric.VACCINATIONS].metricCalculation;
 
+  /**
+   * We don't have a fallback source for non-state vaccinations.
+   * If the page is not a state page or if there is no vaccinations provenance in the API,
+   * we don't render the first half of the disclaimer ("where our data comes from").
+   */
   return (
     <Fragment>
       {'Learn more about '}
-      {region instanceof State && (
+      {region instanceof State ||
+      (provenance && provenance[0].name && provenance[0].url) ? (
         <>
           <DisclaimerTooltip
             title={getDataSourceTooltipContent(
@@ -121,6 +127,8 @@ function renderDisclaimer(
           />
           {' and '}
         </>
+      ) : (
+        ''
       )}
       <DisclaimerTooltip
         title={renderTooltipContent(body)}

--- a/src/components/Disclaimer/Disclaimer.tsx
+++ b/src/components/Disclaimer/Disclaimer.tsx
@@ -1,24 +1,8 @@
 import React from 'react';
 import { DisclaimerWrapper } from './Disclaimer.style';
-import { getMetricDisclaimer } from 'common/metric';
-import { Region } from 'common/regions';
-import { Metric } from 'common/metricEnum';
-import { Sources } from 'api/schema/RegionSummaryWithTimeseries';
 
-const Disclaimer = ({
-  metric,
-  region,
-  provenance,
-}: {
-  metric: Metric;
-  region: Region;
-  provenance?: Sources;
-}) => {
-  return (
-    <DisclaimerWrapper>
-      {getMetricDisclaimer(metric, region, provenance)}
-    </DisclaimerWrapper>
-  );
+const Disclaimer = ({ disclaimerContent }: { disclaimerContent: any }) => {
+  return <DisclaimerWrapper>{disclaimerContent}</DisclaimerWrapper>;
 };
 
 export default Disclaimer;

--- a/src/components/LocationPage/ChartBlock.tsx
+++ b/src/components/LocationPage/ChartBlock.tsx
@@ -40,7 +40,12 @@ function ChartBlock(props: {
 
   const hasMetric = projections.hasMetric(metric);
 
-  const chartHeaderTooltip = getMetricDefinition(metric).renderInfoTooltip();
+  const metricDefinition = getMetricDefinition(metric);
+  const chartHeaderTooltip = metricDefinition.renderInfoTooltip();
+  const disclaimerContent = metricDefinition.renderDisclaimer(
+    region,
+    provenance,
+  );
 
   return (
     <Fragment>
@@ -74,7 +79,7 @@ function ChartBlock(props: {
       {hasMetric && (
         <>
           <MetricChart metric={metric} projections={projections} />
-          <Disclaimer metric={metric} region={region} provenance={provenance} />
+          <Disclaimer disclaimerContent={disclaimerContent} />
         </>
       )}
     </Fragment>


### PR DESCRIPTION
(Forgot to do this in the last PR that shipped provenance):

We don't have a fallback source for county-level vaccinations and so we were hiding the 'data source' half of the vaccinations chart disclaimer for non-state pages. Now that we have provenance for some county vaccinations, this un-hides that half of the disclaimer and allows it to render if there is vaccinations data provenance.

This also removes the `getMetricDisclaimer` util and calls `renderDisclaimer` directly in ChartBlock.tsx