### PR TITLE
Add share widgets to FAQ

### DIFF
--- a/src/screens/Learn/Faq/Section.tsx
+++ b/src/screens/Learn/Faq/Section.tsx
@@ -7,7 +7,7 @@ import { trackEvent, EventAction, EventCategory } from 'components/Analytics';
 
 const Section = (props: { section: FaqSection }) => {
   const { section } = props;
-  const url = 'https://covidactnow.org/faq#';
+  const url = 'https://covidactnow.org/faq';
   const trackShareFacebook = () =>
     trackEvent(EventCategory.FAQ, EventAction.SHARE, 'facebook');
   const trackShareTwitter = () =>
@@ -23,8 +23,8 @@ const Section = (props: { section: FaqSection }) => {
             <ItemName id={question.questionId}>{question.question}</ItemName>
             <MarkdownContent source={question.answer} />
             <SmallShareButtons
-              shareUrl={url + question.questionId}
-              shareQuote={`See the answer to '${question.question}', part of @CovidActNow's FAQs.`}
+              shareUrl={`${url}#${question.questionId}`}
+              shareQuote={`${question.question} @CovidActNow breaks down my top COVID questions. Learn more:`}
               onCopyLink={trackCopyLink}
               onShareOnFacebook={trackShareFacebook}
               onShareOnTwitter={trackShareTwitter}

--- a/src/screens/Learn/Faq/Section.tsx
+++ b/src/screens/Learn/Faq/Section.tsx
@@ -4,10 +4,10 @@ import { MarkdownContent } from 'components/Markdown';
 import { FaqSection, Question } from 'cms-content/learn';
 import SmallShareButtons from 'components/SmallShareButtons';
 import { trackEvent, EventAction, EventCategory } from 'components/Analytics';
+import urlJoin from 'url-join';
 
 const Section = (props: { section: FaqSection }) => {
   const { section } = props;
-  const url = 'https://covidactnow.org/faq';
   const trackShareFacebook = () =>
     trackEvent(EventCategory.FAQ, EventAction.SHARE, 'facebook');
   const trackShareTwitter = () =>
@@ -23,7 +23,11 @@ const Section = (props: { section: FaqSection }) => {
             <ItemName id={question.questionId}>{question.question}</ItemName>
             <MarkdownContent source={question.answer} />
             <SmallShareButtons
-              shareUrl={`${url}#${question.questionId}`}
+              shareUrl={urlJoin(
+                'https://covidactnow.org',
+                'faq',
+                `#${question.questionId}`,
+              )}
               shareQuote={`${question.question} @CovidActNow breaks down my top COVID questions. Learn more:`}
               onCopyLink={trackCopyLink}
               onShareOnFacebook={trackShareFacebook}

--- a/src/screens/Learn/Faq/Section.tsx
+++ b/src/screens/Learn/Faq/Section.tsx
@@ -2,9 +2,18 @@ import React, { Fragment } from 'react';
 import { SectionName, ItemName, ItemsContainer } from '../Learn.style';
 import { MarkdownContent } from 'components/Markdown';
 import { FaqSection, Question } from 'cms-content/learn';
+import SmallShareButtons from 'components/SmallShareButtons';
+import { trackEvent, EventAction, EventCategory } from 'components/Analytics';
 
 const Section = (props: { section: FaqSection }) => {
   const { section } = props;
+  const url = 'https://covidactnow.org/faq#';
+  const trackShareFacebook = () =>
+    trackEvent(EventCategory.FAQ, EventAction.SHARE, 'facebook');
+  const trackShareTwitter = () =>
+    trackEvent(EventCategory.FAQ, EventAction.SHARE, 'twitter');
+  const trackCopyLink = () =>
+    trackEvent(EventCategory.FAQ, EventAction.COPY_LINK, 'FAQ');
   return (
     <Fragment>
       <SectionName id={section.sectionId}>{section.sectionTitle}</SectionName>
@@ -13,6 +22,13 @@ const Section = (props: { section: FaqSection }) => {
           <Fragment key={`faq-question-${i}`}>
             <ItemName id={question.questionId}>{question.question}</ItemName>
             <MarkdownContent source={question.answer} />
+            <SmallShareButtons
+              shareUrl={url + question.questionId}
+              shareQuote={`See the answer to '${question.question}', part of @CovidActNow's FAQs.`}
+              onCopyLink={trackCopyLink}
+              onShareOnFacebook={trackShareFacebook}
+              onShareOnTwitter={trackShareTwitter}
+            />
           </Fragment>
         ))}
       </ItemsContainer>


### PR DESCRIPTION
This PR experiments with adding share widgets to each FAQ. All props of `SmallShareButtons` are not implemented yet as this is simply an exploration.