### PR TITLE
ICU chart margin edit

### DIFF
--- a/src/components/Charts/ChartICUCapacityUsed.tsx
+++ b/src/components/Charts/ChartICUCapacityUsed.tsx
@@ -35,6 +35,8 @@ const ChartICUCapacityUsed = ({
     zones={HOSPITAL_USAGE_LEVEL_INFO_MAP}
     getTooltipContent={getTooltipContent}
     getPointText={getPointText}
+    marginTop={16}
+    marginLeft={38}
   />
 );
 

--- a/src/components/Charts/ChartZones.tsx
+++ b/src/components/Charts/ChartZones.tsx
@@ -199,6 +199,8 @@ const ChartZoneAutosize = ({
   getTooltipContent,
   getPointText,
   height = 400,
+  marginTop,
+  marginLeft,
 }: {
   columnData: Point[];
   zones: LevelInfoMap;
@@ -208,6 +210,8 @@ const ChartZoneAutosize = ({
   ) => { body: string; subtitle: string; width: string };
   getPointText: (valueY: number) => string;
   height?: number;
+  marginTop?: number;
+  marginLeft?: number;
 }) => (
   <Style.ChartContainer>
     <ParentSize>
@@ -220,6 +224,8 @@ const ChartZoneAutosize = ({
           capY={capY}
           getTooltipContent={getTooltipContent}
           getPointText={getPointText}
+          marginTop={marginTop}
+          marginLeft={marginLeft}
         />
       )}
     </ParentSize>


### PR DESCRIPTION
ICU chart needs a bit more spacing for the y axis labels than the other metric charts

Before:
![Screen Shot 2021-03-10 at 7 15 55 PM](https://user-images.githubusercontent.com/44076375/110716372-0b262b00-81d5-11eb-92ba-80d6f491ca5d.png)

After:
<img width="386" alt="Screen Shot 2021-03-10 at 7 16 11 PM" src="https://user-images.githubusercontent.com/44076375/110716396-15482980-81d5-11eb-8d1e-a4bfba14ac04.png">