### PR TITLE
circular dependency: move an utility function from compare → regions

### DIFF
--- a/src/common/regions/types.ts
+++ b/src/common/regions/types.ts
@@ -1,5 +1,4 @@
 import urlJoin from 'url-join';
-import { getAbbreviatedCounty } from 'common/utils/compare';
 
 export type FipsCode = string;
 export type ZipCode = string;
@@ -88,6 +87,24 @@ export class State extends Region {
       (subregion instanceof County && subregion.state === this)
     );
   }
+}
+
+/**
+ * Shortens the county name by using the abbreviated version of 'county'
+ * or the equivalent administrative division.
+ */
+export function getAbbreviatedCounty(fullCountyName: string) {
+  if (fullCountyName.includes('Parish'))
+    return fullCountyName.replace('Parish', 'Par.');
+  if (fullCountyName.includes('Borough'))
+    return fullCountyName.replace('Borough', 'Bor.');
+  if (fullCountyName.includes('Census Area'))
+    return fullCountyName.replace('Census Area', 'C.A.');
+  if (fullCountyName.includes('Municipality'))
+    return fullCountyName.replace('Municipality', 'Mun.');
+  if (fullCountyName.includes('Municipio'))
+    return fullCountyName.replace('Municipio', 'Mun.');
+  else return fullCountyName.replace('County', 'Co.');
 }
 
 export class County extends Region {

--- a/src/common/utils/compare.ts
+++ b/src/common/utils/compare.ts
@@ -12,6 +12,7 @@ import regions, {
   MetroArea,
   getStateName,
   getFormattedStateCode,
+  getAbbreviatedCounty,
 } from 'common/regions';
 import { fail } from 'assert';
 
@@ -225,19 +226,6 @@ export function getHomePageViewMoreCopy(
   } else {
     return `View more`;
   }
-}
-
-// For formatting and abbreviating location names:
-
-export function getAbbreviatedCounty(county: string) {
-  if (county.includes('Parish')) return county.replace('Parish', 'Par.');
-  if (county.includes('Borough')) return county.replace('Borough', 'Bor.');
-  if (county.includes('Census Area'))
-    return county.replace('Census Area', 'C.A.');
-  if (county.includes('Municipality'))
-    return county.replace('Municipality', 'Mun.');
-  if (county.includes('Municipio')) return county.replace('Municipio', 'Mun.');
-  else return county.replace('County', 'Co.');
 }
 
 /*

--- a/src/common/utils/recommend.ts
+++ b/src/common/utils/recommend.ts
@@ -13,16 +13,15 @@ import {
   RecommendationWithIcon,
   RecommendCategory,
   RecommendID,
+  allIcons,
 } from 'cms-content/recommendations';
-import { allIcons } from 'cms-content/recommendations';
 import { EventAction, EventCategory, trackEvent } from 'components/Analytics';
-import { getAbbreviatedCounty } from 'common/utils/compare';
 import { formatDecimal } from '.';
 import {
   getStateName,
   showExposureNotifications,
 } from 'components/LocationPage/Notifications';
-import regions from 'common/regions';
+import regions, { getAbbreviatedCounty } from 'common/regions';
 
 export function trackRecommendationsEvent(action: EventAction, label: string) {
   trackEvent(EventCategory.RECOMMENDATIONS, action, label);


### PR DESCRIPTION
Found out about this while investigating Next.js. `common/utils/compare` imports stuff from `common/regions`, and `common/regions` was importing `getAbbreviatedCounty` from `common/utils/compare`.

Webpack is smart enough (to a point) to handle this, but on one of my experiments this circular dependency was preventing the static HTML files from being generated, so I figured it might make sense to move the function.