### PR TITLE
Compare cleanup: remove metro-filter-related code

### DIFF
--- a/src/common/utils/compare.ts
+++ b/src/common/utils/compare.ts
@@ -204,8 +204,6 @@ export function getRegionNameForRow(region: Region, condensed?: boolean) {
   }
 }
 
-// For college tag:
-
 export function getShareQuote(
   sorter: Metric,
   sliderValue: GeoScopeFilter,
@@ -250,7 +248,7 @@ export function getShareQuote(
   const countyShareCopy =
     currentLocation &&
     hasValidRank &&
-    `${currentLocation.region.name} ranks #${
+    `${currentLocation.region.shortName} ranks #${
       currentLocation.rank
     } out of ${totalLocations} total ${
       geoScopeShareCopy[sliderValue]

--- a/src/common/utils/compare.ts
+++ b/src/common/utils/compare.ts
@@ -107,10 +107,6 @@ export function getNeighboringCounties(
   return [...adjacentCounties, ...[getLocationObj(county)]];
 }
 
-export function getLocationPageCountiesSelection(stateCode: string) {
-  return getAllCountiesOfState(stateCode);
-}
-
 export enum GeoScopeFilter {
   NEARBY,
   STATE,

--- a/src/common/utils/compare.ts
+++ b/src/common/utils/compare.ts
@@ -107,10 +107,6 @@ export function getNeighboringCounties(
   return [...adjacentCounties, ...[getLocationObj(county)]];
 }
 
-export function getAllCountiesSelection() {
-  return getAllCounties();
-}
-
 export function getLocationPageCountiesSelection(stateCode: string) {
   return getAllCountiesOfState(stateCode);
 }

--- a/src/common/utils/compare.ts
+++ b/src/common/utils/compare.ts
@@ -107,49 +107,12 @@ export function getNeighboringCounties(
   return [...adjacentCounties, ...[getLocationObj(county)]];
 }
 
-export enum MetroFilter {
-  ALL,
-  METRO,
-  NON_METRO,
+export function getAllCountiesSelection() {
+  return getAllCounties();
 }
 
-export const FILTER_LABEL = {
-  [MetroFilter.ALL]: 'Metro & Non-metro',
-  [MetroFilter.METRO]: 'Metro only',
-  [MetroFilter.NON_METRO]: 'Non-metro only',
-};
-
-export function getFilterLabel(filter: MetroFilter) {
-  return FILTER_LABEL[filter];
-}
-
-export function getAllCountiesSelection(countyTypeToView: MetroFilter) {
-  switch (countyTypeToView) {
-    case MetroFilter.ALL:
-      return getAllCounties();
-    case MetroFilter.METRO:
-      return getAllMetroCounties();
-    case MetroFilter.NON_METRO:
-      return getAllNonMetroCounties();
-    default:
-      return getAllCounties();
-  }
-}
-
-export function getLocationPageCountiesSelection(
-  stateCode: string,
-  countyTypeToView: MetroFilter,
-) {
-  switch (countyTypeToView) {
-    case MetroFilter.ALL:
-      return getAllCountiesOfState(stateCode);
-    case MetroFilter.METRO:
-      return getStateMetroCounties(stateCode);
-    case MetroFilter.NON_METRO:
-      return getStateNonMetroCounties(stateCode);
-    default:
-      return getAllCountiesOfState(stateCode);
-  }
+export function getLocationPageCountiesSelection(stateCode: string) {
+  return getAllCountiesOfState(stateCode);
 }
 
 export enum GeoScopeFilter {
@@ -158,32 +121,18 @@ export enum GeoScopeFilter {
   COUNTRY,
 }
 
-export function getMetroPrefixCopy(filter: MetroFilter, useAll?: boolean) {
-  if (filter === MetroFilter.METRO) {
-    return 'metro';
-  } else if (filter === MetroFilter.NON_METRO) {
-    return 'non-metro';
-  } else if (useAll) {
-    return 'all';
-  }
-  return '';
-}
-
 export function getLocationPageViewMoreCopy(
   geoscope: GeoScopeFilter,
-  countyTypeToView: MetroFilter,
   region: Region,
 ) {
   if (region instanceof MetroArea) {
     return `View all counties in ${region.shortName}`;
   } else if (geoscope === GeoScopeFilter.COUNTRY) {
-    return `View top 100 ${getMetroPrefixCopy(countyTypeToView)} counties`;
+    return `View top 100 counties`;
   } else if (geoscope === GeoScopeFilter.NEARBY) {
     return 'View all nearby counties';
   } else {
-    return `View all ${getMetroPrefixCopy(
-      countyTypeToView,
-    )} counties in ${getStateName(region)}`;
+    return `View all counties in ${getStateName(region)}`;
   }
 }
 
@@ -213,16 +162,13 @@ export const homepageLabelMap: { [key in HomepageLocationScope]: LabelItem } = {
   },
 };
 
-export function getHomePageViewMoreCopy(
-  homepageScope: HomepageLocationScope,
-  countyTypeToView: MetroFilter,
-) {
+export function getHomePageViewMoreCopy(homepageScope: HomepageLocationScope) {
   if (homepageScope === HomepageLocationScope.STATE) {
     return 'View all states';
   } else if (homepageScope === HomepageLocationScope.MSA) {
     return 'View top 100 metro areas';
   } else if (homepageScope === HomepageLocationScope.COUNTY) {
-    return `View top 100 ${getMetroPrefixCopy(countyTypeToView)} counties`;
+    return `View top 100 counties`;
   } else {
     return `View more`;
   }
@@ -266,7 +212,6 @@ export function getRegionNameForRow(region: Region, condensed?: boolean) {
 
 export function getShareQuote(
   sorter: Metric,
-  countyTypeToView: MetroFilter,
   sliderValue: GeoScopeFilter,
   totalLocations: number,
   sortDescending: boolean,
@@ -284,14 +229,11 @@ export function getShareQuote(
 
   const homepageShareCopy = `Compare all USA ${
     homepageScope === HomepageLocationScope.COUNTY
-      ? `${getMetroPrefixCopy(countyTypeToView)} counties`
+      ? 'counties'
       : `${homepageLabelMap[homepageScope].plural.toLowerCase()}`
   } by their local COVID metrics with @CovidActNow.`;
 
-  const stateShareCopy = `Compare COVID metrics between ${getMetroPrefixCopy(
-    countyTypeToView,
-    true,
-  )} counties in ${stateName} with @CovidActNow.`;
+  const stateShareCopy = `Compare COVID metrics between counties in ${stateName} with @CovidActNow.`;
 
   const hasValidRank =
     currentLocation &&
@@ -314,9 +256,9 @@ export function getShareQuote(
     hasValidRank &&
     `${currentLocation.region.name} ranks #${
       currentLocation.rank
-    } out of ${totalLocations} total ${geoScopeShareCopy[sliderValue]}${
-      countyTypeToView === MetroFilter.ALL ? '' : ' '
-    }${getMetroPrefixCopy(countyTypeToView)} counties when sorted by ${
+    } out of ${totalLocations} total ${
+      geoScopeShareCopy[sliderValue]
+    } counties when sorted by ${
       sortDescending ? descendingCopy : ascendingCopy
     } ${
       sortByPopulation

--- a/src/components/Compare/CompareMain.tsx
+++ b/src/components/Compare/CompareMain.tsx
@@ -19,13 +19,13 @@ import {
   getAllCounties,
   getHomePageViewMoreCopy,
   getNeighboringCounties,
-  getLocationPageCountiesSelection,
   getLocationPageViewMoreCopy,
   GeoScopeFilter,
   HomepageLocationScope,
   getAllMetroAreas,
   getAllCountiesOfMetroArea,
   SummaryForCompare,
+  getAllCountiesOfState,
 } from 'common/utils/compare';
 import { Metric } from 'common/metricEnum';
 import { getSummaryFromFips } from 'common/location_summaries';
@@ -135,7 +135,7 @@ const CompareMain = (props: {
     } else if (geoScope === GeoScopeFilter.NEARBY) {
       return getNeighboringCounties(region.fipsCode);
     } else if (geoScope === GeoScopeFilter.STATE && stateCode) {
-      return getLocationPageCountiesSelection(stateCode);
+      return getAllCountiesOfState(stateCode);
     } else {
       return getAllCounties();
     }

--- a/src/components/Compare/CompareMain.tsx
+++ b/src/components/Compare/CompareMain.tsx
@@ -16,7 +16,7 @@ import {
 } from 'components/Compare/Compare.style';
 import {
   getAllStates,
-  getAllCountiesSelection,
+  getAllCounties,
   getHomePageViewMoreCopy,
   getNeighboringCounties,
   getLocationPageCountiesSelection,
@@ -112,7 +112,7 @@ const CompareMain = (props: {
   const [homepageScope, setHomepageScope] = useState(HomepageLocationScope.MSA);
 
   const homepageScopeToLocations = {
-    [HomepageLocationScope.COUNTY]: getAllCountiesSelection(),
+    [HomepageLocationScope.COUNTY]: getAllCounties(),
     [HomepageLocationScope.MSA]: getAllMetroAreas(),
     [HomepageLocationScope.STATE]: getAllStates(),
   };
@@ -137,7 +137,7 @@ const CompareMain = (props: {
     } else if (geoScope === GeoScopeFilter.STATE && stateCode) {
       return getLocationPageCountiesSelection(stateCode);
     } else {
-      return getAllCountiesSelection();
+      return getAllCounties();
     }
   }
 

--- a/src/components/Compare/CompareMain.tsx
+++ b/src/components/Compare/CompareMain.tsx
@@ -21,7 +21,6 @@ import {
   getNeighboringCounties,
   getLocationPageCountiesSelection,
   getLocationPageViewMoreCopy,
-  MetroFilter,
   GeoScopeFilter,
   HomepageLocationScope,
   getAllMetroAreas,
@@ -108,13 +107,12 @@ const CompareMain = (props: {
   const [sorter, setSorter] = useState(Metric.CASE_DENSITY);
   const [sortDescending, setSortDescending] = useState(true);
   const [sortByPopulation, setSortByPopulation] = useState(true);
-  const [countyTypeToView, setCountyTypeToView] = useState(MetroFilter.ALL);
 
   // For homepage:
   const [homepageScope, setHomepageScope] = useState(HomepageLocationScope.MSA);
 
   const homepageScopeToLocations = {
-    [HomepageLocationScope.COUNTY]: getAllCountiesSelection(countyTypeToView),
+    [HomepageLocationScope.COUNTY]: getAllCountiesSelection(),
     [HomepageLocationScope.MSA]: getAllMetroAreas(),
     [HomepageLocationScope.STATE]: getAllStates(),
   };
@@ -125,10 +123,7 @@ const CompareMain = (props: {
 
   const homepageLocationsForCompare = getHomepageLocations(homepageScope);
 
-  const homepageViewMoreCopy = getHomePageViewMoreCopy(
-    homepageScope,
-    countyTypeToView,
-  );
+  const homepageViewMoreCopy = getHomePageViewMoreCopy(homepageScope);
 
   // For location page:
   const [geoScope, setGeoScope] = useState(GeoScopeFilter.STATE);
@@ -140,9 +135,9 @@ const CompareMain = (props: {
     } else if (geoScope === GeoScopeFilter.NEARBY) {
       return getNeighboringCounties(region.fipsCode);
     } else if (geoScope === GeoScopeFilter.STATE && stateCode) {
-      return getLocationPageCountiesSelection(stateCode, countyTypeToView);
+      return getLocationPageCountiesSelection(stateCode);
     } else {
-      return getAllCountiesSelection(countyTypeToView);
+      return getAllCountiesSelection();
     }
   }
 
@@ -155,7 +150,7 @@ const CompareMain = (props: {
   const locations = getFinalLocations(region);
 
   const viewMoreCopy = region
-    ? getLocationPageViewMoreCopy(geoScope, countyTypeToView, region)
+    ? getLocationPageViewMoreCopy(geoScope, region)
     : homepageViewMoreCopy;
 
   const [showModal, setShowModal] = useState(false);
@@ -173,7 +168,6 @@ const CompareMain = (props: {
     setSorter(Metric.CASE_DENSITY);
     setSortDescending(true);
     setSortByPopulation(true);
-    setCountyTypeToView(MetroFilter.ALL);
     setGeoScope(GeoScopeFilter.STATE);
   }, [location.pathname]);
 
@@ -183,7 +177,6 @@ const CompareMain = (props: {
     sorter,
     sortDescending,
     sortByPopulation,
-    countyTypeToView,
     homepageScope,
     geoScope,
     stateId,
@@ -223,7 +216,6 @@ const CompareMain = (props: {
       setSorter(sharedParams.sorter);
       setSortDescending(sharedParams.sortDescending);
       setSortByPopulation(sharedParams.sortByPopulation);
-      setCountyTypeToView(sharedParams.countyTypeToView);
       setHomepageScope(sharedParams.homepageScope);
       setGeoScope(sharedParams.geoScope);
 
@@ -270,7 +262,6 @@ const CompareMain = (props: {
     locations,
     currentCounty,
     ...uiState,
-    setCountyTypeToView,
     setGeoScope,
     setSorter,
     setSortDescending,

--- a/src/components/Compare/CompareTable.tsx
+++ b/src/components/Compare/CompareTable.tsx
@@ -12,10 +12,8 @@ import Filters from 'components/Compare/Filters';
 import {
   SummaryForCompare,
   RankedLocationSummary,
-  MetroFilter,
   GeoScopeFilter,
   getShareQuote,
-  getMetroPrefixCopy,
   trackCompareEvent,
   HomepageLocationScope,
   homepageLabelMap,
@@ -50,8 +48,6 @@ const CompareTable = (props: {
   locations: SummaryForCompare[];
   currentCounty: any | null;
   viewMoreCopy?: string;
-  setCountyTypeToView: React.Dispatch<React.SetStateAction<MetroFilter>>;
-  countyTypeToView: MetroFilter;
   geoScope: GeoScopeFilter;
   setGeoScope: React.Dispatch<React.SetStateAction<GeoScopeFilter>>;
   stateId?: string;
@@ -159,18 +155,14 @@ const CompareTable = (props: {
 
   const firstColumnHeaderHomepage =
     props.homepageScope === HomepageLocationScope.COUNTY
-      ? `${getMetroPrefixCopy(props.countyTypeToView)} ${
-          homepageLabelMap[HomepageLocationScope.COUNTY].singular
-        }`
+      ? `${homepageLabelMap[HomepageLocationScope.COUNTY].singular}`
       : `${homepageLabelMap[homepageScope].singular}`;
 
   const firstColumnHeader = props.isHomepage
     ? firstColumnHeaderHomepage
     : props.isModal
-    ? `${getMetroPrefixCopy(props.countyTypeToView)} Counties (${
-        sortedLocationsArr.length
-      })`
-    : `${getMetroPrefixCopy(props.countyTypeToView)} County`;
+    ? `Counties (${sortedLocationsArr.length})`
+    : `County`;
 
   const sortedLocations: RankedLocationSummary[] = sortedLocationsArr
     .filter((location: SummaryForCompare) => location.metricsInfo !== null)
@@ -185,7 +177,6 @@ const CompareTable = (props: {
 
   const shareQuote = getShareQuote(
     sorter,
-    props.countyTypeToView,
     sliderNumberToFilterMap[sliderValue],
     sortedLocationsArr.length,
     sortDescending,
@@ -252,8 +243,6 @@ const CompareTable = (props: {
           {!disableFilters && (
             <Filters
               isHomepage={props.isHomepage}
-              countyTypeToView={props.countyTypeToView}
-              setCountyTypeToView={props.setCountyTypeToView}
               stateId={props.stateId}
               county={props.county}
               geoScope={props.geoScope}

--- a/src/components/Compare/Filters.tsx
+++ b/src/components/Compare/Filters.tsx
@@ -1,6 +1,5 @@
-import React, { Fragment, useEffect } from 'react';
+import React, { Fragment } from 'react';
 import {
-  MetroFilter,
   GeoScopeFilter,
   trackCompareEvent,
   HomepageLocationScope,
@@ -17,8 +16,6 @@ import HomepageSlider from './HomepageSlider';
 
 const Filters = (props: {
   isHomepage?: boolean;
-  setCountyTypeToView: React.Dispatch<React.SetStateAction<MetroFilter>>;
-  countyTypeToView: MetroFilter;
   stateId?: string;
   county?: any | null;
   geoScope: GeoScopeFilter;
@@ -31,21 +28,10 @@ const Filters = (props: {
 }) => {
   const {
     sliderValue,
-    setCountyTypeToView,
     homepageScope,
     setHomepageScope,
     homepageSliderValue,
   } = props;
-
-  const disableMetroMenu = props.isHomepage
-    ? homepageScope !== HomepageLocationScope.COUNTY
-    : sliderValue === 0;
-
-  useEffect(() => {
-    if (disableMetroMenu) {
-      setCountyTypeToView(MetroFilter.ALL);
-    }
-  }, [disableMetroMenu, setCountyTypeToView]);
 
   const GeoFilterLabels = {
     [GeoScopeFilter.NEARBY]: 'Nearby',

--- a/src/components/Compare/ModalCompare.tsx
+++ b/src/components/Compare/ModalCompare.tsx
@@ -4,7 +4,6 @@ import { ModalHeader } from 'components/Compare/Compare.style';
 import CloseIcon from '@material-ui/icons/Close';
 import {
   SummaryForCompare,
-  MetroFilter,
   GeoScopeFilter,
   HomepageLocationScope,
 } from 'common/utils/compare';
@@ -20,8 +19,6 @@ interface ModalCompareProps {
   locations: SummaryForCompare[];
   currentCounty?: any;
   handleCloseModal: () => void;
-  setCountyTypeToView: React.Dispatch<React.SetStateAction<MetroFilter>>;
-  countyTypeToView: MetroFilter;
   geoScope: GeoScopeFilter;
   setGeoScope: React.Dispatch<React.SetStateAction<GeoScopeFilter>>;
   stateId?: string;
@@ -69,8 +66,6 @@ const ModalCompare = (props: ModalCompareProps) => {
         {!disableFilters && (
           <Filters
             isHomepage={props.isHomepage}
-            countyTypeToView={props.countyTypeToView}
-            setCountyTypeToView={props.setCountyTypeToView}
             stateId={props.stateId}
             county={props.county}
             geoScope={props.geoScope}
@@ -94,8 +89,6 @@ const ModalCompare = (props: ModalCompareProps) => {
         isHomepage={props.isHomepage}
         locations={props.locations}
         currentCounty={props.currentCounty}
-        countyTypeToView={props.countyTypeToView}
-        setCountyTypeToView={props.setCountyTypeToView}
         geoScope={props.geoScope}
         setGeoScope={props.setGeoScope}
         stateId={props.stateId}


### PR DESCRIPTION
We [removed the metro/non-metro county filter](https://github.com/covid-projections/covid-projections/pull/2912) from compare. This removes all related code that supported that filter

Also adds stateCode to county share quotes