### PR TITLE
Footer content in CMS config

### DIFF
--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -836,3 +836,25 @@ collections:
                 hint: Disclaimer to show below metric chart. Not used if metric is blocked.
                 widget: markdown
                 minimal: true
+  - name: footer
+    label: Footer
+    description: Website footer content
+    format: json
+    files:
+      - name: footer
+        label: Footer
+        file: src/cms-content/footer/footer.json
+        fields:
+          - name: learnLinks
+            label: Learn links
+            widget: list
+            fields:
+              - name: url
+                label: Url
+                widget: string
+              - name: cta
+                label: Cta
+                widget: string
+          - name: aboutUs
+            label: About us
+            widget: markdown

--- a/src/cms-content/footer/index.ts
+++ b/src/cms-content/footer/index.ts
@@ -1,0 +1,11 @@
+import { Markdown } from '../utils';
+
+interface LinkItem {
+  url: string;
+  cta: string;
+}
+
+interface FooterContent {
+  learnLinks: LinkItem[];
+  aboutUs: Markdown;
+}


### PR DESCRIPTION
Adds fields to `config.yml` for the new footer's about-us paragraph + learn links