### PR TITLE
cms vaccines: update the emailAlertVersion to be a string field

### DIFF
--- a/public/admin-vaccines/config.yml
+++ b/public/admin-vaccines/config.yml
@@ -102,8 +102,8 @@ collections:
                 required: false
               - label: Email alert version
                 name: emailAlertVersion
-                default: 0
-                widget: number
+                default: '0'
+                widget: string
               - label: Notes
                 name: notes
                 required: false

--- a/src/cms-content/vaccines/phases.test.ts
+++ b/src/cms-content/vaccines/phases.test.ts
@@ -23,6 +23,9 @@ describe('vaccination info is complete for each state', () => {
       test('has at least one phase', () => {
         expect(vaccinationInfo?.phaseGroups.length).toBeGreaterThan(0);
       });
+      test('emailAlertVersion is a number', () => {
+        expect(Number.isFinite(vaccinationInfo?.emailAlertVersion)).toBe(true);
+      });
     });
   }
 });

--- a/src/cms-content/vaccines/phases.test.ts
+++ b/src/cms-content/vaccines/phases.test.ts
@@ -1,6 +1,6 @@
 import { sortBy } from 'lodash';
 import regions from 'common/regions';
-import { getVaccineInfoByFips } from './phases';
+import { getVaccineInfoByFips, verifyOneItemPerState } from './phases';
 
 describe('vaccination info is complete for each state', () => {
   const states = sortBy(regions.states, state => state.fullName);
@@ -28,4 +28,8 @@ describe('vaccination info is complete for each state', () => {
       });
     });
   }
+
+  test('there are no repeated states in the CMS', () => {
+    expect(() => verifyOneItemPerState()).not.toThrow();
+  });
 });

--- a/src/cms-content/vaccines/phases.ts
+++ b/src/cms-content/vaccines/phases.ts
@@ -21,8 +21,12 @@ export interface RegionVaccinePhaseInfo {
   phaseGroups: RegionPhaseGroup[];
 }
 
-export const stateVaccinationPhases: RegionVaccinePhaseInfo[] =
-  stateVaccinationInfo.regions;
+export const stateVaccinationPhases: RegionVaccinePhaseInfo[] = stateVaccinationInfo.regions.map(
+  ({ emailAlertVersion, ...otherProps }) => ({
+    emailAlertVersion: parseInt(emailAlertVersion, 10),
+    ...otherProps,
+  }),
+);
 
 const vaccinationPhasesMap = keyBy(
   stateVaccinationPhases,

--- a/src/cms-content/vaccines/phases.ts
+++ b/src/cms-content/vaccines/phases.ts
@@ -1,4 +1,5 @@
-import { keyBy } from 'lodash';
+import { assert } from 'common/utils';
+import { keyBy, groupBy, map } from 'lodash';
 import stateVaccinationInfo from './state-vaccine-phases.json';
 
 export interface RegionPhaseGroup {
@@ -37,4 +38,17 @@ export function getVaccineInfoByFips(
   fipsCode: string,
 ): RegionVaccinePhaseInfo | null {
   return vaccinationPhasesMap[fipsCode] || null;
+}
+
+export function verifyOneItemPerState() {
+  const groupedByFips = groupBy(
+    stateVaccinationInfo.regions,
+    info => info.fips,
+  );
+  map(groupedByFips, infoList => {
+    assert(
+      infoList.length === 1,
+      `${infoList[0].fips} (${infoList[0].locationName}) is repeated in state-vaccine-phases.json`,
+    );
+  });
 }

--- a/src/cms-content/vaccines/state-vaccine-phases.json
+++ b/src/cms-content/vaccines/state-vaccine-phases.json
@@ -1,7 +1,7 @@
 {
   "regions": [
     {
-      "emailAlertVersion": 1,
+      "emailAlertVersion": "1",
       "locationName": "Alabama",
       "fips": "01",
       "eligibilityInfoUrl": "https://www.alabamapublichealth.gov/covid19vaccine/assets/adph-covid19-vaccination-allocation-plan.pdf",
@@ -50,7 +50,7 @@
       "fips": "02",
       "eligibilityInfoUrl": "http://dhss.alaska.gov/dph/Epi/id/Pages/COVID-19/VaccineAvailability.aspx",
       "vaccinationSignupUrl": "https://vaccinefinder.org/",
-      "emailAlertVersion": 2,
+      "emailAlertVersion": "2",
       "phaseGroups": [
         {
           "phase": "1a",
@@ -119,7 +119,7 @@
       "fips": "04",
       "eligibilityInfoUrl": "https://www.azdhs.gov/documents/preparedness/epidemiology-disease-control/infectious-disease-epidemiology/novel-coronavirus/vaccine/covid19-vp-infographic-eng.pdf",
       "vaccinationSignupUrl": "https://www.azdhs.gov/preparedness/epidemiology-disease-control/infectious-disease-epidemiology/index.php#novel-coronavirus-find-vaccine",
-      "emailAlertVersion": 3,
+      "emailAlertVersion": "3",
       "phaseGroups": [
         {
           "phase": "1A",
@@ -181,7 +181,7 @@
       "fips": "05",
       "eligibilityInfoUrl": "https://www.healthy.arkansas.gov/programs-services/topics/covid-19-vaccination-plan",
       "vaccinationSignupUrl": "https://www.healthy.arkansas.gov/programs-services/topics/covid-19-map-of-1-a-pharmacy-locations",
-      "emailAlertVersion": 3,
+      "emailAlertVersion": "3",
       "phaseGroups": [
         {
           "phase": "1A",
@@ -235,7 +235,7 @@
       ]
     },
     {
-      "emailAlertVersion": 1,
+      "emailAlertVersion": "1",
       "locationName": "California",
       "fips": "06",
       "eligibilityInfoUrl": "https://covid19.ca.gov/vaccines/#California's-vaccination-plan",
@@ -278,7 +278,7 @@
       "notes": "Note, the state website has removed references to phase 1b tier 2 and phase 1C. An example of the changes are https://www.placer.ca.gov/DocumentCenter/View/49578/COVID-Vaccine-Infographic-11421."
     },
     {
-      "emailAlertVersion": 2,
+      "emailAlertVersion": "2",
       "locationName": "Colorado",
       "fips": "08",
       "eligibilityInfoUrl": "https://covid19.colorado.gov/for-coloradans/vaccine/vaccine-for-coloradans",
@@ -345,7 +345,7 @@
       "fips": "09",
       "eligibilityInfoUrl": "https://portal.ct.gov/Coronavirus/COVID-19-Vaccinations",
       "vaccinationSignupUrl": "https://dphsubmissions.ct.gov/OnlineVaccine",
-      "emailAlertVersion": 2,
+      "emailAlertVersion": "2",
       "phaseGroups": [
         {
           "phase": "1a",
@@ -411,7 +411,7 @@
       "fips": "10",
       "eligibilityInfoUrl": "https://coronavirus.delaware.gov/vaccine/",
       "vaccinationSignupUrl": "https://vaccinefinder.org/",
-      "emailAlertVersion": 1,
+      "emailAlertVersion": "1",
       "phaseGroups": [
         {
           "phase": "1A",
@@ -474,7 +474,7 @@
       "fips": "11",
       "eligibilityInfoUrl": "https://coronavirus.dc.gov/vaccine-information",
       "vaccinationSignupUrl": "https://coronavirus.dc.gov/vaccinatedc",
-      "emailAlertVersion": 2,
+      "emailAlertVersion": "2",
       "phaseGroups": [
         {
           "phase": "1A",
@@ -551,7 +551,7 @@
       ]
     },
     {
-      "emailAlertVersion": 3,
+      "emailAlertVersion": "3",
       "locationName": "Florida",
       "fips": "12",
       "eligibilityInfoUrl": "https://myvaccine.fl.gov/",
@@ -575,7 +575,7 @@
       ]
     },
     {
-      "emailAlertVersion": 2,
+      "emailAlertVersion": "2",
       "locationName": "Georgia",
       "fips": "13",
       "eligibilityInfoUrl": "https://dph.georgia.gov/covid-vaccine",
@@ -629,7 +629,7 @@
       "fips": "15",
       "eligibilityInfoUrl": "https://hawaiicovid19.com/vaccine/",
       "vaccinationSignupUrl": "https://hawaiicovid19.com/vaccination-registration/",
-      "emailAlertVersion": 2,
+      "emailAlertVersion": "2",
       "phaseGroups": [
         {
           "phase": "1A",
@@ -682,7 +682,7 @@
       "fips": "16",
       "eligibilityInfoUrl": "https://coronavirus.idaho.gov/covid-19-vaccine/",
       "vaccinationSignupUrl": "https://vaccinefinder.org/",
-      "emailAlertVersion": 1,
+      "emailAlertVersion": "1",
       "phaseGroups": [
         {
           "phase": "1",
@@ -732,7 +732,7 @@
       ]
     },
     {
-      "emailAlertVersion": 2,
+      "emailAlertVersion": "2",
       "locationName": "Illinois",
       "fips": "17",
       "eligibilityInfoUrl": "https://www.dph.illinois.gov/covid19/vaccine-distribution",
@@ -787,7 +787,7 @@
       "fips": "18",
       "eligibilityInfoUrl": "https://www.coronavirus.in.gov/vaccine/index.htm",
       "vaccinationSignupUrl": "https://vaccinefinder.org/",
-      "emailAlertVersion": 3,
+      "emailAlertVersion": "3",
       "phaseGroups": [
         {
           "phase": "1A",
@@ -843,7 +843,7 @@
       "fips": "19",
       "eligibilityInfoUrl": "https://idph.iowa.gov/Emerging-Health-Issues/Novel-Coronavirus/Vaccine/Information-for-the-Public",
       "vaccinationSignupUrl": "https://vaccinefinder.org/",
-      "emailAlertVersion": 1,
+      "emailAlertVersion": "1",
       "phaseGroups": [
         {
           "phase": "1A",
@@ -876,7 +876,7 @@
       "fips": "20",
       "eligibilityInfoUrl": "https://www.kansasvaccine.gov/157/Availability",
       "vaccinationSignupUrl": "https://www.kansasvaccine.gov/160/Find-a-Vaccine",
-      "emailAlertVersion": 1,
+      "emailAlertVersion": "1",
       "phaseGroups": [
         {
           "phase": "1",
@@ -930,7 +930,7 @@
       "fips": "21",
       "eligibilityInfoUrl": "https://govstatus.egov.com/ky-covid-vaccine",
       "vaccinationSignupUrl": "https://vaccinefinder.org/",
-      "emailAlertVersion": 2,
+      "emailAlertVersion": "2",
       "phaseGroups": [
         {
           "phase": "1",
@@ -993,7 +993,7 @@
       "fips": "22",
       "eligibilityInfoUrl": "https://ldh.la.gov/covidvaccine/",
       "vaccinationSignupUrl": "https://ldh.la.gov/covidvaccine-locations/",
-      "emailAlertVersion": 2,
+      "emailAlertVersion": "2",
       "phaseGroups": [
         {
           "phase": "1A",
@@ -1035,7 +1035,7 @@
       "fips": "23",
       "eligibilityInfoUrl": "https://www.maine.gov/covid19/vaccines",
       "vaccinationSignupUrl": "https://vaccinefinder.org/",
-      "emailAlertVersion": 2,
+      "emailAlertVersion": "2",
       "phaseGroups": [
         {
           "phase": "1A",
@@ -1097,7 +1097,7 @@
       "fips": "24",
       "eligibilityInfoUrl": "https://covidlink.maryland.gov/content/vaccine/",
       "vaccinationSignupUrl": "https://maryland.maps.arcgis.com/apps/instant/nearby/index.html?appid=0dbfb100676346ed9758be319ab3f40c",
-      "emailAlertVersion": 1,
+      "emailAlertVersion": "1",
       "phaseGroups": [
         {
           "phase": "1A",
@@ -1147,7 +1147,7 @@
       ]
     },
     {
-      "emailAlertVersion": 2,
+      "emailAlertVersion": "2",
       "locationName": "Massachusetts",
       "fips": "25",
       "phaseGroups": [
@@ -1217,7 +1217,7 @@
       "vaccinationSignupUrl": "https://www.mass.gov/info-details/covid-19-vaccine-locations-for-individuals-currently-eligible-to-be-vaccinated"
     },
     {
-      "emailAlertVersion": 3,
+      "emailAlertVersion": "3",
       "locationName": "Michigan",
       "fips": "26",
       "eligibilityInfoUrl": "https://www.michigan.gov/documents/coronavirus/1-12_Vaccine_Timeline_712927_7.pdf",
@@ -1288,7 +1288,7 @@
       "fips": "27",
       "eligibilityInfoUrl": "https://mn.gov/covid19/vaccine/whos-getting-vaccinated/index.jsp",
       "vaccinationSignupUrl": "https://mn.gov/covid19/vaccine/find-vaccine/index.jsp",
-      "emailAlertVersion": 1,
+      "emailAlertVersion": "1",
       "phaseGroups": [
         {
           "phase": "1",
@@ -1348,7 +1348,7 @@
       "fips": "28",
       "eligibilityInfoUrl": "https://msdh.ms.gov/msdhsite/_static/14,22816,420,976.html#eligible",
       "vaccinationSignupUrl": "https://covidvaccine.umc.edu/",
-      "emailAlertVersion": 3,
+      "emailAlertVersion": "3",
       "phaseGroups": [
         {
           "phase": "1A",
@@ -1390,7 +1390,7 @@
       ]
     },
     {
-      "emailAlertVersion": 1,
+      "emailAlertVersion": "1",
       "eligibilityInfoUrl": "https://covidvaccine.mo.gov/priority/",
       "vaccinationSignupUrl": "https://covidvaccine.mo.gov/map/",
       "fips": "29",
@@ -1457,7 +1457,7 @@
       "fips": "30",
       "eligibilityInfoUrl": "https://dphhs.mt.gov/covid19vaccine",
       "vaccinationSignupUrl": "https://dphhs.mt.gov/publichealth/FCSS/countytribalhealthdepts",
-      "emailAlertVersion": 2,
+      "emailAlertVersion": "2",
       "phaseGroups": [
         {
           "phase": "1",
@@ -1502,7 +1502,7 @@
       "fips": "31",
       "eligibilityInfoUrl": "http://dhhs.ne.gov/Pages/COVID-19-Vaccine-Information.aspx",
       "vaccinationSignupUrl": "https://vaccinefinder.org/",
-      "emailAlertVersion": 1,
+      "emailAlertVersion": "1",
       "phaseGroups": [
         {
           "phase": "1",
@@ -1547,7 +1547,7 @@
       "fips": "32",
       "eligibilityInfoUrl": "https://www.immunizenevada.org/county-specific-covid-19-vaccine-plan",
       "vaccinationSignupUrl": "https://dpbhrdc.nv.gov/redcap/surveys/?s=N7ACTF4CYL",
-      "emailAlertVersion": 1,
+      "emailAlertVersion": "1",
       "phaseGroups": [
         {
           "phase": "1A",
@@ -1581,7 +1581,7 @@
       "fips": "33",
       "eligibilityInfoUrl": "https://www.vaccines.nh.gov/covid-19-vaccine-schedule-nh-residents",
       "vaccinationSignupUrl": "https://vaccinefinder.org/",
-      "emailAlertVersion": 1,
+      "emailAlertVersion": "1",
       "phaseGroups": [
         {
           "phase": "1A",
@@ -1640,7 +1640,7 @@
       ]
     },
     {
-      "emailAlertVersion": 1,
+      "emailAlertVersion": "1",
       "locationName": "New Jersey",
       "fips": "34",
       "eligibilityInfoUrl": "https://covid19.nj.gov/faqs/nj-information/slowing-the-spread/who-is-eligible-for-vaccination-in-new-jersey-who-is-included-in-the-vaccination-phases",
@@ -1689,7 +1689,7 @@
       "fips": "35",
       "eligibilityInfoUrl": "https://cv.nmhealth.org/covid-vaccine/",
       "vaccinationSignupUrl": "https://cvvaccine.nmhealth.org/",
-      "emailAlertVersion": 1,
+      "emailAlertVersion": "1",
       "phaseGroups": [
         {
           "phase": "1A",
@@ -1739,7 +1739,7 @@
       ]
     },
     {
-      "emailAlertVersion": 1,
+      "emailAlertVersion": "1",
       "locationName": "New York",
       "fips": "36",
       "eligibilityInfoUrl": "https://covid19vaccine.health.ny.gov/phased-distribution-vaccine",
@@ -1772,7 +1772,7 @@
       ]
     },
     {
-      "emailAlertVersion": 2,
+      "emailAlertVersion": "2",
       "locationName": "North Carolina",
       "fips": "37",
       "eligibilityInfoUrl": "https://covid19.ncdhhs.gov/vaccines/find-your-spot-take-your-shot",
@@ -1821,7 +1821,7 @@
       "fips": "38",
       "eligibilityInfoUrl": "https://www.health.nd.gov/covid-19-vaccine-priority-groups",
       "vaccinationSignupUrl": "https://www.health.nd.gov/covidvaccinelocator",
-      "emailAlertVersion": 2,
+      "emailAlertVersion": "2",
       "phaseGroups": [
         {
           "phase": "1A",
@@ -1866,7 +1866,7 @@
       "fips": "69",
       "eligibilityInfoUrl": "https://www.vaccinatecnmi.com/",
       "vaccinationSignupUrl": "https://www.vaccinatecnmi.com/covid-19/registration/",
-      "emailAlertVersion": 1,
+      "emailAlertVersion": "1",
       "phaseGroups": [
         {
           "phase": "1A",
@@ -1916,7 +1916,7 @@
       ]
     },
     {
-      "emailAlertVersion": 2,
+      "emailAlertVersion": "2",
       "locationName": "Ohio",
       "fips": "39",
       "eligibilityInfoUrl": "https://coronavirus.ohio.gov/wps/portal/gov/covid-19/covid-19-vaccination-program",
@@ -1999,7 +1999,7 @@
       ]
     },
     {
-      "emailAlertVersion": 2,
+      "emailAlertVersion": "2",
       "locationName": "Oklahoma",
       "fips": "40",
       "eligibilityInfoUrl": "https://oklahoma.gov/covid19/vaccine-information.html",
@@ -2057,7 +2057,7 @@
       "fips": "41",
       "eligibilityInfoUrl": "https://covidvaccine.oregon.gov/#prioritization",
       "vaccinationSignupUrl": "https://www.oregon.gov/oha/covid19/Pages/vaccine-information-by-county.aspx",
-      "emailAlertVersion": 3,
+      "emailAlertVersion": "3",
       "phaseGroups": [
         {
           "phase": "1A",
@@ -2148,7 +2148,7 @@
       ]
     },
     {
-      "emailAlertVersion": 2,
+      "emailAlertVersion": "2",
       "locationName": "Pennsylvania",
       "fips": "42",
       "eligibilityInfoUrl": "https://www.health.pa.gov/topics/disease/coronavirus/Vaccine/Pages/Vaccine.aspx#data",
@@ -2204,7 +2204,7 @@
       "fips": "44",
       "eligibilityInfoUrl": "https://covid.ri.gov/vaccination",
       "vaccinationSignupUrl": "https://vaccinefinder.org/",
-      "emailAlertVersion": 3,
+      "emailAlertVersion": "3",
       "phaseGroups": [
         {
           "phase": "1",
@@ -2276,7 +2276,7 @@
       "fips": "45",
       "eligibilityInfoUrl": "https://scdhec.gov/covid19/covid-19-vaccine",
       "vaccinationSignupUrl": "https://vaxlocator.dhec.sc.gov/",
-      "emailAlertVersion": 2,
+      "emailAlertVersion": "2",
       "phaseGroups": [
         {
           "phase": "1A",
@@ -2321,7 +2321,7 @@
       "fips": "46",
       "eligibilityInfoUrl": "https://doh.sd.gov/Covid/Vaccine/Public.aspx",
       "vaccinationSignupUrl": "https://doh.sd.gov/Covid/Vaccine/ProviderMap/default.aspx",
-      "emailAlertVersion": 2,
+      "emailAlertVersion": "2",
       "phaseGroups": [
         {
           "phase": "1A",
@@ -2389,7 +2389,7 @@
       ]
     },
     {
-      "emailAlertVersion": 3,
+      "emailAlertVersion": "3",
       "locationName": "Tennessee",
       "fips": "47",
       "eligibilityInfoUrl": "https://covid19.tn.gov/covid-19-vaccines/vaccine-phases/",
@@ -2467,7 +2467,7 @@
       ]
     },
     {
-      "emailAlertVersion": 2,
+      "emailAlertVersion": "2",
       "locationName": "Texas",
       "fips": "48",
       "eligibilityInfoUrl": "https://www.dshs.state.tx.us/coronavirus/immunize/vaccine.aspx",
@@ -2507,7 +2507,7 @@
       ]
     },
     {
-      "emailAlertVersion": 3,
+      "emailAlertVersion": "3",
       "locationName": "Utah",
       "fips": "49",
       "eligibilityInfoUrl": "https://coronavirus.utah.gov/vaccine-distribution/",
@@ -2552,7 +2552,7 @@
       ]
     },
     {
-      "emailAlertVersion": 4,
+      "emailAlertVersion": "4",
       "locationName": "Vermont",
       "fips": "50",
       "eligibilityInfoUrl": "https://www.healthvermont.gov/covid-19/vaccine/about-covid-19-vaccines-vermont",
@@ -2621,7 +2621,7 @@
       ]
     },
     {
-      "emailAlertVersion": 1,
+      "emailAlertVersion": "1",
       "locationName": "Virginia",
       "fips": "51",
       "eligibilityInfoUrl": "https://www.vdh.virginia.gov/covid-19-vaccine/",
@@ -2663,7 +2663,7 @@
       ]
     },
     {
-      "emailAlertVersion": 2,
+      "emailAlertVersion": "2",
       "locationName": "Washington",
       "fips": "53",
       "eligibilityInfoUrl": "https://www.doh.wa.gov/Emergencies/COVID19/vaccine",
@@ -2744,7 +2744,7 @@
       ]
     },
     {
-      "emailAlertVersion": 2,
+      "emailAlertVersion": "2",
       "locationName": "West Virginia",
       "eligibilityInfoUrl": "https://dhhr.wv.gov/covid-19/pages/vaccine.aspx",
       "vaccinationSignupUrl": "https://member.everbridge.net/747122446041089/login",
@@ -2768,7 +2768,7 @@
       "fips": "54"
     },
     {
-      "emailAlertVersion": 3,
+      "emailAlertVersion": "3",
       "locationName": "Wisconsin",
       "fips": "55",
       "eligibilityInfoUrl": "https://www.dhs.wisconsin.gov/covid-19/vaccine-about.htm",
@@ -2801,7 +2801,7 @@
       ]
     },
     {
-      "emailAlertVersion": 1,
+      "emailAlertVersion": "1",
       "locationName": "Wyoming",
       "fips": "56",
       "eligibilityInfoUrl": "https://health.wyo.gov/publichealth/immunization/wyoming-covid-19-vaccine-information/",
@@ -2846,7 +2846,7 @@
       ]
     },
     {
-      "emailAlertVersion": 0,
+      "emailAlertVersion": "0",
       "locationName": "Puerto Rico",
       "fips": "72",
       "eligibilityInfoUrl": "https://www.vacunatepr.com/fases-vacunacion-covid-19",


### PR DESCRIPTION
[Trello](https://trello.com/c/Aus9dlOE/1027-update-the-data-type-for-emailalertversion-on-the-cms) - The UI to change numbers is error-prone, so it's easier for the team to enter values as strings. In this PR, I change the type in the CMS config and the JSON file, but leave the external interface of the vaccination phases info unchanged (the emailAlertVersion is exposed as a number)

- Updated the config to take strings
- Updated the vaccine information (phases) to be strings
- Added unit tests to ensure that `emailAlertVersion` is a number
- Add unit tests to ensure that there are no repeated states