### PR TITLE
Removed Source Deck Link in Explore

### DIFF
--- a/src/components/Explore/Explore.tsx
+++ b/src/components/Explore/Explore.tsx
@@ -13,7 +13,6 @@ import { useTheme } from '@material-ui/core/styles';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import { ParentSize } from '@vx/responsive';
 import { useModelLastUpdatedDate } from 'common/utils/model';
-import ExternalLink from 'components/ExternalLink';
 import ShareImageButtonGroup from 'components/ShareButtons';
 import ExploreTabs from './ExploreTabs';
 import ExploreChart from './ExploreChart';

--- a/src/components/Explore/Explore.tsx
+++ b/src/components/Explore/Explore.tsx
@@ -34,7 +34,6 @@ import {
   getSeriesLabel,
   EXPLORE_CHART_IDS,
   getSubtitle,
-  DATA_SOURCES_URL,
 } from './utils';
 import * as Styles from './Explore.style';
 import {
@@ -64,8 +63,7 @@ function trackShare(label: string, value?: number) {
 function getNoDataCopy(metricName: string, locationNames: string) {
   return (
     <p>
-      We don't have {metricName} data for {locationNames}. Learn more about{' '}
-      <ExternalLink href={DATA_SOURCES_URL}>our data sources</ExternalLink>.
+      We don't have {metricName} data for {locationNames}.
     </p>
   );
 }
@@ -432,11 +430,7 @@ const Explore: React.FunctionComponent<{
       />
       <Styles.DisclaimerWrapper>
         <Styles.DisclaimerBody>
-          Last updated {lastUpdatedDateString}. Learn more about{' '}
-          <ExternalLink href="https://docs.google.com/presentation/d/1XmKCBWYZr9VQKFAdWh_D7pkpGGM_oR9cPjj-UrNdMJQ/edit">
-            our data sources
-          </ExternalLink>
-          .
+          Last updated {lastUpdatedDateString}.
         </Styles.DisclaimerBody>
       </Styles.DisclaimerWrapper>
     </Styles.Container>

--- a/src/components/Explore/utils.ts
+++ b/src/components/Explore/utils.ts
@@ -57,9 +57,6 @@ export const EXPLORE_METRICS = [
   ExploreMetric.ICU_HOSPITALIZATIONS,
 ];
 
-export const DATA_SOURCES_URL =
-  'https://docs.google.com/presentation/d/1XmKCBWYZr9VQKFAdWh_D7pkpGGM_oR9cPjj-UrNdMJQ/edit';
-
 export function getMetricByChartId(chartId: string): ExploreMetric | undefined {
   switch (chartId) {
     case 'cases':


### PR DESCRIPTION
We've deprecated the google slides source deck doc. Eventually we would like a similar "find where this data comes from" as we do for the metrics, but for now I'm removing the old links and just keeping it generic.