### PR TITLE
Chart label + bottom axis edits

### DIFF
--- a/src/components/Charts/BoxedAnnotation.tsx
+++ b/src/components/Charts/BoxedAnnotation.tsx
@@ -17,7 +17,7 @@ export const BoxedAnnotation = ({
   x,
   y,
   text,
-  padding = 4,
+  padding = 2,
 }: {
   x: number;
   y: number;

--- a/src/components/Charts/ChartCaseDensity.tsx
+++ b/src/components/Charts/ChartCaseDensity.tsx
@@ -153,8 +153,8 @@ const ChartCaseDensity: FunctionComponent<{
         </Style.LineGrid>
         <Style.TextAnnotation>
           <BoxedAnnotation
-            x={getXCoord(lastPoint) + 30}
-            y={getYCoord(lastPoint)}
+            x={getXCoord(lastPoint)}
+            y={getYCoord(lastPoint) - 20}
             text={formatDecimal(getYCaseDensity(lastPoint), 1)}
           />
         </Style.TextAnnotation>

--- a/src/components/Charts/Charts.style.ts
+++ b/src/components/Charts/Charts.style.ts
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import { materialSMBreakpoint } from 'assets/theme/sizes';
 
 export const charts = {
   fontFamily: "'Source Code Pro', 'Roboto Mono', monospace",
@@ -116,11 +117,21 @@ export const RegionAnnotation = styled(TextAnnotation)<{ isActive: boolean }>`
     stroke: ${props =>
       props.isActive || palette(props).isDarkMode ? props.color : 'none'};
     stroke-width: 1px;
+    display: ${props => !props.isActive && 'none'};
+    }
   }
   text {
     fill: ${props =>
       props.isActive ? palette(props).background : props.color};
-    text-anchor: end;
+    text-anchor: start;
+    display: ${props => !props.isActive && 'none'};
+    }
+
+  @media (min-width: ${materialSMBreakpoint}) {
+    display: ${props => !props.isActive && 'inherit'};
+    text {
+      display: ${props => !props.isActive && 'inherit'};
+    }
   }
 `;
 

--- a/src/components/Charts/Charts.style.ts
+++ b/src/components/Charts/Charts.style.ts
@@ -128,7 +128,9 @@ export const RegionAnnotation = styled(TextAnnotation)<{ isActive: boolean }>`
     }
 
   @media (min-width: ${materialSMBreakpoint}) {
-    display: ${props => !props.isActive && 'inherit'};
+    rect {
+      display: ${props => !props.isActive && 'inherit'};
+    }
     text {
       display: ${props => !props.isActive && 'inherit'};
     }

--- a/src/components/Charts/ZoneAnnotation.tsx
+++ b/src/components/Charts/ZoneAnnotation.tsx
@@ -16,7 +16,8 @@ const ZoneAnnotation = ({
   y: number;
 }) => (
   <Style.RegionAnnotation color={color} isActive={isActive}>
-    <BoxedAnnotation x={x} y={y} text={name} />
+    {/* An x of 8 accounts for the annotation box's 4px of padding, and then some */}
+    <BoxedAnnotation x={8} y={y} text={name} />
   </Style.RegionAnnotation>
 );
 

--- a/src/components/Charts/ZoneAnnotation.tsx
+++ b/src/components/Charts/ZoneAnnotation.tsx
@@ -16,8 +16,8 @@ const ZoneAnnotation = ({
   y: number;
 }) => (
   <Style.RegionAnnotation color={color} isActive={isActive}>
-    {/* An x of 8 accounts for the annotation box's 4px of padding, and then some */}
-    <BoxedAnnotation x={8} y={y} text={name} />
+    {/* An x of 4 accounts for the annotation box's 2px of padding, and then some */}
+    <BoxedAnnotation x={4} y={y} text={name} />
   </Style.RegionAnnotation>
 );
 

--- a/src/components/Charts/utils.ts
+++ b/src/components/Charts/utils.ts
@@ -148,7 +148,7 @@ export const getUtcScale = (
   dateTo: Date,
   minX: number,
   maxX: number,
-  zoneLabelsWidth = 80,
+  zoneLabelsWidth = 15,
 ) => {
   const dateScale = scaleUtc({
     domain: [dateFrom, dateTo],


### PR DESCRIPTION
- Moves risk level labels to the left side of each metric chart
- Only renders active zone's label on mobile
- Removes padding on right side of x-axis that previously made room for labels