### PR TITLE
Split Map view from SocialLocationPreview

### DIFF
--- a/src/components/ShareBlock/ShareBlock.tsx
+++ b/src/components/ShareBlock/ShareBlock.tsx
@@ -8,6 +8,7 @@ import {
   LinkedinIcon,
 } from 'react-share';
 import SocialLocationPreview from 'components/SocialLocationPreview/SocialLocationPreview';
+import SocialLocationPreviewMap from 'components/SocialLocationPreview/SocialLocationPreviewMap';
 import { Projections } from 'common/models/Projections';
 import * as urls from 'common/urls';
 import {
@@ -67,6 +68,13 @@ const ShareBlock = ({
   });
 
   const geolocatedRegions = useGeolocationRegions();
+
+  const SocialPreview =
+    projections && stats ? (
+      <SocialLocationPreview projections={projections} stats={stats} />
+    ) : (
+      <SocialLocationPreviewMap isEmbedPreview />
+    );
 
   const defaultSignupRegions = region
     ? getDefaultRegions(region)
@@ -146,13 +154,7 @@ const ShareBlock = ({
               </EmbedPrompt>
             </SocialTextArea>
           </SocialTextAreaWrapper>
-          <SocialMockupWrapper>
-            <SocialLocationPreview
-              isEmbedPreview
-              projections={projections}
-              stats={stats}
-            />
-          </SocialMockupWrapper>
+          <SocialMockupWrapper>{SocialPreview}</SocialMockupWrapper>
         </ShareRowContentArea>
       </ShareRow>
     </ShareContainer>

--- a/src/components/SocialLocationPreview/SocialLocationPreview.tsx
+++ b/src/components/SocialLocationPreview/SocialLocationPreview.tsx
@@ -1,106 +1,30 @@
-import React, { ComponentType } from 'react';
+import React from 'react';
 import { Projections } from 'common/models/Projections';
 import { useModelLastUpdatedDate } from 'common/utils/model';
 
 import {
   Wrapper,
   PreviewHeader,
-  USMapPreviewHeader,
   HeaderText,
   HeaderHeader,
-  USMapHeaderText,
-  MapHeaderHeader,
   HeaderSubhead,
   AlarmLevel,
   PreviewBody,
   PreviewFooter,
   FooterText,
-  MapWrapper,
 } from './SocialLocationPreview.style';
 import { Level } from 'common/level';
 import { LOCATION_SUMMARY_LEVELS } from 'common/metrics/location_summary';
-import Map from 'components/Map/Map';
 import { COLOR_MAP } from 'common/colors';
 import SummaryStats from 'components/SummaryStats/SummaryStats';
-import { Legend, LegendItem } from 'components/Map/Legend';
 
 const SocialLocationPreview = (props: {
-  projections?: Projections;
-  stats?: { [key: string]: number | null };
-  border?: Boolean;
-  isEmbed?: Boolean;
-  Footer?: ComponentType;
-  isEmbedPreview?: boolean;
+  projections: Projections;
+  stats: { [key: string]: number | null };
 }) => {
   const lastUpdatedDate: Date | null = useModelLastUpdatedDate() || new Date();
   const lastUpdatedDateString =
     lastUpdatedDate !== null ? lastUpdatedDate.toLocaleDateString() : '';
-  const navigateToCAN = () => {
-    window.top.location.href = 'https://covidactnow.org/';
-    return false;
-  };
-  const Footer = props.Footer;
-  const isEmbed = props.isEmbed;
-  const showCountyView = !isEmbed && !props.isEmbedPreview;
-  if (!props.projections || !props.stats) {
-    return (
-      <Wrapper border={props.border}>
-        <MapHeaderHeader>US COVID Risk &amp; Vaccine Tracker</MapHeaderHeader>
-        <USMapPreviewHeader sideLegend={!isEmbed}>
-          <MapWrapper>
-            <Map
-              onClick={isEmbed ? navigateToCAN : undefined}
-              hideLegend={!isEmbed}
-              hideLegendTitle={true}
-              hideInstructions={true}
-              showCounties={showCountyView}
-            />
-          </MapWrapper>
-          {isEmbed ? (
-            ''
-          ) : (
-            <USMapHeaderText>
-              <Legend condensed={true}>
-                <LegendItem
-                  key={'legend-5'}
-                  title={LOCATION_SUMMARY_LEVELS[Level.SUPER_CRITICAL].name}
-                  color={LOCATION_SUMMARY_LEVELS[Level.SUPER_CRITICAL].color}
-                />
-                <LegendItem
-                  key={'legend-4'}
-                  title={LOCATION_SUMMARY_LEVELS[Level.CRITICAL].name}
-                  color={LOCATION_SUMMARY_LEVELS[Level.CRITICAL].color}
-                />
-                <LegendItem
-                  key={'legend-3'}
-                  title={LOCATION_SUMMARY_LEVELS[Level.HIGH].name}
-                  color={LOCATION_SUMMARY_LEVELS[Level.HIGH].color}
-                />
-                <LegendItem
-                  key={'legend-2'}
-                  title={LOCATION_SUMMARY_LEVELS[Level.MEDIUM].name}
-                  color={LOCATION_SUMMARY_LEVELS[Level.MEDIUM].color}
-                />
-                <LegendItem
-                  key={'legend-1'}
-                  title={LOCATION_SUMMARY_LEVELS[Level.LOW].name}
-                  color={LOCATION_SUMMARY_LEVELS[Level.LOW].color}
-                />
-              </Legend>
-            </USMapHeaderText>
-          )}
-        </USMapPreviewHeader>
-        {Footer ? (
-          <Footer />
-        ) : (
-          <PreviewFooter>
-            <FooterText>Last Updated {lastUpdatedDateString}</FooterText>
-            <FooterText>covidactnow.org</FooterText>
-          </PreviewFooter>
-        )}
-      </Wrapper>
-    );
-  }
 
   const alarmLevel = props.projections.getAlarmLevel();
   const levelInfo = LOCATION_SUMMARY_LEVELS[alarmLevel];

--- a/src/components/SocialLocationPreview/SocialLocationPreviewMap.tsx
+++ b/src/components/SocialLocationPreview/SocialLocationPreviewMap.tsx
@@ -1,0 +1,93 @@
+import React, { ComponentType } from 'react';
+import { useModelLastUpdatedDate } from 'common/utils/model';
+
+import {
+  Wrapper,
+  USMapPreviewHeader,
+  USMapHeaderText,
+  MapHeaderHeader,
+  PreviewFooter,
+  FooterText,
+  MapWrapper,
+} from './SocialLocationPreview.style';
+import { Level } from 'common/level';
+import { LOCATION_SUMMARY_LEVELS } from 'common/metrics/location_summary';
+import Map from 'components/Map/Map';
+import { Legend, LegendItem } from 'components/Map/Legend';
+
+const SocialLocationPreview = (props: {
+  border?: Boolean;
+  isEmbed?: Boolean;
+  Footer?: ComponentType;
+  isEmbedPreview?: boolean;
+}) => {
+  const lastUpdatedDate: Date | null = useModelLastUpdatedDate() || new Date();
+  const lastUpdatedDateString =
+    lastUpdatedDate !== null ? lastUpdatedDate.toLocaleDateString() : '';
+  const navigateToCAN = () => {
+    window.top.location.href = 'https://covidactnow.org/';
+    return false;
+  };
+  const Footer = props.Footer;
+  const isEmbed = props.isEmbed;
+  const showCountyView = !isEmbed && !props.isEmbedPreview;
+  return (
+    <Wrapper border={props.border}>
+      <MapHeaderHeader>US COVID Risk &amp; Vaccine Tracker</MapHeaderHeader>
+      <USMapPreviewHeader sideLegend={!isEmbed}>
+        <MapWrapper>
+          <Map
+            onClick={isEmbed ? navigateToCAN : undefined}
+            hideLegend={!isEmbed}
+            hideLegendTitle={true}
+            hideInstructions={true}
+            showCounties={showCountyView}
+          />
+        </MapWrapper>
+        {isEmbed ? (
+          ''
+        ) : (
+          <USMapHeaderText>
+            <Legend condensed={true}>
+              <LegendItem
+                key={'legend-5'}
+                title={LOCATION_SUMMARY_LEVELS[Level.SUPER_CRITICAL].name}
+                color={LOCATION_SUMMARY_LEVELS[Level.SUPER_CRITICAL].color}
+              />
+              <LegendItem
+                key={'legend-4'}
+                title={LOCATION_SUMMARY_LEVELS[Level.CRITICAL].name}
+                color={LOCATION_SUMMARY_LEVELS[Level.CRITICAL].color}
+              />
+              <LegendItem
+                key={'legend-3'}
+                title={LOCATION_SUMMARY_LEVELS[Level.HIGH].name}
+                color={LOCATION_SUMMARY_LEVELS[Level.HIGH].color}
+              />
+              <LegendItem
+                key={'legend-2'}
+                title={LOCATION_SUMMARY_LEVELS[Level.MEDIUM].name}
+                color={LOCATION_SUMMARY_LEVELS[Level.MEDIUM].color}
+              />
+              <LegendItem
+                key={'legend-1'}
+                title={LOCATION_SUMMARY_LEVELS[Level.LOW].name}
+                color={LOCATION_SUMMARY_LEVELS[Level.LOW].color}
+              />
+            </Legend>
+          </USMapHeaderText>
+        )}
+      </USMapPreviewHeader>
+      {Footer ? (
+        <Footer />
+      ) : (
+        <PreviewFooter>
+          <FooterText>Last Updated {lastUpdatedDateString}</FooterText>
+          <FooterText>covidactnow.org</FooterText>
+        </PreviewFooter>
+      )}
+    </Wrapper>
+  );
+};
+
+export default SocialLocationPreview;

--- a/src/screens/Embed/Embed.tsx
+++ b/src/screens/Embed/Embed.tsx
@@ -25,7 +25,7 @@ import {
   EmbedHeader,
   EmbedSubheader,
 } from './Embed.style';
-import SocialLocationPreview from 'components/SocialLocationPreview/SocialLocationPreview';
+import SocialLocationPreviewMap from 'components/SocialLocationPreview/SocialLocationPreviewMap';
 import { useRegionFromParams } from 'common/regions';
 
 function LocationEmbed() {
@@ -91,7 +91,7 @@ export default function Embed({ isNational }: { isNational: boolean }) {
   if (isNational) {
     return (
       <EmbedContainer height={US_MAP_EMBED_HEIGHT} width={US_MAP_EMBED_WIDTH}>
-        <SocialLocationPreview border isEmbed Footer={EmbedFooter} />
+        <SocialLocationPreviewMap border isEmbed Footer={EmbedFooter} />
       </EmbedContainer>
     );
   }

--- a/src/screens/internal/ShareImage/HomeShareCardImage.tsx
+++ b/src/screens/internal/ShareImage/HomeShareCardImage.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import SocialLocationPreview from 'components/SocialLocationPreview/SocialLocationPreview';
+import SocialLocationPreviewMap from 'components/SocialLocationPreview/SocialLocationPreviewMap';
 import { ShareCardWrapper } from './ShareCardImage.style';
 import { DarkScreenshotWrapper } from './ShareImage.style';
 import { SCREENSHOT_CLASS } from 'components/Screenshot';
@@ -14,7 +14,7 @@ const HomeShareCardImage = () => {
     <DarkScreenshotWrapper className={SCREENSHOT_CLASS}>
       <Header isHomePage />
       <ShareCardWrapper isHomePage>
-        <SocialLocationPreview />;
+        <SocialLocationPreviewMap />;
       </ShareCardWrapper>
     </DarkScreenshotWrapper>
   );

--- a/src/screens/internal/ShareImage/USMapImage.tsx
+++ b/src/screens/internal/ShareImage/USMapImage.tsx
@@ -1,5 +1,5 @@
 import { SCREENSHOT_CLASS } from 'components/Screenshot';
-import SocialLocationPreview from 'components/SocialLocationPreview/SocialLocationPreview';
+import SocialLocationPreviewMap from 'components/SocialLocationPreview/SocialLocationPreviewMap';
 import React from 'react';
 import { ScreenshotWrapper } from './ShareImage.style';
 import { USMapWrapper } from './USMapImage.style';
@@ -8,7 +8,7 @@ export const USMapImage = () => {
   return (
     <ScreenshotWrapper className={SCREENSHOT_CLASS}>
       <USMapWrapper>
-        <SocialLocationPreview />
+        <SocialLocationPreviewMap />
       </USMapWrapper>
     </ScreenshotWrapper>
   );


### PR DESCRIPTION
Split out the map-specific view, so that the location-specific version can have non-optional props, simplifies and smooths the way for next.js migration.

Depends on the ShareCardImage pull request (https://github.com/covid-projections/covid-projections/pull/3057) being landed first.  I'll have to clean up and rebase after that lands.