### PR TITLE
add aria-label to nav bar home and back links

### DIFF
--- a/src/components/AppBar/NavBar.tsx
+++ b/src/components/AppBar/NavBar.tsx
@@ -112,7 +112,11 @@ const NavBar: React.FC = () => {
     <Style.AppBar position="sticky" color="transparent" elevation={0}>
       <Style.Toolbar>
         {isLocationPage(pathname) && (
-          <Style.BackLink to="/" onClick={() => trackNavigation('Back Home')}>
+          <Style.BackLink
+            to="/"
+            onClick={() => trackNavigation('Back Home')}
+            aria-label="Covid Act Now"
+          >
             <ArrowBack />
           </Style.BackLink>
         )}
@@ -120,6 +124,7 @@ const NavBar: React.FC = () => {
           to="/"
           style={{ display: 'inline-flex' }}
           onClick={() => trackNavigation('Home (Logo)')}
+          aria-label="Covid Act Now"
         >
           <Logo />
         </Link>

--- a/src/components/AppBar/NavBar.tsx
+++ b/src/components/AppBar/NavBar.tsx
@@ -115,7 +115,7 @@ const NavBar: React.FC = () => {
           <Style.BackLink
             to="/"
             onClick={() => trackNavigation('Back Home')}
-            aria-label="Covid Act Now"
+            aria-label="Back to Covid Act Now"
           >
             <ArrowBack />
           </Style.BackLink>


### PR DESCRIPTION
- Add aria-labels for the Logo and back links on the NavBar component.
- For logos and links that go to the home page, it's considered better to spell out the name of the website rather than having something more contextual like "Home" or "Back"