### PR TITLE
vaccination alerts: reorder phases (most recently eligible first)

### DIFF
--- a/src/cms-content/vaccines/email-alerts.ts
+++ b/src/cms-content/vaccines/email-alerts.ts
@@ -73,7 +73,8 @@ export function getEmailAlertData(
     .map((phaseInfo, index, allCurrentPhases) => {
       const isLastCurrentPhase = index === allCurrentPhases.length - 1;
       return formatVaccinationPhaseInfo(phaseInfo, isLastCurrentPhase);
-    });
+    })
+    .reverse();
 
   assert(
     currentPhases.length > 0,

--- a/src/cms-content/vaccines/email-alerts.ts
+++ b/src/cms-content/vaccines/email-alerts.ts
@@ -68,6 +68,8 @@ export function getEmailAlertData(
     `Vaccination eligibility info for ${fipsCode} not found in the CMS`,
   );
 
+  // The vaccination phases are entered in order in the CMS, we reverse the currently
+  // active vaccination phases here to show the most recently eligible first.
   const currentPhases = vacinationInfo.phaseGroups
     .filter(phaseInfo => phaseInfo.currentlyEligible)
     .map((phaseInfo, index, allCurrentPhases) => {


### PR DESCRIPTION
[Trello](https://trello.com/c/XnbCqZ2O/1053-revert-the-order-of-the-eligible-phases-in-the-vaccination-alerts-email) 

We want to reorder the vaccination phases to show the most recently eligible phase first, and past phases in reverse order. For most places, we don't have the date when the phase became eligible, so we rely on the order they were added in the CMS.