### PR TITLE
Change update location summaries to query by state rather than pulling counties in all at once

### DIFF
--- a/scripts/county_history_data/generate.ts
+++ b/scripts/county_history_data/generate.ts
@@ -8,11 +8,11 @@
 import fs from 'fs-extra';
 import path from 'path';
 import _ from 'lodash';
-import { fetchAllCountyProjections } from '../../src/common/utils/model';
+import { fetchAllCountyProjectionsByState } from '../../src/common/utils/model';
 import { Projection } from '../../src/common/models/Projection';
 
 async function main() {
-  const allProjections = await fetchAllCountyProjections();
+  const allProjections = await fetchAllCountyProjectionsByState();
   const result = {} as {
     [date: string]: {
       [fips: string]: { population: number; caseDensity: number };

--- a/scripts/update_location_summaries.ts
+++ b/scripts/update_location_summaries.ts
@@ -5,7 +5,7 @@ import _ from 'lodash';
 import {
   fetchAllStateProjections,
   fetchAllMetroProjections,
-  fetchCountyProjectionsForState,
+  fetchAllCountyProjections,
 } from '../src/common/utils/model';
 import {
   currentSnapshot,
@@ -21,7 +21,7 @@ import { Projections } from '../src/common/models/Projections';
 import { DatasetId } from '../src/common/models/Projection';
 import { assert } from '../src/common/utils';
 import { Level } from '../src/common/level';
-import regions, { State } from '../src/common/regions';
+import regions from '../src/common/regions';
 import { importFipsToCcviMap } from '../src/common/data';
 
 const OUTPUT_FOLDER = path.join(__dirname, '..', 'src', 'assets', 'data');
@@ -57,20 +57,9 @@ const INDIGENOUS_FIPS = [
   '55078',
 ];
 
-async function fetchCountyProjections() {
-  // Query counties for states individually as the entire counties.timeseries.json is too large
-  // to be parsed by node.
-  const allProjections = await Promise.all(
-    regions.states.map(
-      async (state: State) => await fetchCountyProjectionsForState(state),
-    ),
-  );
-  return allProjections.flatMap(obj => obj);
-}
-
 async function main() {
   const allStatesProjections = await fetchAllStateProjections();
-  const allCountiesProjections = await fetchCountyProjections();
+  const allCountiesProjections = await fetchAllCountyProjections();
   const allMetroProjections = await fetchAllMetroProjections();
   await buildSummaries([
     ...allStatesProjections,

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -66,6 +66,19 @@ export class Api {
   }
 
   /**
+   * Fetches the summary+timeseries for every region in the specified state
+   */
+  async fetchCountySummariesWithTimeseriesForState(
+    state: State,
+  ): Promise<RegionSummaryWithTimeseries[]> {
+    const all = await this.fetchApiJson<AggregateRegionSummaryWithTimeseries>(
+      `county/${state.stateCode}.timeseries.json`,
+    );
+    assert(all != null, 'Failed to load timeseries');
+    return all;
+  }
+
+  /**
    * Fetches the summary+timeseries for a region. Returns null if not found.
    */
   async fetchSummaryWithTimeseries(


### PR DESCRIPTION
We finally hit the limit of string size for parsing a json file for the version of node we're on.  This splits up the querying by states - we should be good for a while (and maybe can even upgrade our version of node now!)