### PR TITLE
Learn landing page update

### DIFF
--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -354,6 +354,9 @@ collections:
           - label: Intro
             name: intro
             widget: markdown
+          - label: Editors Note
+            name: editorsNote
+            widget: markdown
           - label: Sections
             name: sections
             widget: list

--- a/src/cms-content/learn/landing.ts
+++ b/src/cms-content/learn/landing.ts
@@ -16,6 +16,7 @@ export interface LandingSection {
 export interface LandingContent {
   header: string;
   intro: Markdown;
+  editorsNote: Markdown;
   sections: LandingSection[];
   metadataTitle: string;
   metadataDescription: string;

--- a/src/cms-content/learn/learn-landing.json
+++ b/src/cms-content/learn/learn-landing.json
@@ -1,5 +1,5 @@
 {
-  "intro": "Here you can find clear, trusted, shareable information to make informed decisions around COVID, as well as essential resources that will help you understand, interpret, and apply Covid Act Now’s data. You can also sign up for alerts to learn when the vaccine eligibility or the risk level in your area has changed.\n\n**A note on our editorial policy:** To bring you the most accurate, up-to-date information and advice about COVID, Covid Act Now’s editorial team relies on established, scientific sources, including academic and medical research institutions, professional medical associations, and governmental health agencies. We review the latest scientific literature on COVID and include links to primary studies. Our global understanding of COVID is evolving rapidly, and we note when there are limitations in studies.",
+  "intro": "Here you can find clear, trusted, shareable information to make informed decisions around COVID, as well as essential resources that will help you understand, interpret, and apply Covid Act Now’s data. You can also sign up for alerts to learn when the vaccine eligibility or the risk level in your area has changed.",
   "header": "Learn about COVID",
   "metadataTitle": "COVID-19 Essential Information & Resources",
   "metadataDescription": "Find recent and trusted information & resources about the novel Coronavirus (2019-nCoV). Learn about Symptoms, Tests, Risks, and more. Backed by medical experts. Make informed decisions to stop the disease for you and your community.",
@@ -46,5 +46,6 @@
       "buttonCta": "View case studies",
       "buttonRedirect": "/case-studies"
     }
-  ]
+  ],
+  "editorsNote": "**A note on our editorial policy:** To bring you the most accurate, up-to-date information and advice about COVID, Covid Act Now’s editorial team relies on established, scientific sources, including academic and medical research institutions, professional medical associations, and governmental health agencies. We review the latest scientific literature on COVID and include links to primary studies. Our global understanding of COVID is evolving rapidly, and we note when there are limitations in studies."
 }

--- a/src/screens/Learn/Landing/Landing.tsx
+++ b/src/screens/Learn/Landing/Landing.tsx
@@ -15,6 +15,7 @@ const Landing: React.FC = () => {
     sections,
     metadataTitle,
     metadataDescription,
+    editorsNote,
   } = landingPageContent;
 
   const date = formatMetatagDate();
@@ -42,6 +43,7 @@ const Landing: React.FC = () => {
             </ButtonContainer>
           </Fragment>
         ))}
+        <MarkdownContent source={editorsNote} />
       </PageContent>
     </Fragment>
   );


### PR DESCRIPTION
Moves editorial note to bottom of page of [learn landing page](https://covid-projections-git-casulin-learn-landing-update-covidactnow.vercel.app/learn)