### PR TITLE
change the email input label under 360px

### DIFF
--- a/src/components/EmailAlertsForm/EmailAlertsForm.tsx
+++ b/src/components/EmailAlertsForm/EmailAlertsForm.tsx
@@ -49,7 +49,7 @@ const EmailAlertsForm: React.FC<{
   const [showConfirmation, setShowConfirmation] = useState(false);
   const formRef = createRef<HTMLFormElement>();
 
-  const isSmallMobile = useBreakpoint(321);
+  const isSmallMobile = useBreakpoint(360);
 
   // The default (geolocated) regions are updated asynchronously, so once we
   // get the default regions we set them as selected initially

--- a/src/components/EmailAlertsForm/EmailAlertsForm.tsx
+++ b/src/components/EmailAlertsForm/EmailAlertsForm.tsx
@@ -8,6 +8,7 @@ import React, {
 import { AutocompleteGetTagProps } from '@material-ui/lab/Autocomplete';
 import { isValidEmail } from 'common/utils';
 import { Region } from 'common/regions';
+import { useBreakpoint } from 'common/hooks';
 import AutocompleteRegions from 'components/AutocompleteRegions';
 import {
   subscribeToLocations,
@@ -47,6 +48,8 @@ const EmailAlertsForm: React.FC<{
   const [defaultInitialized, setDefaultInitialized] = useState(false);
   const [showConfirmation, setShowConfirmation] = useState(false);
   const formRef = createRef<HTMLFormElement>();
+
+  const isSmallMobile = useBreakpoint(321);
 
   // The default (geolocated) regions are updated asynchronously, so once we
   // get the default regions we set them as selected initially
@@ -111,9 +114,10 @@ const EmailAlertsForm: React.FC<{
     setSelectedRegions(newRegions);
   };
 
-  const emailInputLabel = emailError
-    ? 'Invalid email'
+  const validInputLabel = isSmallMobile
+    ? 'Enter your email'
     : 'Enter your email address';
+  const emailInputLabel = emailError ? 'Invalid email' : validInputLabel;
 
   const renderTags = (
     regionItems: Region[],


### PR DESCRIPTION
[Trello](https://trello.com/c/x7OlFWF6/1112-bug-placeholder-for-email-input-on-iphone-5-se-overlaps-the-sign-up-button) - Fix the email form placeholder for iPhone 5.

I just changed "Enter your email address" to "Enter your email" for viewports 320px and under.

**iPhone X (375px)**
<img src="https://user-images.githubusercontent.com/114084/112022367-79c98980-8aef-11eb-8b93-67add12332b5.png" width="375px" alt="screenshot of the email form on an iPhone X (375px)"/>


**iPhone 5 (320px)**
<img src="https://user-images.githubusercontent.com/114084/112022333-7209e500-8aef-11eb-9979-4aef4477f1b0.png" width="320px" alt="screenshot of the email form on an iPhone 5 (320px)" />
