### PR TITLE
Pull `projections` out of LocationPageHeader

### DIFF
--- a/src/components/LocationPage/ChartsHolder.tsx
+++ b/src/components/LocationPage/ChartsHolder.tsx
@@ -177,7 +177,7 @@ const ChartsHolder = ({ projections, region, chartId }: ChartsHolderProps) => {
     <>
       <ChartContentWrapper>
         <LocationPageHeader
-          projections={projections}
+          alarmLevel={projections.getAlarmLevel()}
           stats={projections.getMetricValues()}
           onMetricClick={metric => onClickMetric(metric)}
           onHeaderShareClick={onClickShare}

--- a/src/components/LocationPage/LocationPageHeader.tsx
+++ b/src/components/LocationPage/LocationPageHeader.tsx
@@ -7,9 +7,8 @@ import { Level } from 'common/level';
 import { COLOR_MAP } from 'common/colors';
 import { Metric } from 'common/metricEnum';
 import { useModelLastUpdatedDate } from 'common/utils/model';
-import { Projections } from 'common/models/Projections';
 import { formatUtcDate } from 'common/utils';
-import { Region } from 'common/regions';
+import { County, Region } from 'common/regions';
 import LocationHeaderStats from 'components/SummaryStats/LocationHeaderStats';
 import { ThermometerImage } from 'components/Thermometer';
 import LocationPageHeading from './LocationPageHeading';
@@ -50,7 +49,7 @@ function renderInfoTooltip(): React.ReactElement {
 const noop = () => {};
 
 const LocationPageHeader = (props: {
-  projections: Projections;
+  alarmLevel: Level;
   condensed?: boolean;
   stats: { [key: string]: number | null };
   onMetricClick: (metric: Metric) => void;
@@ -62,13 +61,12 @@ const LocationPageHeader = (props: {
   const hasStats = !!Object.values(props.stats).filter(
     (val: number | null) => val !== null,
   ).length;
-  const { projections, region } = props;
+  const { alarmLevel, region } = props;
+  const isCounty = region instanceof County;
 
   //TODO (chelsi): get rid of this use of 'magic' numbers
   const headerTopMargin = !hasStats ? -202 : -218;
   const headerBottomMargin = !hasStats ? 0 : 0;
-
-  const alarmLevel = projections.getAlarmLevel();
 
   const levelInfo = LOCATION_SUMMARY_LEVELS[alarmLevel];
 
@@ -132,7 +130,7 @@ const LocationPageHeader = (props: {
           />
         </TopContainer>
         <FooterContainer>
-          {projections.isCounty && !isEmbed && (
+          {isCounty && !isEmbed && (
             <HeaderSubCopy>
               <span>Updated {lastUpdatedDateString} · </span>
               <span>See something wrong? </span>
@@ -146,7 +144,7 @@ const LocationPageHeader = (props: {
               .
             </HeaderSubCopy>
           )}
-          {!projections.isCounty && !isEmbed && (
+          {!isCounty && !isEmbed && (
             <HeaderSubCopy>
               <LastUpdatedDate>Updated {lastUpdatedDateString}</LastUpdatedDate>
             </HeaderSubCopy>

--- a/src/components/LocationPage/LocationPageHeader.tsx
+++ b/src/components/LocationPage/LocationPageHeader.tsx
@@ -121,7 +121,7 @@ const LocationPageHeader = (props: {
               </SectionColumn>
             </SectionHalf>
             <SectionHalf>
-              <NotificationArea projections={projections} />
+              <NotificationArea region={region} />
             </SectionHalf>
           </HeaderSection>
           <LocationHeaderStats

--- a/src/components/LocationPage/Notifications.tsx
+++ b/src/components/LocationPage/Notifications.tsx
@@ -8,7 +8,6 @@ import {
   WarningIcon,
   PurpleInfoIcon,
 } from 'components/LocationPage/LocationPageHeader.style';
-import { Projections } from 'common/models/Projections';
 import { State, County, Region, MetroArea } from 'common/regions';
 import { trackEvent, EventCategory, EventAction } from 'components/Analytics';
 import { CcviLevel, getCcviLevel, getCcviLevelName } from 'common/ccvi';
@@ -39,11 +38,7 @@ const EXPOSURE_NOTIFICATIONS_STATE_FIPS = [
   '56', // Wyoming
 ];
 
-const NotificationArea: React.FC<{ projections: Projections }> = ({
-  projections,
-}) => {
-  const region = projections.region;
-
+const NotificationArea: React.FC<{ region: Region }> = ({ region }) => {
   enum Notification {
     HospitalizationsPeak,
     ExposureNotifications,
@@ -86,7 +81,7 @@ const NotificationArea: React.FC<{ projections: Projections }> = ({
         {notification === Notification.Vulnerability && (
           <VulnerabilityCopy
             locationName={region.shortName}
-            fips={projections.fips}
+            fips={region.fipsCode}
           />
         )}
       </SectionColumn>


### PR DESCRIPTION
We don't actually need the whole projections in the location page header, so pull it out and pass in or compute what we need (alarmLevel / isCounty).

This will also help defer loading of projection details for metrics charts below while still rendering a helpful header above the fold.