### PR TITLE
fix compare slider component

### DIFF
--- a/src/components/Compare/HomepageSlider.stories.tsx
+++ b/src/components/Compare/HomepageSlider.stories.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import HomepageSlider from './HomepageSlider';
+import { HomepageLocationScope } from 'common/utils/compare';
+
+export default {
+  title: 'Shared Components/HomepageSlider',
+  component: HomepageSlider,
+};
+
+export const Example = () => (
+  <HomepageSlider
+    $isModal={false}
+    homepageScope={HomepageLocationScope.MSA}
+    onChange={() => {}}
+    homepageSliderValue={50}
+  />
+);

--- a/src/components/Compare/HomepageSlider.tsx
+++ b/src/components/Compare/HomepageSlider.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { HomepageLocationScope, homepageLabelMap } from 'common/utils/compare';
 import { SliderContainer } from 'components/Compare/Filters.style';
 import { StyledSlider } from './HomepageSlider.style';
-import VisuallyHiddenDiv from 'components/VisuallyHidden/VisuallyHidden';
 
 /* Last value is set to 99 for styling so that the final mark falls on the slider and not to the right of it */
 const marks = [
@@ -20,9 +19,13 @@ const marks = [
   },
 ];
 
-function getValueLabel(value: number): string {
+function getAriaValueText(value: number): string {
   const item = marks.find(item => item.value === value);
   return item?.label ?? 'Unknown value';
+}
+
+function getAriaLabel(index: number): string {
+  return index < 3 ? marks[index].label : 'Unknown value';
 }
 
 const HomepageSlider: React.FC<{
@@ -30,24 +33,21 @@ const HomepageSlider: React.FC<{
   homepageScope: HomepageLocationScope;
   homepageSliderValue: HomepageLocationScope;
   $isModal: boolean;
-}> = ({ onChange, homepageScope, homepageSliderValue, $isModal }) => {
-  const currentLabel = homepageLabelMap[homepageScope].plural;
-
-  return (
-    <SliderContainer $isModal={$isModal}>
-      <StyledSlider
-        onChange={onChange}
-        value={homepageSliderValue}
-        step={null}
-        marks={marks}
-        track={false}
-        $homepageScope={homepageScope}
-        $isModal={$isModal}
-        aria-label="Select county, metro areas or states"
-        getAriaValueText={getValueLabel}
-      />
-    </SliderContainer>
-  );
-};
+}> = ({ onChange, homepageScope, homepageSliderValue, $isModal }) => (
+  <SliderContainer $isModal={$isModal}>
+    <StyledSlider
+      onChange={onChange}
+      value={homepageSliderValue}
+      step={null}
+      marks={marks}
+      track={false}
+      $homepageScope={homepageScope}
+      $isModal={$isModal}
+      aria-label="Select county, metro areas or states"
+      getAriaValueText={getAriaValueText}
+      getAriaLabel={getAriaLabel}
+    />
+  </SliderContainer>
+);
 
 export default HomepageSlider;

--- a/src/components/Compare/HomepageSlider.tsx
+++ b/src/components/Compare/HomepageSlider.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { HomepageLocationScope, homepageLabelMap } from 'common/utils/compare';
 import { SliderContainer } from 'components/Compare/Filters.style';
 import { StyledSlider } from './HomepageSlider.style';
+import VisuallyHiddenDiv from 'components/VisuallyHidden/VisuallyHidden';
 
 /* Last value is set to 99 for styling so that the final mark falls on the slider and not to the right of it */
 const marks = [
@@ -19,12 +20,19 @@ const marks = [
   },
 ];
 
+function getValueLabel(value: number): string {
+  const item = marks.find(item => item.value === value);
+  return item?.label ?? 'Unknown value';
+}
+
 const HomepageSlider: React.FC<{
   onChange: (event: React.ChangeEvent<{}>, value: any) => void;
   homepageScope: HomepageLocationScope;
   homepageSliderValue: HomepageLocationScope;
   $isModal: boolean;
 }> = ({ onChange, homepageScope, homepageSliderValue, $isModal }) => {
+  const currentLabel = homepageLabelMap[homepageScope].plural;
+
   return (
     <SliderContainer $isModal={$isModal}>
       <StyledSlider
@@ -35,6 +43,8 @@ const HomepageSlider: React.FC<{
         track={false}
         $homepageScope={homepageScope}
         $isModal={$isModal}
+        aria-label="Select county, metro areas or states"
+        getAriaValueText={getValueLabel}
       />
     </SliderContainer>
   );


### PR DESCRIPTION
[Trello](https://trello.com/c/HQ4EvlEY/1117-accessibility-add-aria-labels-to-slider-values) - The slider component was missing the `aria-label` attribute and the text version for the selected value. I also added the `getValueLabel` property which gives values its corresponding name.

Tested with VoiceOver, works well 

**Learn more**
- https://material-ui.com/components/slider/#accessibility
- https://material-ui.com/api/slider/