### PR TITLE
performance: preload fonts

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,19 +1,21 @@
 <!DOCTYPE html>
 <html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <!--link rel="icon" href="%PUBLIC_URL%/favicon.ico" /-->
+    <meta
+      name="viewport"
+      content="minimum-scale=1, initial-scale=1, width=device-width"
+    />
 
-<head>
-  <meta charset="utf-8" />
-  <!--link rel="icon" href="%PUBLIC_URL%/favicon.ico" /-->
-  <meta name="viewport" content="minimum-scale=1, initial-scale=1, width=device-width" />
-
-  <meta name="theme-color" content="#000000" />
-  <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
-  <!--
+    <meta name="theme-color" content="#000000" />
+    <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
+    <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
-  <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-  <!--
+    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.
       Only files inside the `public` folder can be referenced from the HTML.
@@ -23,104 +25,156 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
 
-  <!-- General meta tags (per-page) -->
-  <title data-react-helmet="true">Covid Act Now</title>
-  <link data-react-helmet="true" rel="canonical" href="https://covidactnow.org/" />
-  <meta data-react-helmet="true" name="description"
-    content="U.S. COVID Risk & Vaccine Tracker. All 50 states. 3,000+ counties." />
-  <meta data-react-helmet="true" name="image" content="" />
+    <!-- General meta tags (per-page) -->
+    <title data-react-helmet="true">Covid Act Now</title>
+    <link
+      data-react-helmet="true"
+      rel="canonical"
+      href="https://covidactnow.org/"
+    />
+    <meta
+      data-react-helmet="true"
+      name="description"
+      content="U.S. COVID Risk & Vaccine Tracker. All 50 states. 3,000+ counties."
+    />
+    <meta data-react-helmet="true" name="image" content="" />
 
-  <!-- Facebook Open Graph meta tags (site-wide) -->
-  <meta property="og:type" content="website" />
-  <meta property="og:site_name" content="Covid Act Now" />
-  <meta property="og:image:type" content="image/png" />
-  <meta property="fb:app_id" content="743805156345210" />
+    <!-- Facebook Open Graph meta tags (site-wide) -->
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="Covid Act Now" />
+    <meta property="og:image:type" content="image/png" />
+    <meta property="fb:app_id" content="743805156345210" />
 
-  <!-- Facebook Open Graph meta tags (per-page) -->
-  <!-- NOTE: These are replaced at build time by scripts/generate_index_pages.ts -->
-  <meta property="og:url" content="https://covidactnow.org" />
-  <meta property="og:image:url" content="https://covidactnow.org/covidactnow.png?fbrefresh=v3" />
-  <meta property="og:image:width" content="1200" />
-  <meta property="og:image:height" content="630" />
-  <meta property="og:title" content="U.S. COVID Risk & Vaccine Tracker" />
-  <meta property="og:description"
-    content="Covid Act Now has real-time COVID data and risk level for your community. See how your community is doing at covidactnow.org." />
+    <!-- Facebook Open Graph meta tags (per-page) -->
+    <!-- NOTE: These are replaced at build time by scripts/generate_index_pages.ts -->
+    <meta property="og:url" content="https://covidactnow.org" />
+    <meta
+      property="og:image:url"
+      content="https://covidactnow.org/covidactnow.png?fbrefresh=v3"
+    />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:title" content="U.S. COVID Risk & Vaccine Tracker" />
+    <meta
+      property="og:description"
+      content="Covid Act Now has real-time COVID data and risk level for your community. See how your community is doing at covidactnow.org."
+    />
 
-  <!-- Twitter meta tags (site-wide) -->
-  <meta name="twitter:card" content="summary_large_image" />
+    <!-- Twitter meta tags (site-wide) -->
+    <meta name="twitter:card" content="summary_large_image" />
 
-  <!-- Twitter meta tags (per-page) -->
-  <!-- NOTE: These are replaced at build time by scripts/generate_index_pages.ts -->
-  <meta name="twitter:image" content="https://covidactnow.org/covidactnow.png" />
-  <meta name="twitter:title" content="U.S. COVID Risk & Vaccine Tracker" />
-  <meta name="twitter:description"
-    content="Covid Act Now has real-time COVID data and risk level for your community. See how your community is doing at covidactnow.org." />
+    <!-- Twitter meta tags (per-page) -->
+    <!-- NOTE: These are replaced at build time by scripts/generate_index_pages.ts -->
+    <meta
+      name="twitter:image"
+      content="https://covidactnow.org/covidactnow.png"
+    />
+    <meta name="twitter:title" content="U.S. COVID Risk & Vaccine Tracker" />
+    <meta
+      name="twitter:description"
+      content="Covid Act Now has real-time COVID data and risk level for your community. See how your community is doing at covidactnow.org."
+    />
 
-  <link
-    href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;700&family=Roboto:wght@400;500;700&display=swap"
-    rel="stylesheet">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 
-  <!-- Google Optimize for A/B testing: Uncomment when running experiments -->
-  <script async src="https://www.googleoptimize.com/optimize.js?id=OPT-WT27VPR"></script>
+    <link
+      rel="preload"
+      as="style"
+      href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;700&family=Roboto:wght@400;500;700&display=swap"
+    />
 
-  <!-- Twitter universal website tag code -->
-  <script async>
-    !function (e, t, n, s, u, a) {
-      e.twq || (s = e.twq = function () {
-        s.exe ? s.exe.apply(s, arguments) : s.queue.push(arguments);
-      }, s.version = '1.1', s.queue = [], u = t.createElement(n), u.async = !0, u.src = '//static.ads-twitter.com/uwt.js',
-        a = t.getElementsByTagName(n)[0], a.parentNode.insertBefore(u, a))
-    }(window, document, 'script');
-    // Insert Twitter Pixel ID and Standard Event data below
-    twq('init', 'o3f92');
-    twq('track', 'PageView');
-  </script>
-  <!-- End Twitter universal website tag code -->
+    <!-- Google Optimize for A/B testing: Uncomment when running experiments -->
+    <script
+      async
+      src="https://www.googleoptimize.com/optimize.js?id=OPT-WT27VPR"
+    ></script>
 
-  <!-- Facebook Pixel Code -->
-  <script async>
-    !function (f, b, e, v, n, t, s) {
-      if (f.fbq) return; n = f.fbq = function () {
-        n.callMethod ?
-          n.callMethod.apply(n, arguments) : n.queue.push(arguments)
-      };
-      if (!f._fbq) f._fbq = n; n.push = n; n.loaded = !0; n.version = '2.0';
-      n.queue = []; t = b.createElement(e); t.async = !0;
-      t.src = v; s = b.getElementsByTagName(e)[0];
-      s.parentNode.insertBefore(t, s)
-    }(window, document, 'script',
-      'https://connect.facebook.net/en_US/fbevents.js');
-    fbq('init', '692591964861759');
-    fbq('track', 'PageView');
-  </script>
+    <!-- Twitter universal website tag code -->
+    <script async>
+      !(function (e, t, n, s, u, a) {
+        e.twq ||
+          ((s = e.twq = function () {
+            s.exe ? s.exe.apply(s, arguments) : s.queue.push(arguments);
+          }),
+          (s.version = '1.1'),
+          (s.queue = []),
+          (u = t.createElement(n)),
+          (u.async = !0),
+          (u.src = '//static.ads-twitter.com/uwt.js'),
+          (a = t.getElementsByTagName(n)[0]),
+          a.parentNode.insertBefore(u, a));
+      })(window, document, 'script');
+      // Insert Twitter Pixel ID and Standard Event data below
+      twq('init', 'o3f92');
+      twq('track', 'PageView');
+    </script>
+    <!-- End Twitter universal website tag code -->
 
-  <!-- Global site tag (gtag.js) - Google Ads: 527465415 -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=AW-527465415"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag() { dataLayer.push(arguments); }
-    gtag('js', new Date());
-    gtag('config', 'AW-527465415');
-  </script>
+    <!-- Facebook Pixel Code -->
+    <script async>
+      !(function (f, b, e, v, n, t, s) {
+        if (f.fbq) return;
+        n = f.fbq = function () {
+          n.callMethod
+            ? n.callMethod.apply(n, arguments)
+            : n.queue.push(arguments);
+        };
+        if (!f._fbq) f._fbq = n;
+        n.push = n;
+        n.loaded = !0;
+        n.version = '2.0';
+        n.queue = [];
+        t = b.createElement(e);
+        t.async = !0;
+        t.src = v;
+        s = b.getElementsByTagName(e)[0];
+        s.parentNode.insertBefore(t, s);
+      })(
+        window,
+        document,
+        'script',
+        'https://connect.facebook.net/en_US/fbevents.js',
+      );
+      fbq('init', '692591964861759');
+      fbq('track', 'PageView');
+    </script>
 
-  <!-- Event snippet for Website traffic conversion page -->
-  <script>
-    gtag('event', 'conversion', { 'send_to': 'AW-527465415/lRyqCM2a9-kBEMf3wfsB' });
-  </script>
+    <!-- Global site tag (gtag.js) - Google Ads: 527465415 -->
+    <script
+      async
+      src="https://www.googletagmanager.com/gtag/js?id=AW-527465415"
+    ></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag() {
+        dataLayer.push(arguments);
+      }
+      gtag('js', new Date());
+      gtag('config', 'AW-527465415');
+    </script>
 
+    <!-- Event snippet for Website traffic conversion page -->
+    <script>
+      gtag('event', 'conversion', {
+        send_to: 'AW-527465415/lRyqCM2a9-kBEMf3wfsB',
+      });
+    </script>
 
-  <noscript>
-    <img height="1" width="1" src="https://www.facebook.com/tr?id=692591964861759&ev=PageView
-      &noscript=1" />
-  </noscript>
-  <!-- End Facebook Pixel Code -->
+    <noscript>
+      <img
+        height="1"
+        width="1"
+        src="https://www.facebook.com/tr?id=692591964861759&ev=PageView
+      &noscript=1"
+      />
+    </noscript>
+    <!-- End Facebook Pixel Code -->
+  </head>
 
-</head>
-
-<body>
-  <noscript>You need to enable JavaScript to run this app.</noscript>
-  <div id="root"></div>
-  <!--
+  <body>
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div id="root"></div>
+    <!--
       This HTML file is a template.
       If you open it directly in the browser, you will see an empty page.
 
@@ -130,6 +184,5 @@
       To begin the development, run `npm start` or `yarn start`.
       To create a production bundle, use `npm run build` or `yarn build`.
     -->
-</body>
-
+  </body>
 </html>

--- a/src/screens/internal/ShareImage/HomeShareCardImage.tsx
+++ b/src/screens/internal/ShareImage/HomeShareCardImage.tsx
@@ -14,7 +14,7 @@ const HomeShareCardImage = () => {
     <DarkScreenshotWrapper className={SCREENSHOT_CLASS}>
       <Header isHomePage />
       <ShareCardWrapper isHomePage>
-        <SocialLocationPreviewMap />;
+        <SocialLocationPreviewMap />
       </ShareCardWrapper>
     </DarkScreenshotWrapper>
   );


### PR DESCRIPTION
- Preload the fonts. Lighthouse keeps saying that they are in the critical rendering path. I tested this branch and couldn't see an improvement, but no harm either, so probably worth trying.
- Remove extra semicolon in a JSX statement.

**Note**
The linter re-indented the `index.html` file, but the only changes are 

```html
<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
<link
  rel="preload"
  as="style"
  href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;700&family=Roboto:wght@400;500;700&display=swap"/>
```