### PR TITLE
Metric chart max-y edit

### DIFF
--- a/src/components/Charts/utils.ts
+++ b/src/components/Charts/utils.ts
@@ -109,7 +109,7 @@ export const computeTickPositions = (
   const maxZones = includeSuperCritical(maxY, zones)
     ? zones[Level.CRITICAL].upperLimit
     : zones[Level.HIGH].upperLimit;
-  const maxTick = maxY < 1.5 * maxZones ? 1.5 * maxZones : maxY;
+  const maxTick = maxY < 1.2 * maxZones ? 1.2 * maxZones : maxY;
   return [
     minY,
     zones[Level.LOW].upperLimit,


### PR DESCRIPTION
Max-y currently defaults to whichever # is larger between 1.5 * upperLimit vs. the max value. This pr changes that 1.5 to 1.2 in order to use as little vertical space as is necessary.

Example before:
<img width="990" alt="Screen Shot 2021-03-10 at 5 07 07 PM" src="https://user-images.githubusercontent.com/44076375/110705129-ef665900-81c3-11eb-860a-2e5cd1fa4c26.png">

Example after:
<img width="995" alt="Screen Shot 2021-03-10 at 5 07 27 PM" src="https://user-images.githubusercontent.com/44076375/110705149-f8572a80-81c3-11eb-842a-06531fb85dd7.png">