### PR TITLE
Remove footer from embed

### DIFF
--- a/src/components/NewFooter/Footer.tsx
+++ b/src/components/NewFooter/Footer.tsx
@@ -2,12 +2,19 @@ import React from 'react';
 import { StyledFooter } from './Menu.style';
 import MenuContent from './MenuContent';
 import { trackEvent, EventCategory, EventAction } from 'components/Analytics';
+import { useIsEmbed } from 'common/utils/hooks';
 
 const trackFooterEvent = (label: string) => {
   trackEvent(EventCategory.FOOTER, EventAction.NAVIGATE, label);
 };
 
 const Footer: React.FC = () => {
+  const isEmbed = useIsEmbed();
+
+  if (isEmbed) {
+    return null;
+  }
+
   return (
     <StyledFooter role="contentinfo">
       <MenuContent trackMenuEvent={trackFooterEvent} />


### PR DESCRIPTION
Bug: new footer was rendering in embed. This removes. [Trello](https://trello.com/c/tDTgkBC5/1132-new-footer-shows-up-in-embeds)