### PR TITLE
Fonts file

### DIFF
--- a/src/common/theme/fonts.ts
+++ b/src/common/theme/fonts.ts
@@ -1,0 +1,30 @@
+import { css } from 'styled-components';
+
+const fonts = {
+  regularBook: css`
+    font-family: Roboto;
+    font-weight: 400;
+  `,
+  regularBookMidWeight: css`
+    font-family: Roboto;
+    font-weight: 500;
+  `,
+  regularBookBold: css`
+    font-family: Roboto;
+    font-weight: 700;
+  `,
+  monospace: css`
+    font-family: Source Code Pro;
+    font-weight: 400;
+  `,
+  monospaceMidWeight: css`
+    font-family: Source Code Pro;
+    font-weight: 500;
+  `,
+  monospaceBold: css`
+    font-family: Source Code Pro;
+    font-weight: 700;
+  `,
+};
+
+export default fonts;

--- a/src/common/theme/index.ts
+++ b/src/common/theme/index.ts
@@ -1,0 +1,3 @@
+import fonts from './fonts';
+
+export { fonts };

--- a/src/components/Compare/ModalFaq.style.tsx
+++ b/src/components/Compare/ModalFaq.style.tsx
@@ -2,6 +2,7 @@ import styled from 'styled-components';
 import { COLOR_MAP } from 'common/colors';
 import { Typography } from '@material-ui/core';
 import MuiCloseIcon from '@material-ui/icons/Close';
+import { fonts } from 'common/theme';
 
 export const Wrapper = styled.div`
   background-color: white;
@@ -39,7 +40,7 @@ export const Header = styled(Typography)`
 `;
 
 export const Subheader = styled(Typography)`
-  font-family: Source Code Pro;
+  ${fonts.monospace};
   font-size: 0.875rem;
   color: ${COLOR_MAP.GRAY.DARK};
   text-transform: uppercase;

--- a/src/screens/AlertUnsubscribe/AlertUnsubscribe.style.tsx
+++ b/src/screens/AlertUnsubscribe/AlertUnsubscribe.style.tsx
@@ -1,6 +1,7 @@
 import styled, { css } from 'styled-components';
 import { Typography, Box } from '@material-ui/core';
 import { COLOR_MAP } from 'common/colors';
+import { fonts } from 'common/theme';
 
 export const Wrapper = styled(Box)`
   max-width: 700px;
@@ -19,17 +20,15 @@ export const Wrapper = styled(Box)`
 `;
 
 export const UnsubscribeHeader = styled(Typography)`
-  font-family: Roboto;
+  ${fonts.regularBookBold};
   font-size: 2rem;
   margin-bottom: 2.5rem;
-  font-weight: 700;
   line-height: 1.2;
 `;
 
 const Button = css`
-  font-family: Roboto;
+  ${fonts.regularBookBold};
   font-size: 0.875rem;
-  font-weight: 700;
   line-height: 1.1rem;
   text-transform: uppercase;
   color: white;
@@ -68,7 +67,7 @@ export const UnsubscribeButton = styled.button`
 `;
 
 export const BodyCopy = styled(Typography)`
-  font-family: Roboto;
+  ${fonts.regularBook};
   font-size: 1.1rem;
   margin-bottom: 1.75rem;
   line-height: 1.4;


### PR DESCRIPTION
Starts to centralize our font styles

Adds `common/theme` folder, currently with `fonts.ts` (later going to add `colors.ts` into it as well)

In `fonts.ts`, we are exporting each set of font styles (ie. roboto + bold) as a set of css properties, that can be called as `${fonts.regularBookBold}`