### PR TITLE
Add time manipulation utils

### DIFF
--- a/src/common/utils/time-utils.test.ts
+++ b/src/common/utils/time-utils.test.ts
@@ -1,8 +1,11 @@
 import {
   TimeFormat,
+  TimeUnit,
   formatDateTime,
   parseDateString,
   dateToUTC,
+  addTime,
+  subtractTime,
 } from 'common/utils/time-utils';
 
 // Date object constructor takes a zero-indexed month number.
@@ -55,5 +58,45 @@ describe('convert to UTC', () => {
   // Ambiguous date is assumed to be in UTC.
   test('Date object to UTC', () => {
     expect(dateToUTC(testDate).toISOString()).toBe('2020-03-01T08:00:00.000Z');
+  });
+});
+
+describe('add time', () => {
+  test('Add hours', () => {
+    expect(addTime(testDate, 8, TimeUnit.HOURS).toISOString()).toBe(
+      '2020-03-01T16:00:00.000Z',
+    );
+  });
+  test('Add days', () => {
+    expect(addTime(testDate, 5, TimeUnit.DAYS)).toEqual(new Date(2020, 2, 6));
+  });
+  test('Add weeks', () => {
+    expect(addTime(testDate, 2, TimeUnit.WEEKS)).toEqual(new Date(2020, 2, 15));
+  });
+  test('Add months', () => {
+    expect(addTime(testDate, 3, TimeUnit.MONTHS)).toEqual(new Date(2020, 5, 1));
+  });
+});
+
+describe('subtract time', () => {
+  test('Subtract hours', () => {
+    expect(subtractTime(testDate, 8, TimeUnit.HOURS).toISOString()).toBe(
+      '2020-03-01T00:00:00.000Z',
+    );
+  });
+  test('Subtract days', () => {
+    expect(subtractTime(testDate, 5, TimeUnit.DAYS)).toEqual(
+      new Date(2020, 1, 25),
+    );
+  });
+  test('Subtract weeks', () => {
+    expect(subtractTime(testDate, 2, TimeUnit.WEEKS)).toEqual(
+      new Date(2020, 1, 16),
+    );
+  });
+  test('Subtract months', () => {
+    expect(subtractTime(testDate, 3, TimeUnit.MONTHS)).toEqual(
+      new Date(2019, 11, 1),
+    );
   });
 });

--- a/src/common/utils/time-utils.ts
+++ b/src/common/utils/time-utils.ts
@@ -1,4 +1,5 @@
 import { DateTime } from 'luxon';
+import moment from 'moment';
 
 export enum TimeFormat {
   YYYY_MM_DD = 'yyyy-MM-dd', // 2020-03-01
@@ -7,6 +8,13 @@ export enum TimeFormat {
   MMM_D_YYYY = 'MMM d, yyyy', // Mar 1, 2020
   MMMM_D_YYYY = 'MMMM d, yyyy', // March 1, 2020
   MMMM_D = 'MMMM d', // March 1
+}
+
+export enum TimeUnit {
+  HOURS = 'hours',
+  DAYS = 'days',
+  WEEKS = 'weeks',
+  MONTHS = 'months',
 }
 
 // Parse date string to JS date object.
@@ -23,4 +31,14 @@ export function formatDateTime(date: Date, formatString: TimeFormat): string {
 // Convert date object to UTC.
 export function dateToUTC(date: Date): Date {
   return DateTime.fromJSDate(date, { zone: 'utc' }).toJSDate();
+}
+
+// Add a specified amount of time (in units) to date object.
+export function addTime(date: Date, amount: number, unit: TimeUnit): Date {
+  return moment(date).add(amount, unit).toDate();
+}
+
+// Subtract a specified amount of time (in units) to date object.
+export function subtractTime(date: Date, amount: number, unit: TimeUnit): Date {
+  return moment(date).subtract(amount, unit).toDate();
 }


### PR DESCRIPTION
This PR creates time utils to add time to or subtract time from a given date object in specified units. Functions adding or subtracting time that are directly using `moment` will be replaced with these time utils. After that, we will switch these utils to use `Luxon` instead.