### PR TITLE
Use summary for location page header

### DIFF
--- a/src/common/models/Projections.ts
+++ b/src/common/models/Projections.ts
@@ -8,6 +8,12 @@ import { LocationSummary, MetricSummary } from 'common/location_summaries';
 import { RegionSummaryWithTimeseries } from 'api/schema/RegionSummaryWithTimeseries';
 import { County, Region } from 'common/regions';
 
+export type MetricValue = number | null;
+
+export type MetricValues = {
+  [metric in Metric]: MetricValue;
+};
+
 /**
  * The complete set of data / metrics and related information for a given
  * location (state or county).
@@ -77,12 +83,12 @@ export class Projections {
     return this.getMetricValue(metric) !== null;
   }
 
-  getMetricValue(metric: Metric): number | null {
+  getMetricValue(metric: Metric): MetricValue {
     return this.primary.getMetricValue(metric);
   }
 
-  getMetricValues(): { [metric in Metric]: number | null } {
-    const result = {} as { [metric in Metric]: number | null };
+  getMetricValues(): MetricValues {
+    const result = {} as MetricValues;
     for (const metric of ALL_METRICS) {
       result[metric] = this.getMetricValue(metric);
     }

--- a/src/common/models/Projections.ts
+++ b/src/common/models/Projections.ts
@@ -8,10 +8,8 @@ import { LocationSummary, MetricSummary } from 'common/location_summaries';
 import { RegionSummaryWithTimeseries } from 'api/schema/RegionSummaryWithTimeseries';
 import { County, Region } from 'common/regions';
 
-export type MetricValue = number | null;
-
 export type MetricValues = {
-  [metric in Metric]: MetricValue;
+  [metric in Metric]: number | null;
 };
 
 /**
@@ -83,7 +81,7 @@ export class Projections {
     return this.getMetricValue(metric) !== null;
   }
 
-  getMetricValue(metric: Metric): MetricValue {
+  getMetricValue(metric: Metric): number | null {
     return this.primary.getMetricValue(metric);
   }
 

--- a/src/components/LocationPage/ChartsHolder.tsx
+++ b/src/components/LocationPage/ChartsHolder.tsx
@@ -181,9 +181,7 @@ const ChartsHolder = ({ region, chartId }: ChartsHolderProps) => {
     scrollToRecommendations();
   }, [chartId, metricRefs, isRecommendationsShareUrl]);
 
-  const initialFipsList = useMemo(() => {
-    return projections?.primary?.fips ? [projections.primary.fips] : [];
-  }, [projections]);
+  const initialFipsList = [region.fipsCode];
 
   const ccviScores = useCcviForFips(region.fipsCode);
 

--- a/src/components/LocationPage/LocationPageHeader.tsx
+++ b/src/components/LocationPage/LocationPageHeader.tsx
@@ -33,6 +33,7 @@ import { MetroArea } from 'common/regions';
 import { InfoTooltip, renderTooltipContent } from 'components/InfoTooltip';
 import { locationPageHeaderTooltipContent } from 'cms-content/tooltips';
 import { trackOpenTooltip } from 'components/InfoTooltip';
+import type { MetricValues } from 'common/models/Projections';
 
 function renderInfoTooltip(): React.ReactElement {
   const { body } = locationPageHeaderTooltipContent;
@@ -51,7 +52,7 @@ const noop = () => {};
 const LocationPageHeader = (props: {
   alarmLevel: Level;
   condensed?: boolean;
-  stats: { [key: string]: number | null };
+  stats: MetricValues;
   onMetricClick: (metric: Metric) => void;
   onHeaderShareClick: () => void;
   onHeaderSignupClick: () => void;

--- a/src/screens/LocationPage/LocationPage.tsx
+++ b/src/screens/LocationPage/LocationPage.tsx
@@ -6,8 +6,6 @@ import AppMetaTags from 'components/AppMetaTags/AppMetaTags';
 import MiniMap from 'components/MiniMap';
 import EnsureSharingIdInUrl from 'components/EnsureSharingIdInUrl';
 import ChartsHolder from 'components/LocationPage/ChartsHolder';
-import { LoadingScreen } from './LocationPage.style';
-import { useProjectionsFromRegion } from 'common/utils/model';
 import { getPageTitle, getPageDescription } from './utils';
 import { getStateCode, MetroArea, Region } from 'common/regions';
 
@@ -21,7 +19,6 @@ function LocationPage({ region }: LocationPageProps) {
   const defaultMapOption = getDefaultMapOption(region);
   const [mapOption, setMapOption] = useState(defaultMapOption);
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
-  const projections = useProjectionsFromRegion(region);
 
   useEffect(() => {
     setMapOption(defaultMapOption);
@@ -42,17 +39,7 @@ function LocationPage({ region }: LocationPageProps) {
           mobileMenuOpen={mobileMenuOpen}
           setMobileMenuOpen={setMobileMenuOpen}
         />
-        {/* Shows a loading screen if projections are not loaded yet, or
-         * if a new location has been selected */}
-        {!projections || projections.fips !== region.fipsCode ? (
-          <LoadingScreen />
-        ) : (
-          <ChartsHolder
-            projections={projections}
-            chartId={chartId}
-            region={region}
-          />
-        )}
+        <ChartsHolder chartId={chartId} region={region} />
         <MiniMap
           region={region}
           mobileMenuOpen={mobileMenuOpen}


### PR DESCRIPTION
This allows deferred loading of the projections needed for the other graphs below the fold.