### PR TITLE
Migrate time manipulation utils to Luxon

### DIFF
--- a/scripts/alert_emails/generate_daily_alerts.ts
+++ b/scripts/alert_emails/generate_daily_alerts.ts
@@ -13,11 +13,17 @@ import path from 'path';
 import { fetchMainSnapshotNumber } from '../../src/common/utils/snapshots';
 import regions from '../../src/common/regions';
 import { Alert } from './interfaces';
-import moment from 'moment';
 import { getFirestore } from '../common/firebase';
 import { SummariesMap } from '../../src/common/location_summaries';
 import { Level } from '../../src/common/level';
 import { resolveSnapshot } from './utils';
+import {
+  dateToUTC,
+  TimeUnit,
+  subtractTime,
+  TimeFormat,
+  formatDateTime,
+} from '../../src/common/utils/time-utils';
 
 const summariesFolder = path.join(__dirname, 'summaries');
 const outputFile = path.join(__dirname, 'alerts.json');
@@ -43,7 +49,10 @@ async function main() {
     const locationName = region.fullName;
     const locationURL = region.canonicalUrl;
     // Use today's date (roughly in the Pacific timezone).
-    const lastUpdated = moment.utc().subtract(8, 'hours').format('MM/DD/YYYY');
+    const lastUpdated = formatDateTime(
+      subtractTime(dateToUTC(new Date()), 8, TimeUnit.HOURS),
+      TimeFormat.MM_DD_YYYY,
+    );
     if (oldLevel !== newLevel && newLevel !== Level.UNKNOWN) {
       alerts[fips] = {
         fips,

--- a/src/common/utils/time-utils.test.ts
+++ b/src/common/utils/time-utils.test.ts
@@ -3,6 +3,7 @@ import {
   TimeUnit,
   formatDateTime,
   parseDateString,
+  parseDateUnix,
   dateToUTC,
   addTime,
   subtractTime,
@@ -50,6 +51,20 @@ describe('date string parsing', () => {
   });
   test('Date string to date object', () => {
     expect(parseDateString('2020-03-01')).toEqual(testDate);
+  });
+});
+
+// Unix time are expressed in milliseconds.
+describe('unix time parsing', () => {
+  test('unix time at midnight', () => {
+    expect(parseDateUnix(1583049600000).toISOString()).toBe(
+      '2020-03-01T08:00:00.000Z',
+    );
+  });
+  test('unix time with non-zero minutes and seconds', () => {
+    expect(parseDateUnix(1583080230000).toISOString()).toBe(
+      '2020-03-01T16:30:30.000Z',
+    );
   });
 });
 

--- a/src/common/utils/time-utils.ts
+++ b/src/common/utils/time-utils.ts
@@ -1,5 +1,4 @@
 import { DateTime } from 'luxon';
-import moment from 'moment';
 
 export enum TimeFormat {
   YYYY_MM_DD = 'yyyy-MM-dd', // 2020-03-01
@@ -7,14 +6,16 @@ export enum TimeFormat {
   MMM_DD_YYYY = 'MMM dd, yyyy', // Mar 01, 2020
   MMM_D_YYYY = 'MMM d, yyyy', // Mar 1, 2020
   MMMM_D_YYYY = 'MMMM d, yyyy', // March 1, 2020
+  MMM_YY = 'MMM yy', // Mar 20.
   MMMM_D = 'MMMM d', // March 1
+  MMM = 'MMM', // Mar
 }
 
 export enum TimeUnit {
-  HOURS = 'hours',
-  DAYS = 'days',
-  WEEKS = 'weeks',
-  MONTHS = 'months',
+  HOURS,
+  DAYS,
+  WEEKS,
+  MONTHS,
 }
 
 // Parse date string to JS date object.
@@ -22,10 +23,19 @@ export function parseDateString(dateString: string): Date {
   return DateTime.fromISO(dateString).toJSDate();
 }
 
+// Parse unix timestamp (in milliseconds) to JS date object.
+export function parseDateUnix(unixTimestamp: number): Date {
+  return DateTime.fromMillis(unixTimestamp).toJSDate();
+}
+
 // Format the date object according to the specified string token.
 // More info about tokens: https://moment.github.io/luxon/docs/manual/formatting
-export function formatDateTime(date: Date, formatString: TimeFormat): string {
-  return DateTime.fromJSDate(date).toFormat(formatString);
+export function formatDateTime(date: Date, format: TimeFormat): string {
+  return DateTime.fromJSDate(date).toFormat(format);
+}
+
+export function formatUTCDateTime(date: Date, format: TimeFormat): string {
+  return DateTime.fromJSDate(date, { zone: 'utc' }).toFormat(format);
 }
 
 // Convert date object to UTC.
@@ -35,10 +45,28 @@ export function dateToUTC(date: Date): Date {
 
 // Add a specified amount of time (in units) to date object.
 export function addTime(date: Date, amount: number, unit: TimeUnit): Date {
-  return moment(date).add(amount, unit).toDate();
+  switch (unit) {
+    case TimeUnit.HOURS:
+      return DateTime.fromJSDate(date).plus({ hours: amount }).toJSDate();
+    case TimeUnit.DAYS:
+      return DateTime.fromJSDate(date).plus({ days: amount }).toJSDate();
+    case TimeUnit.WEEKS:
+      return DateTime.fromJSDate(date).plus({ weeks: amount }).toJSDate();
+    case TimeUnit.MONTHS:
+      return DateTime.fromJSDate(date).plus({ months: amount }).toJSDate();
+  }
 }
 
 // Subtract a specified amount of time (in units) to date object.
 export function subtractTime(date: Date, amount: number, unit: TimeUnit): Date {
-  return moment(date).subtract(amount, unit).toDate();
+  switch (unit) {
+    case TimeUnit.HOURS:
+      return DateTime.fromJSDate(date).minus({ hours: amount }).toJSDate();
+    case TimeUnit.DAYS:
+      return DateTime.fromJSDate(date).minus({ days: amount }).toJSDate();
+    case TimeUnit.WEEKS:
+      return DateTime.fromJSDate(date).minus({ weeks: amount }).toJSDate();
+    case TimeUnit.MONTHS:
+      return DateTime.fromJSDate(date).minus({ months: amount }).toJSDate();
+  }
 }

--- a/src/components/Charts/utils.ts
+++ b/src/components/Charts/utils.ts
@@ -3,6 +3,13 @@ import { range } from 'lodash';
 import moment from 'moment';
 import { scaleUtc } from '@vx/scale';
 import { LevelInfoMap, Level, LevelInfo } from 'common/level';
+import {
+  TimeFormat,
+  formatDateTime,
+  TimeUnit,
+  addTime,
+  subtractTime,
+} from 'common/utils/time-utils';
 
 export const last = (list: any[]) => list[list.length - 1];
 
@@ -12,7 +19,7 @@ export const roundAxisLimits = (axisMin: number, axisMax: number) => [
 ];
 
 export const getTruncationDate = (date: Date, truncationDays: number) =>
-  moment(date).subtract(truncationDays, 'days').toDate();
+  subtractTime(date, truncationDays, TimeUnit.DAYS);
 
 export const randomizeId = (name: string): string =>
   `${name}-${Math.random().toFixed(9)}`;
@@ -163,12 +170,12 @@ export const getUtcScale = (
 };
 
 export const getXTickFormat = (date: Date) => {
-  const momentDate = moment(date);
-
   // Shows the year if the tick is in January (0) or December (11)
   const dateFormat =
-    momentDate.month() === 0 || momentDate.month() === 11 ? `MMM 'YY` : 'MMM';
-  return momentDate.format(dateFormat);
+    date.getMonth() === 0 || date.getMonth() === 11
+      ? TimeFormat.MMM_YY
+      : TimeFormat.MMM;
+  return formatDateTime(date, dateFormat).replace(' ', " '");
 };
 
 /**
@@ -189,6 +196,6 @@ export function getTimeAxisTicks(from: Date, to: Date) {
   const dateFrom = moment(from).startOf('month').toDate();
   const numMonths = moment(to).diff(dateFrom, 'months');
   return range(1, numMonths + 1).map((i: number) =>
-    moment(dateFrom).add(i, 'month').toDate(),
+    addTime(dateFrom, i, TimeUnit.MONTHS),
   );
 }

--- a/src/components/NationalText/utils.tsx
+++ b/src/components/NationalText/utils.tsx
@@ -1,13 +1,17 @@
 import React, { Fragment } from 'react';
 import AggregationsJSON from 'assets/data/aggregations.json';
 import { last, isNull } from 'lodash';
-import moment from 'moment';
 import {
   formatPercent,
   formatDecimal,
   getPercentChange,
   formatEstimate,
 } from 'common/utils';
+import {
+  parseDateUnix,
+  TimeFormat,
+  formatUTCDateTime,
+} from 'common/utils/time-utils';
 
 const getTwoWeekPercentChange = (series: any[]): number | null => {
   const lastTwoWeeks = series.slice(-15);
@@ -43,9 +47,10 @@ export function getNationalText(): React.ReactElement {
   );
 
   const lastDate = last(dates);
-  const lastDateFormatted: string = moment
-    .utc(lastDate)
-    .format('MMMM Do, YYYY');
+  const lastDateFormatted: string = formatUTCDateTime(
+    parseDateUnix(lastDate!),
+    TimeFormat.MMMM_D_YYYY,
+  );
 
   const getChangeDescriptorCopy = (percentChange: number): string => {
     const changeByCopy = `by about ${formatPercent(Math.abs(percentChange))}`;


### PR DESCRIPTION
This PR migrates time additions and subtractions to Luxon and adds a time util to parse time from Unix timestamp (in milliseconds).