### PR TITLE
ForwardRef for Mui complaints

### DIFF
--- a/src/components/Compare/ModalCompare.tsx
+++ b/src/components/Compare/ModalCompare.tsx
@@ -12,7 +12,7 @@ import Filters from 'components/Compare/Filters';
 import { LockBodyScroll } from 'components/Dialog';
 import { Region, MetroArea } from 'common/regions';
 
-const ModalCompare = (props: {
+interface ModalCompareProps {
   stateName?: string;
   county: any | null;
   setShowModal: any;
@@ -44,7 +44,9 @@ const ModalCompare = (props: {
   region?: Region;
   vaccinesFirst?: boolean;
   vulnerabilityFirst?: boolean;
-}) => {
+}
+
+const ModalCompare = (props: ModalCompareProps) => {
   const { handleCloseModal, region } = props;
 
   useEffect(() => {
@@ -125,4 +127,11 @@ const ModalCompare = (props: {
   );
 };
 
-export default ModalCompare;
+// Swallow the ref, because we don't need it, to silence a warning
+const ModalCompareWrapper = React.forwardRef(
+  (props: ModalCompareProps, ref) => {
+    return <ModalCompare {...props} />;
+  },
+);
+
+export default ModalCompareWrapper;

--- a/src/components/Compare/ModalFaq.tsx
+++ b/src/components/Compare/ModalFaq.tsx
@@ -12,14 +12,18 @@ import {
 import { LockBodyScroll } from 'components/Dialog';
 import { useEscToClose } from 'common/hooks';
 
-const ModalFaq = (props: { handleCloseModal: () => void }) => {
-  useEscToClose(props.handleCloseModal);
+interface ModalFaqProps {
+  handleCloseModal: () => void;
+}
+
+const ModalFaq = ({ handleCloseModal }: ModalFaqProps) => {
+  useEscToClose(handleCloseModal);
 
   return (
     <Fragment>
       <LockBodyScroll />
       <Wrapper>
-        <CloseIcon onClick={props.handleCloseModal} />
+        <CloseIcon onClick={handleCloseModal} />
         <Content>
           <Header>Compare table</Header>
           <Subheader>Frequently asked questions</Subheader>
@@ -55,4 +59,9 @@ const ModalFaq = (props: { handleCloseModal: () => void }) => {
   );
 };
 
-export default ModalFaq;
+// Swallow the ref, because we don't need it, to silence a warning
+const ModalFaqWrapper = React.forwardRef((props: ModalFaqProps, ref) => {
+  return <ModalFaq {...props} />;
+});
+
+export default ModalFaqWrapper;


### PR DESCRIPTION
This lets these things take a forwarded ref, they don't do anything with it, but it avoids some very long log messages from Mui components that clutter the error and warning stream.