### PR TITLE
remove learn more under key metrics

### DIFF
--- a/src/screens/HomePage/CriteriaExplanation/CriteriaExplanation.style.tsx
+++ b/src/screens/HomePage/CriteriaExplanation/CriteriaExplanation.style.tsx
@@ -16,14 +16,6 @@ export const CriteriaList = styled.div`
   }
 `;
 
-export const RiskLevelChangeExplainer = styled(Typography)<{
-  component?: string;
-}>`
-  margin-top: 2rem;
-  text-align: center;
-  color: ${COLOR_MAP.GRAY_BODY_COPY};
-`;
-
 export const Wrapper = styled.div`
   margin: 0 1rem;
   padding: 2.5rem 0;

--- a/src/screens/HomePage/CriteriaExplanation/CriteriaExplanation.tsx
+++ b/src/screens/HomePage/CriteriaExplanation/CriteriaExplanation.tsx
@@ -9,7 +9,6 @@ import {
   ListSubheader,
   Content,
   KickerWrapper,
-  RiskLevelChangeExplainer,
 } from './CriteriaExplanation.style';
 import { Subtitle1 } from 'components/Typography';
 import ExternalLink from 'components/ExternalLink';
@@ -62,13 +61,6 @@ const CriteriaExplanation = (props: { isMobile: Boolean }) => {
           </Content>
         </Criterion>
       </CriteriaList>
-      <RiskLevelChangeExplainer component="p">
-        Learn about{' '}
-        <ExternalLink href="/faq#december-risk-levels-change">
-          changes we made
-        </ExternalLink>{' '}
-        to how we determine risk levels on December 21.
-      </RiskLevelChangeExplainer>
     </Wrapper>
   );
 };

--- a/src/screens/HomePage/CriteriaExplanation/CriteriaExplanation.tsx
+++ b/src/screens/HomePage/CriteriaExplanation/CriteriaExplanation.tsx
@@ -11,7 +11,6 @@ import {
   KickerWrapper,
 } from './CriteriaExplanation.style';
 import { Subtitle1 } from 'components/Typography';
-import ExternalLink from 'components/ExternalLink';
 
 const Kicker = (props: {
   number: string;


### PR DESCRIPTION
[Trello](https://trello.com/c/1P5daYqh/1024-remove-phrase-from-key-risk-metrics-section-of-homepage) 