### PR TITLE
Split ShareCardImage into Home and Location versions

### DIFF
--- a/src/screens/internal/ShareImage/HomeShareCardImage.tsx
+++ b/src/screens/internal/ShareImage/HomeShareCardImage.tsx
@@ -10,7 +10,6 @@ import { Header } from './LocationShareCardImage';
  * screenshot that we then use as our OpenGraph image.
  */
 const HomeShareCardImage = () => {
-  // FIXME: do we need <ScreenshotReady> on this one? it was missing before
   return (
     <DarkScreenshotWrapper className={SCREENSHOT_CLASS}>
       <Header isHomePage />

--- a/src/screens/internal/ShareImage/HomeShareCardImage.tsx
+++ b/src/screens/internal/ShareImage/HomeShareCardImage.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import SocialLocationPreview from 'components/SocialLocationPreview/SocialLocationPreview';
+import { ShareCardWrapper } from './ShareCardImage.style';
+import { DarkScreenshotWrapper } from './ShareImage.style';
+import { SCREENSHOT_CLASS } from 'components/Screenshot';
+import { Header } from './LocationShareCardImage';
+
+/**
+ * Screen that just shows the appropriate share card so that we can take a
+ * screenshot that we then use as our OpenGraph image.
+ */
+const HomeShareCardImage = () => {
+  // FIXME: do we need <ScreenshotReady> on this one? it was missing before
+  return (
+    <DarkScreenshotWrapper className={SCREENSHOT_CLASS}>
+      <Header isHomePage />
+      <ShareCardWrapper isHomePage>
+        <SocialLocationPreview />;
+      </ShareCardWrapper>
+    </DarkScreenshotWrapper>
+  );
+};
+
+export default HomeShareCardImage;

--- a/src/screens/internal/ShareImage/LocationShareCardImage.tsx
+++ b/src/screens/internal/ShareImage/LocationShareCardImage.tsx
@@ -11,27 +11,27 @@ import { ScreenshotReady, SCREENSHOT_CLASS } from 'components/Screenshot';
 import { useRegionFromParams } from 'common/regions';
 import { Region } from 'common/regions';
 import { TimeFormat, formatDateTime } from 'common/utils/time-utils';
-
-// TODO(michael): Split this into HomeImage and LocationImage (with some shared code).
+import { assert } from 'common/utils';
 
 /**
  * Screen that just shows the appropriate share card so that we can take a
  * screenshot that we then use as our OpenGraph image.
  */
-const ShareCardImage = () => {
+const LocationShareCardImage = () => {
   const region = useRegionFromParams();
-  const isHomePage = !region;
+  // we know Region won't be null because this won't be called for non-region routes
+  assert(region !== null);
   return (
     <DarkScreenshotWrapper className={SCREENSHOT_CLASS}>
-      <Header isHomePage={isHomePage} />
-      <ShareCardWrapper isHomePage={isHomePage}>
-        <ShareCard region={region} />
+      <Header />
+      <ShareCardWrapper>
+        <LocationShareCard region={region} />;
       </ShareCardWrapper>
     </DarkScreenshotWrapper>
   );
 };
 
-const Header = (props: { isHomePage?: Boolean }) => {
+export const Header = (props: { isHomePage?: Boolean }) => {
   return (
     <>
       <TitleWrapper isHomePage={props.isHomePage}>
@@ -42,18 +42,6 @@ const Header = (props: { isHomePage?: Boolean }) => {
       </LastUpdatedWrapper>
     </>
   );
-};
-
-interface ShareCardProps {
-  region: Region | null;
-}
-
-const ShareCard = ({ region }: ShareCardProps) => {
-  if (region) {
-    return <LocationShareCard region={region} />;
-  } else {
-    return <SocialLocationPreview />;
-  }
 };
 
 interface LocationShareCardProps {
@@ -76,4 +64,4 @@ const LocationShareCard = ({ region }: LocationShareCardProps) => {
   );
 };
 
-export default ShareCardImage;
+export default LocationShareCardImage;

--- a/src/screens/internal/ShareImage/ShareImage.tsx
+++ b/src/screens/internal/ShareImage/ShareImage.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Route, Switch, RouteComponentProps } from 'react-router-dom';
-import ShareCardImage from './ShareCardImage';
+import HomeShareCardImage from './HomeShareCardImage';
+import LocationShareCardImage from './LocationShareCardImage';
 import ChartShareImage from './ChartShareImage';
 import ChartExportImage from './ChartExportImage';
 import ExploreChartImage from './ExploreChartImage';
@@ -31,7 +32,7 @@ export default function ShareImage({ match }: RouteComponentProps<{}>) {
   return (
     <Switch>
       {/* HOME PAGE SHARE CARD */}
-      <Route exact path={`${match.path}`} component={ShareCardImage} />
+      <Route exact path={`${match.path}`} component={HomeShareCardImage} />
 
       {/* HOME PAGE MAP IMAGE (used in meta name="image" tag) */}
       <Route exact path={`${match.path}map/`}>
@@ -42,17 +43,17 @@ export default function ShareImage({ match }: RouteComponentProps<{}>) {
       <Route
         exact
         path={`${match.path}states/:stateId`}
-        component={ShareCardImage}
+        component={LocationShareCardImage}
       />
       <Route
         exact
         path={`${match.path}counties/:countyFipsId`}
-        component={ShareCardImage}
+        component={LocationShareCardImage}
       />
       <Route
         exact
         path={`${match.path}metros/:fipsCode`}
-        component={ShareCardImage}
+        component={LocationShareCardImage}
       />
 
       {/* METRIC CHARTS */}


### PR DESCRIPTION
This resolves a todo by @mikelehen and also simplifies migration to next.js

I thought about making a component that takes {children} instead of copying the wrappers, but wasn't sure it was worth the hassle.  Feel free to press for that though, if you think it is.

It also became evident that the homepage does *not* include the `<ScreenshotReady>` component like the individual location-based share cards do.  Is that intentional, or a bug?  Let me know, I can fix it while I'm at it.