### PR TITLE
Migrate UTC conversion instances to time utils

### DIFF
--- a/src/cms-content/articles/index.ts
+++ b/src/cms-content/articles/index.ts
@@ -5,7 +5,7 @@ import thirdSurge from './third-surge.json';
 import canCompare from './can-compare.json';
 import metros from './metros.json';
 import {
-  timeFormats,
+  TimeFormat,
   parseDateString,
   formatDateTime,
 } from 'common/utils/time-utils';
@@ -31,7 +31,7 @@ function sanitizeArticle(article: ArticleJSON): Article {
   return {
     ...article,
     articleID: sanitizeID(article.articleID),
-    date: formatDateTime(parseDateString(article.date), timeFormats.MM_DD_YYYY),
+    date: formatDateTime(parseDateString(article.date), TimeFormat.MM_DD_YYYY),
   };
 }
 

--- a/src/cms-content/articles/utils.ts
+++ b/src/cms-content/articles/utils.ts
@@ -1,7 +1,7 @@
 import { Markdown, sanitizeID } from '../utils';
 import { keyBy, sortBy } from 'lodash';
 import {
-  timeFormats,
+  TimeFormat,
   parseDateString,
   formatDateTime,
 } from 'common/utils/time-utils';
@@ -27,7 +27,7 @@ export function sanitizeArticle(article: ArticleJSON): Article {
   return {
     ...article,
     articleID: sanitizeID(article.articleID),
-    date: formatDateTime(parseDateString(article.date), timeFormats.MM_DD_YYYY),
+    date: formatDateTime(parseDateString(article.date), TimeFormat.MM_DD_YYYY),
   };
 }
 

--- a/src/common/urls.ts
+++ b/src/common/urls.ts
@@ -3,7 +3,7 @@ import { assert } from 'common/utils';
 import urlJoin from 'url-join';
 import * as QueryString from 'query-string';
 import { Region } from './regions';
-import { timeFormats, formatDateTime } from 'common/utils/time-utils';
+import { TimeFormat, formatDateTime } from 'common/utils/time-utils';
 
 /**
  * We append a short unique string corresponding to the currently published
@@ -31,7 +31,7 @@ function getShareImageBaseUrl(): string {
 }
 
 export function getMapImageUrl(): string {
-  const date = formatDateTime(new Date(), timeFormats.YYYY_MM_DD);
+  const date = formatDateTime(new Date(), TimeFormat.YYYY_MM_DD);
   return urlJoin(
     getShareImageBaseUrl(),
     `${date}-image-covid-us-map-cases.png`,

--- a/src/common/utils/index.ts
+++ b/src/common/utils/index.ts
@@ -1,6 +1,5 @@
-import moment from 'moment';
 import _ from 'lodash';
-import { timeFormats, formatDateTime } from 'common/utils/time-utils';
+import { TimeFormat, formatDateTime, dateToUTC } from 'common/utils/time-utils';
 
 export function assert(condition: any, msg?: string): asserts condition {
   if (!condition) {
@@ -21,11 +20,12 @@ export function nonNull<T>(value: T | null | undefined): T {
  * Returns a date formatted as a string, assuming the Date is in the UTC
  * timezone (this is probably the case if it came from our API). The default
  * format is locale-specific, for US: April 29, 2020.
- *
- * See https://momentjs.com/docs/#/displaying/format/ for more details.
  */
-export function formatUtcDate(date: Date, format: string = 'LL'): string {
-  return moment.utc(date).format(format);
+export function formatUtcDate(
+  date: Date,
+  format: TimeFormat = TimeFormat.MMMM_D_YYYY,
+): string {
+  return formatDateTime(dateToUTC(date), format);
 }
 
 /**
@@ -33,7 +33,7 @@ export function formatUtcDate(date: Date, format: string = 'LL'): string {
  */
 
 export function formatMetatagDate(): string {
-  return formatDateTime(new Date(), timeFormats.MMM_DD_YYYY);
+  return formatDateTime(new Date(), TimeFormat.MMM_DD_YYYY);
 }
 
 /**

--- a/src/common/utils/model.ts
+++ b/src/common/utils/model.ts
@@ -1,11 +1,11 @@
 import { useState, useEffect } from 'react';
 import { Projections } from '../models/Projections';
 import { Api } from 'api';
-import moment from 'moment';
 import { assert, fail } from '.';
 import { getSnapshotUrlOverride } from './snapshots';
 import regions, { Region, County, RegionType } from 'common/regions';
 import { RegionSummary } from 'api/schema/RegionSummary';
+import { parseDateString, dateToUTC } from 'common/utils/time-utils';
 
 export enum APIRegionSubPath {
   COUNTIES = 'counties',
@@ -171,8 +171,8 @@ export function useModelLastUpdatedDate() {
   useEffect(() => {
     new Api().fetchVersionInfo().then(version => {
       // NOTE: "new Date(version.timestamp)" on safari fails due to pickiness about the
-      // date formatting, so just use moment to parse.
-      setLastUpdated(moment.utc(version.timestamp).toDate());
+      // date formatting, so just use time utils to parse.
+      setLastUpdated(dateToUTC(parseDateString(version.timestamp)));
     });
   }, []);
 

--- a/src/common/utils/time-utils.test.ts
+++ b/src/common/utils/time-utils.test.ts
@@ -1,5 +1,5 @@
 import {
-  timeFormats,
+  TimeFormat,
   formatDateTime,
   parseDateString,
   dateToUTC,
@@ -11,31 +11,31 @@ const testDate = new Date(2020, 2, 1);
 
 describe('time formatting', () => {
   test('Date in ISO format', () => {
-    expect(formatDateTime(testDate, timeFormats.YYYY_MM_DD)).toBe('2020-03-01');
+    expect(formatDateTime(testDate, TimeFormat.YYYY_MM_DD)).toBe('2020-03-01');
   });
   test('Dash seperated date', () => {
-    expect(formatDateTime(testDate, timeFormats.MM_DD_YYYY)).toBe('03/01/2020');
+    expect(formatDateTime(testDate, TimeFormat.MM_DD_YYYY)).toBe('03/01/2020');
   });
   test('Date in full month, day, year', () => {
-    expect(formatDateTime(testDate, timeFormats.MMMM_D_YYYY)).toBe(
+    expect(formatDateTime(testDate, TimeFormat.MMMM_D_YYYY)).toBe(
       'March 1, 2020',
     );
   });
   test('Date in shorthand month, day, year', () => {
-    expect(formatDateTime(testDate, timeFormats.MMM_DD_YYYY)).toBe(
+    expect(formatDateTime(testDate, TimeFormat.MMM_DD_YYYY)).toBe(
       'Mar 01, 2020',
     );
   });
   test('Date in full month and unpadded day', () => {
-    expect(formatDateTime(testDate, timeFormats.MMMM_D)).toBe('March 1');
+    expect(formatDateTime(testDate, TimeFormat.MMMM_D)).toBe('March 1');
   });
   test('Past date', () => {
-    expect(formatDateTime(new Date(2015, 1, 1), timeFormats.YYYY_MM_DD)).toBe(
+    expect(formatDateTime(new Date(2015, 1, 1), TimeFormat.YYYY_MM_DD)).toBe(
       '2015-02-01',
     );
   });
   test('Future date', () => {
-    expect(formatDateTime(new Date(2025, 1, 1), timeFormats.YYYY_MM_DD)).toBe(
+    expect(formatDateTime(new Date(2025, 1, 1), TimeFormat.YYYY_MM_DD)).toBe(
       '2025-02-01',
     );
   });

--- a/src/common/utils/time-utils.ts
+++ b/src/common/utils/time-utils.ts
@@ -1,10 +1,10 @@
 import { DateTime } from 'luxon';
-import moment from 'moment';
 
-export enum timeFormats {
+export enum TimeFormat {
   YYYY_MM_DD = 'yyyy-MM-dd', // 2020-03-01
   MM_DD_YYYY = 'MM/dd/yyyy', // 03/01/2020
   MMM_DD_YYYY = 'MMM dd, yyyy', // Mar 01, 2020
+  MMM_D_YYYY = 'MMM d, yyyy', // Mar 1, 2020
   MMMM_D_YYYY = 'MMMM d, yyyy', // March 1, 2020
   MMMM_D = 'MMMM d', // March 1
 }
@@ -15,12 +15,12 @@ export function parseDateString(dateString: string): Date {
 }
 
 // Format the date object according to the specified string token.
-// More info about tokens: https://momentjs.com/docs/#/displaying/
-export function formatDateTime(date: Date, formatString: timeFormats): string {
+// More info about tokens: https://moment.github.io/luxon/docs/manual/formatting
+export function formatDateTime(date: Date, formatString: TimeFormat): string {
   return DateTime.fromJSDate(date).toFormat(formatString);
 }
 
 // Convert date object to UTC.
 export function dateToUTC(date: Date): Date {
-  return moment.utc(date).toDate();
+  return DateTime.fromJSDate(date, { zone: 'utc' }).toJSDate();
 }

--- a/src/components/Charts/ChartCaseDensity.tsx
+++ b/src/components/Charts/ChartCaseDensity.tsx
@@ -28,6 +28,7 @@ import {
   getTimeAxisTicks,
 } from './utils';
 import { AxisBottom } from 'components/Charts/Axis';
+import { TimeFormat } from 'common/utils/time-utils';
 
 type Point = {
   x: number;
@@ -103,7 +104,7 @@ const ChartCaseDensity: FunctionComponent<{
     <Tooltip
       left={marginLeft + getXCoord(p)}
       top={marginTop + getYCoord(p)}
-      title={formatUtcDate(getDate(p), 'MMM D, YYYY')}
+      title={formatUtcDate(getDate(p), TimeFormat.MMM_D_YYYY)}
       subtitle="DAILY NEW CASES"
       width={'145px'}
     >

--- a/src/components/Charts/ChartRt.tsx
+++ b/src/components/Charts/ChartRt.tsx
@@ -30,6 +30,7 @@ import {
   getTimeAxisTicks,
 } from './utils';
 import { AxisBottom } from 'components/Charts/Axis';
+import { TimeFormat } from 'common/utils/time-utils';
 
 type PointRt = Omit<Column, 'y'> & {
   y: RtRange;
@@ -110,7 +111,7 @@ const ChartRt = ({
       <Tooltip
         left={marginLeft + getXCoord(d)}
         top={marginTop + getYCoord(d)}
-        title={formatUtcDate(getDate(d), 'MMM D, YYYY')}
+        title={formatUtcDate(getDate(d), TimeFormat.MMM_D_YYYY)}
         subtitle="Infection rate"
         subtext={isConfirmed ? undefined : 'Data might change'}
         width="150px"

--- a/src/components/Charts/ChartVaccinations.tsx
+++ b/src/components/Charts/ChartVaccinations.tsx
@@ -18,6 +18,7 @@ import { findPointByDate } from 'components/Explore/utils';
 import * as ChartStyle from './Charts.style';
 import { getUtcScale, getTimeAxisTicks } from './utils';
 import { AxisBottom } from 'components/Charts/Axis';
+import { TimeFormat } from 'common/utils/time-utils';
 
 const getDate = (d: Column) => new Date(d.x);
 const getY = (d: Column) => d.y;
@@ -65,7 +66,7 @@ const VaccinesTooltip: React.FC<{
       width={'160px'}
       top={top(pointInitiated)}
       left={left(pointCompleted ? pointCompleted : pointInitiated)}
-      title={formatUtcDate(new Date(pointInitiated.x), 'MMM D, YYYY')}
+      title={formatUtcDate(new Date(pointInitiated.x), TimeFormat.MMM_D_YYYY)}
     >
       <Styles.TooltipLine>
         <Styles.TooltipLabel>

--- a/src/components/Charts/ChartZones.tsx
+++ b/src/components/Charts/ChartZones.tsx
@@ -28,6 +28,7 @@ import {
   getTimeAxisTicks,
 } from './utils';
 import { AxisBottom } from 'components/Charts/Axis';
+import { TimeFormat } from 'common/utils/time-utils';
 
 type Point = Omit<Column, 'y'> & {
   y: number;
@@ -117,7 +118,7 @@ const ChartZones = ({
     <Tooltip
       top={marginTop + getYCoord(d)}
       left={marginLeft + getXCoord(d)}
-      title={formatUtcDate(getDate(d), 'MMM D, YYYY')}
+      title={formatUtcDate(getDate(d), TimeFormat.MMM_D_YYYY)}
       subtitle={getTooltipContent(getY(d)).subtitle}
       width={getTooltipContent(getY(d)).width}
     >

--- a/src/components/Explore/MultipleLocationsChart.tsx
+++ b/src/components/Explore/MultipleLocationsChart.tsx
@@ -16,6 +16,7 @@ import { Line } from '@vx/shape';
 import DateMarker from './DateMarker';
 import GridLines from './GridLines';
 import Axes from './Axes';
+import { TimeFormat } from 'common/utils/time-utils';
 
 interface LabelInfo {
   x: number;
@@ -52,7 +53,7 @@ const MultipleLocationsTooltip: React.FC<{
       width={'210px'}
       top={top}
       left={left}
-      title={formatUtcDate(new Date(pointInfo.x), 'MMM D, YYYY')}
+      title={formatUtcDate(new Date(pointInfo.x), TimeFormat.MMM_D_YYYY)}
     >
       <Styles.TooltipSubtitle>
         {currentSeries && currentSeries.tooltipLabel}

--- a/src/components/Explore/SingleLocationChart.tsx
+++ b/src/components/Explore/SingleLocationChart.tsx
@@ -16,6 +16,7 @@ import { ScreenshotReady } from 'components/Screenshot';
 import DateMarker from './DateMarker';
 import GridLines from './GridLines';
 import Axes from './Axes';
+import { TimeFormat } from 'common/utils/time-utils';
 
 const getDate = (d: Column) => new Date(d.x);
 const getY = (d: Column) => d.y;
@@ -38,7 +39,7 @@ const SingleLocationTooltip: React.FC<{
       width={'210px'}
       top={top(pointSmooth)}
       left={left(pointSmooth)}
-      title={formatUtcDate(new Date(pointSmooth.x), 'MMM D, YYYY')}
+      title={formatUtcDate(new Date(pointSmooth.x), TimeFormat.MMM_D_YYYY)}
     >
       <Styles.TooltipSubtitle>
         {`${seriesRaw.tooltipLabel}: ${

--- a/src/components/Explore/utils.ts
+++ b/src/components/Explore/utils.ts
@@ -19,7 +19,7 @@ import regions, {
 } from 'common/regions';
 import { fail } from 'assert';
 import { pluralize } from 'common/utils';
-import { timeFormats, formatDateTime } from 'common/utils/time-utils';
+import { TimeFormat, formatDateTime } from 'common/utils/time-utils';
 
 /** Common interface to represent real Projection objects as well as aggregated projections. */
 interface ProjectionLike {
@@ -279,7 +279,7 @@ function getLocationFileName(region: Region) {
 }
 
 export function getImageFilename(locations: Region[], metric: ExploreMetric) {
-  const downloadDate = formatDateTime(new Date(), timeFormats.YYYY_MM_DD);
+  const downloadDate = formatDateTime(new Date(), TimeFormat.YYYY_MM_DD);
   const chartId = getChartIdByMetric(metric);
   const fileNameSuffix = `${chartId}-${downloadDate}`;
 

--- a/src/components/Header/HomePageHeader.tsx
+++ b/src/components/Header/HomePageHeader.tsx
@@ -1,19 +1,15 @@
 import React, { ReactElement } from 'react';
-import moment from 'moment';
 import { Wrapper, Content, Subcopy, Header } from './HomePageHeader.style';
 import { useModelLastUpdatedDate } from 'common/utils/model';
 import { InfoTooltip, renderTooltipContent } from 'components/InfoTooltip';
-// TODO (Fai): Migrate this content to CMS when possible.
-// import { homePageHeaderTooltipContent } from 'cms-content/tooltips';
 import { trackOpenTooltip } from 'components/InfoTooltip';
 import { DateTime } from 'luxon';
+import { dateToUTC, formatDateTime, TimeFormat } from 'common/utils/time-utils';
 
 function renderInfoTooltip(updatedDate: Date): ReactElement {
-  const updatedDateStr = DateTime.fromJSDate(updatedDate).toFormat(
-    'yyyy-MM-dd',
-  );
-  // 5 pm UTC = 9 am PST
-  // TODO (Fai): Update this when we switch to PDT.
+  const updatedDateStr = formatDateTime(updatedDate, TimeFormat.YYYY_MM_DD);
+  // 5 pm UTC = 10 am PST
+  // TODO (Fai): Create time util to set hour of the day.
   const updatedTime = DateTime.fromISO(`${updatedDateStr}T17:00:00.000Z`);
   const updatedTimeStr = updatedTime.toFormat('h a ZZZZ');
   const body = `We aim to update our data by ${updatedTimeStr} daily. Occasionally, when additional review is required, an update can be delayed by several hours. Note that certain data sources that we use (eg. ICU hospitalizations) are only updated once per week.`;
@@ -34,7 +30,8 @@ const HomePageHeader: React.FC = () => {
       <Content>
         <Header>U.S. COVID Risk &amp; Vaccine Tracker</Header>
         <Subcopy>
-          Updated on {moment.utc(lastUpdatedDate).format('MMMM D')}{' '}
+          Updated on{' '}
+          {formatDateTime(dateToUTC(lastUpdatedDate), TimeFormat.MMMM_D)}{' '}
           {renderInfoTooltip(lastUpdatedDate)}
         </Subcopy>
       </Content>

--- a/src/components/LocationPage/ShareButtons.tsx
+++ b/src/components/LocationPage/ShareButtons.tsx
@@ -19,7 +19,7 @@ import * as urls from 'common/urls';
 import { County, MetroArea, Region, State } from 'common/regions';
 import { fail } from 'common/utils';
 import { Metric } from 'common/metricEnum';
-import { timeFormats, formatDateTime } from 'common/utils/time-utils';
+import { TimeFormat, formatDateTime } from 'common/utils/time-utils';
 
 const getShareImageUrl = (region: Region, chartIdentifier: number): string => {
   const imageBaseUrl = ShareImageUrlJSON.share_image_url;
@@ -71,7 +71,7 @@ const InnerContent = ({
   };
 
   const downloadLink = getShareImageUrl(region, chartIdentifier);
-  const downloadDate = formatDateTime(new Date(), timeFormats.YYYY_MM_DD);
+  const downloadDate = formatDateTime(new Date(), TimeFormat.YYYY_MM_DD);
 
   function makeDownloadFilename(chartIdentifier: number) {
     const chartDownloadType = {

--- a/src/screens/Learn/Faq/Faq.tsx
+++ b/src/screens/Learn/Faq/Faq.tsx
@@ -18,7 +18,7 @@ import { EventCategory } from 'components/Analytics';
 import FaqStructuredData from './FaqStructuredData';
 import Footer from 'screens/Learn/Footer/Footer';
 import {
-  timeFormats,
+  TimeFormat,
   parseDateString,
   formatDateTime,
 } from 'common/utils/time-utils';
@@ -65,7 +65,7 @@ const Faq: React.FC = () => {
           Last updated{' '}
           {formatDateTime(
             parseDateString(lastUpdatedDate),
-            timeFormats.MM_DD_YYYY,
+            TimeFormat.MM_DD_YYYY,
           )}
         </LastUpdatedDate>
         <MobileOnly>

--- a/src/screens/Learn/Glossary/Glossary.tsx
+++ b/src/screens/Learn/Glossary/Glossary.tsx
@@ -18,7 +18,7 @@ import { useScrollToTopButton } from 'common/hooks';
 import Footer from 'screens/Learn/Footer/Footer';
 import ExternalLink from 'components/ExternalLink';
 import {
-  timeFormats,
+  TimeFormat,
   parseDateString,
   formatDateTime,
 } from 'common/utils/time-utils';
@@ -80,7 +80,7 @@ const Glossary: React.FC = () => {
           Last updated{' '}
           {formatDateTime(
             parseDateString(lastUpdatedDate),
-            timeFormats.MM_DD_YYYY,
+            TimeFormat.MM_DD_YYYY,
           )}
         </LastUpdatedDate>
         {terms.map((term: Term, i: number) => (

--- a/src/screens/internal/ShareImage/ShareCardImage.tsx
+++ b/src/screens/internal/ShareImage/ShareCardImage.tsx
@@ -10,7 +10,7 @@ import { DarkScreenshotWrapper } from './ShareImage.style';
 import { ScreenshotReady, SCREENSHOT_CLASS } from 'components/Screenshot';
 import { useRegionFromParams } from 'common/regions';
 import { Region } from 'common/regions';
-import { timeFormats, formatDateTime } from 'common/utils/time-utils';
+import { TimeFormat, formatDateTime } from 'common/utils/time-utils';
 
 // TODO(michael): Split this into HomeImage and LocationImage (with some shared code).
 
@@ -38,7 +38,7 @@ const Header = (props: { isHomePage?: Boolean }) => {
         Real-time COVID metrics
       </TitleWrapper>
       <LastUpdatedWrapper>
-        Updated {formatDateTime(new Date(), timeFormats.MMMM_D_YYYY)}
+        Updated {formatDateTime(new Date(), TimeFormat.MMMM_D_YYYY)}
       </LastUpdatedWrapper>
     </>
   );


### PR DESCRIPTION
This PR migrates all direct usages of `moment` for UTC conversion to using time utils instead.