### PR TITLE
Trims FAQ ids

### DIFF
--- a/src/cms-content/utils.ts
+++ b/src/cms-content/utils.ts
@@ -1,7 +1,7 @@
-import { deburr, words } from 'lodash';
+import { deburr, words, trim } from 'lodash';
 
 export function sanitizeID(sectionId: string): string {
-  return deburr(words(sectionId).join('-')).toLowerCase();
+  return trim(deburr(words(sectionId).join('-')).toLowerCase());
 }
 
 export type Markdown = string;


### PR DESCRIPTION
Noticed while [qa'ing this PR](https://github.com/covid-projections/covid-projections/pull/3087) that some share URLs weren't working properly because their IDs were entered into the CMS with trailing white space. This fixes