### PR TITLE
add missing aria-labels on the new footer

### DIFF
--- a/src/components/ExternalLink/ExternalLink.tsx
+++ b/src/components/ExternalLink/ExternalLink.tsx
@@ -1,11 +1,23 @@
-import React from 'react';
+import React, { DetailedHTMLProps } from 'react';
 
-const ExternalLink: React.FC<{ href: string; onClick?: () => void }> = ({
+type AnchorLinkType = DetailedHTMLProps<
+  React.AnchorHTMLAttributes<HTMLAnchorElement>,
+  HTMLAnchorElement
+>;
+
+const ExternalLink: React.FC<AnchorLinkType> = ({
   href,
   children,
   onClick = () => {},
+  ...otherProps
 }) => (
-  <a href={href} target="_blank" rel="noopener noreferrer" onClick={onClick}>
+  <a
+    href={href}
+    onClick={onClick}
+    {...otherProps}
+    target="_blank"
+    rel="noopener noreferrer"
+  >
     {children}
   </a>
 );

--- a/src/components/ExternalLink/ExternalLink.tsx
+++ b/src/components/ExternalLink/ExternalLink.tsx
@@ -6,18 +6,10 @@ type AnchorLinkType = DetailedHTMLProps<
 >;
 
 const ExternalLink: React.FC<AnchorLinkType> = ({
-  href,
   children,
-  onClick = () => {},
   ...otherProps
 }) => (
-  <a
-    href={href}
-    onClick={onClick}
-    {...otherProps}
-    target="_blank"
-    rel="noopener noreferrer"
-  >
+  <a target="_blank" rel="noopener noreferrer" {...otherProps}>
     {children}
   </a>
 );

--- a/src/components/NewFooter/MenuContent.tsx
+++ b/src/components/NewFooter/MenuContent.tsx
@@ -46,7 +46,7 @@ const MenuContent: React.FC = () => {
         ))}
       </Section>
       <Section>
-        <LogoWrapper to="/">
+        <LogoWrapper to="/" aria-label="Covid Act Now">
           <LogoNonUrl />
         </LogoWrapper>
         <AboutCopy>{aboutUs}</AboutCopy>


### PR DESCRIPTION
- The `ExternalLink` component was not passing additional link props to the underlying `a` element
- The link to the logo didn't have an alt-text (set to "Covid Act Now")