### PR TITLE
Text tooltips update

### DIFF
--- a/src/common/metrics/case_density.tsx
+++ b/src/common/metrics/case_density.tsx
@@ -9,7 +9,7 @@ import { MetricDefinition } from './interfaces';
 import { Metric } from 'common/metricEnum';
 import {
   InfoTooltip,
-  DisclaimerTooltip,
+  TextTooltip,
   renderTooltipContent,
 } from 'components/InfoTooltip';
 import { metricToTooltipMap } from 'cms-content/tooltips';
@@ -115,7 +115,7 @@ function renderDisclaimer(
   return (
     <Fragment>
       {'Learn more about '}
-      <DisclaimerTooltip
+      <TextTooltip
         title={getDataSourceTooltipContent(
           Metric.CASE_DENSITY,
           region,
@@ -127,7 +127,7 @@ function renderDisclaimer(
         }
       />
       {' and '}
-      <DisclaimerTooltip
+      <TextTooltip
         title={renderTooltipContent(body)}
         mainCopy={'how we calculate our metrics'}
         trackOpenTooltip={() =>

--- a/src/common/metrics/case_growth.tsx
+++ b/src/common/metrics/case_growth.tsx
@@ -11,7 +11,7 @@ import { MetricDefinition } from './interfaces';
 import Thermometer from 'components/Thermometer';
 import {
   InfoTooltip,
-  DisclaimerTooltip,
+  TextTooltip,
   renderTooltipContent,
 } from 'components/InfoTooltip';
 import { metricToTooltipMap } from 'cms-content/tooltips';
@@ -135,7 +135,7 @@ function renderDisclaimer(
   return (
     <Fragment>
       {'Learn more about '}
-      <DisclaimerTooltip
+      <TextTooltip
         title={getDataSourceTooltipContent(
           Metric.CASE_GROWTH_RATE,
           region,
@@ -147,7 +147,7 @@ function renderDisclaimer(
         }
       />
       {' and '}
-      <DisclaimerTooltip
+      <TextTooltip
         title={renderTooltipContent(body)}
         mainCopy={'how we calculate our metrics'}
         trackOpenTooltip={() =>

--- a/src/common/metrics/hospitalizations.tsx
+++ b/src/common/metrics/hospitalizations.tsx
@@ -11,7 +11,7 @@ import { MetricDefinition } from './interfaces';
 import Thermometer from 'components/Thermometer';
 import {
   InfoTooltip,
-  DisclaimerTooltip,
+  TextTooltip,
   renderTooltipContent,
 } from 'components/InfoTooltip';
 import { metricToTooltipMap } from 'cms-content/tooltips';
@@ -163,7 +163,7 @@ function renderDisclaimer(
   return (
     <Fragment>
       {'Learn more about '}
-      <DisclaimerTooltip
+      <TextTooltip
         title={getDataSourceTooltipContent(
           Metric.HOSPITAL_USAGE,
           region,
@@ -175,7 +175,7 @@ function renderDisclaimer(
         }
       />
       {' and '}
-      <DisclaimerTooltip
+      <TextTooltip
         title={renderTooltipContent(body)}
         mainCopy={'how we calculate our metrics'}
         trackOpenTooltip={() =>

--- a/src/common/metrics/positive_rate.tsx
+++ b/src/common/metrics/positive_rate.tsx
@@ -11,7 +11,7 @@ import { MetricDefinition } from './interfaces';
 import Thermometer from 'components/Thermometer';
 import {
   InfoTooltip,
-  DisclaimerTooltip,
+  TextTooltip,
   renderTooltipContent,
 } from 'components/InfoTooltip';
 import { metricToTooltipMap } from 'cms-content/tooltips';
@@ -154,7 +154,7 @@ function renderDisclaimer(
   return (
     <Fragment>
       {'Learn more about '}
-      <DisclaimerTooltip
+      <TextTooltip
         title={getDataSourceTooltipContent(
           Metric.POSITIVE_TESTS,
           region,
@@ -166,7 +166,7 @@ function renderDisclaimer(
         }
       />
       {' and '}
-      <DisclaimerTooltip
+      <TextTooltip
         title={renderTooltipContent(body)}
         mainCopy={'how we calculate our metrics'}
         trackOpenTooltip={() =>

--- a/src/common/metrics/vaccinations.tsx
+++ b/src/common/metrics/vaccinations.tsx
@@ -8,7 +8,7 @@ import { MetricDefinition } from './interfaces';
 import { Metric } from 'common/metricEnum';
 import {
   InfoTooltip,
-  DisclaimerTooltip,
+  TextTooltip,
   renderTooltipContent,
 } from 'components/InfoTooltip';
 import { metricToTooltipMap } from 'cms-content/tooltips';
@@ -114,7 +114,7 @@ function renderDisclaimer(
       {region instanceof State ||
       (provenance && provenance[0].name && provenance[0].url) ? (
         <>
-          <DisclaimerTooltip
+          <TextTooltip
             title={getDataSourceTooltipContent(
               Metric.VACCINATIONS,
               region,
@@ -130,7 +130,7 @@ function renderDisclaimer(
       ) : (
         ''
       )}
-      <DisclaimerTooltip
+      <TextTooltip
         title={renderTooltipContent(body)}
         mainCopy={'how we calculate our metrics'}
         trackOpenTooltip={() =>

--- a/src/components/Charts/Tooltip.style.ts
+++ b/src/components/Charts/Tooltip.style.ts
@@ -17,6 +17,7 @@ export const Tooltip = styled.div`
   border-radius: 4px;
   background-color: ${props => palette(props).tooltip.background};
   box-shadow: 2px 2px 6px ${props => palette(props).tooltip.shadow};
+  cursor: default;
 `;
 
 export const TooltipArrow = styled(Tooltip)`

--- a/src/components/DataCoverageTable/DataCoverageTable.style.tsx
+++ b/src/components/DataCoverageTable/DataCoverageTable.style.tsx
@@ -1,29 +1,9 @@
-import { TableHead, Typography } from '@material-ui/core';
+import { TableHead } from '@material-ui/core';
 import TableCell from '@material-ui/core/TableCell';
 import TableRow from '@material-ui/core/TableRow';
 import { materialSMBreakpoint } from 'assets/theme/sizes';
-
 import { COLOR_MAP } from 'common/colors';
-import { InfoIcon } from 'components/InfoTooltip/Tooltip.style';
 import styled from 'styled-components';
-
-export const TextWithTooltipContainer = styled.div`
-  ${InfoIcon} {
-    margin-left: 0.2rem;
-    vertical-align: middle;
-  }
-`;
-
-export const UnderlinedText = styled(Typography)`
-  text-decoration-line: underline;
-  text-decoration-style: dotted;
-  text-underline-position: under;
-  vertical-align: middle;
-  font-size: 16px;
-  @media (max-width: ${materialSMBreakpoint}) {
-    font-size: 14px;
-  }
-`;
 
 export const StyledTableHead = styled(TableHead)`
   font-family: Roboto;

--- a/src/components/DataCoverageTable/DataCoverageTable.tsx
+++ b/src/components/DataCoverageTable/DataCoverageTable.tsx
@@ -14,7 +14,7 @@ import {
 import coverageSummary from 'components/DataCoverageTable/coverage-summary.json';
 import { formatPercent, pluralize } from 'common/utils';
 import { RegionType } from 'common/regions';
-import { TextTooltip, LargeTooltipAnchorText } from 'components/InfoTooltip';
+import { TextTooltip } from 'components/InfoTooltip';
 
 export const COVERAGE_SUMMARY = coverageSummary as MetricCoverage[];
 
@@ -70,7 +70,6 @@ const TextWithTooltip: React.FC<{ text: string; tooltipContent: string }> = ({
       title={tooltipContent}
       mainCopy={text}
       trackOpenTooltip={() => {}}
-      altAnchorComponent={LargeTooltipAnchorText}
     />
   );
 };

--- a/src/components/DataCoverageTable/DataCoverageTable.tsx
+++ b/src/components/DataCoverageTable/DataCoverageTable.tsx
@@ -1,14 +1,10 @@
 import React from 'react';
-
 import Table from '@material-ui/core/Table';
 import TableBody from '@material-ui/core/TableBody';
 import TableContainer from '@material-ui/core/TableContainer';
 import TableRow from '@material-ui/core/TableRow';
 import CheckIcon from '@material-ui/icons/Check';
-
 import {
-  TextWithTooltipContainer,
-  UnderlinedText,
   StyledTableHead,
   MetricTableCell,
   AvailabilityTableCell,
@@ -17,8 +13,8 @@ import {
 } from './DataCoverageTable.style';
 import coverageSummary from 'components/DataCoverageTable/coverage-summary.json';
 import { formatPercent, pluralize } from 'common/utils';
-import { InfoTooltip } from 'components/InfoTooltip';
 import { RegionType } from 'common/regions';
+import { TextTooltip, LargeTooltipAnchorText } from 'components/InfoTooltip';
 
 export const COVERAGE_SUMMARY = coverageSummary as MetricCoverage[];
 
@@ -70,12 +66,12 @@ const TextWithTooltip: React.FC<{ text: string; tooltipContent: string }> = ({
   tooltipContent,
 }) => {
   return (
-    <TextWithTooltipContainer>
-      <UnderlinedText align="center">
-        {text}
-        <InfoTooltip trackOpenTooltip={() => {}} title={tooltipContent} />
-      </UnderlinedText>
-    </TextWithTooltipContainer>
+    <TextTooltip
+      title={tooltipContent}
+      mainCopy={text}
+      trackOpenTooltip={() => {}}
+      altAnchorComponent={LargeTooltipAnchorText}
+    />
   );
 };
 

--- a/src/components/InfoTooltip/TextTooltip.tsx
+++ b/src/components/InfoTooltip/TextTooltip.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import {
   StyledTooltip,
   StyledCloseIcon,
-  SmallTooltipAnchorText,
+  TooltipAnchorText,
 } from './Tooltip.style';
 import { StyledTooltipProps } from 'components/InfoTooltip';
 import VisuallyHiddenDiv from 'components/VisuallyHidden/VisuallyHidden';
@@ -15,10 +15,6 @@ const TextTooltip: React.FC<StyledTooltipProps> = props => {
   const isMobile = useBreakpoint(600);
 
   const idForAccessability = uuidv4();
-
-  const AnchorTextComponent = props.altAnchorComponent
-    ? props.altAnchorComponent
-    : SmallTooltipAnchorText;
 
   return (
     <>
@@ -35,13 +31,13 @@ const TextTooltip: React.FC<StyledTooltipProps> = props => {
         leaveTouchDelay={60000} // for mobile: long leaveTouchDelay makes the tooltip stay open until close-icon is clicked
         aria-describedby={idForAccessability}
       >
-        <AnchorTextComponent
+        <TooltipAnchorText
           tabIndex={0}
           role="button"
           onClick={() => tooltipAnchorOnClick(isMobile, () => setIsOpen(true))}
         >
           {props.mainCopy}
-        </AnchorTextComponent>
+        </TooltipAnchorText>
       </StyledTooltip>
       <VisuallyHiddenDiv content={props.title} elemId={idForAccessability} />
     </>

--- a/src/components/InfoTooltip/TextTooltip.tsx
+++ b/src/components/InfoTooltip/TextTooltip.tsx
@@ -1,16 +1,24 @@
 import React, { useState } from 'react';
-import { StyledSpan, StyledTooltip, StyledCloseIcon } from './Tooltip.style';
+import {
+  StyledTooltip,
+  StyledCloseIcon,
+  SmallTooltipAnchorText,
+} from './Tooltip.style';
 import { StyledTooltipProps } from 'components/InfoTooltip';
 import VisuallyHiddenDiv from 'components/VisuallyHidden/VisuallyHidden';
 import { useBreakpoint } from 'common/hooks';
 import { tooltipAnchorOnClick } from 'components/InfoTooltip';
 import { v4 as uuidv4 } from 'uuid';
 
-const DisclaimerTooltip: React.FC<StyledTooltipProps> = props => {
+const TextTooltip: React.FC<StyledTooltipProps> = props => {
   const [isOpen, setIsOpen] = useState(false);
   const isMobile = useBreakpoint(600);
 
   const idForAccessability = uuidv4();
+
+  const AnchorTextComponent = props.altAnchorComponent
+    ? props.altAnchorComponent
+    : SmallTooltipAnchorText;
 
   return (
     <>
@@ -27,17 +35,17 @@ const DisclaimerTooltip: React.FC<StyledTooltipProps> = props => {
         leaveTouchDelay={60000} // for mobile: long leaveTouchDelay makes the tooltip stay open until close-icon is clicked
         aria-describedby={idForAccessability}
       >
-        <StyledSpan
+        <AnchorTextComponent
           tabIndex={0}
           role="button"
           onClick={() => tooltipAnchorOnClick(isMobile, () => setIsOpen(true))}
         >
           {props.mainCopy}
-        </StyledSpan>
+        </AnchorTextComponent>
       </StyledTooltip>
       <VisuallyHiddenDiv content={props.title} elemId={idForAccessability} />
     </>
   );
 };
 
-export default DisclaimerTooltip;
+export default TextTooltip;

--- a/src/components/InfoTooltip/Tooltip.style.tsx
+++ b/src/components/InfoTooltip/Tooltip.style.tsx
@@ -55,10 +55,18 @@ export const StyledCloseIcon = styled(CloseIcon)`
 export const InfoIcon = styled(InfoOutlinedIcon)<{ $isOpen: boolean }>`
   color: ${({ $isOpen }) =>
     $isOpen ? COLOR_MAP.BLUE : COLOR_MAP.GRAY_BODY_COPY};
-  cursor: pointer;
+  cursor: default;
   margin-left: 0.5rem;
   height: 18px;
   width: 18px;
+
+  &:focus {
+    outline: none;
+  }
+
+  &:focus-visible {
+    outline: rgb(0, 95, 204) 1px auto;
+  }
 `;
 
 export const StyledMarkdown = styled(MarkdownBody)`
@@ -84,20 +92,18 @@ export const StyledMarkdown = styled(MarkdownBody)`
   }
 `;
 
-const tooltipAnchorText = css`
+export const TooltipAnchorText = styled.span`
   text-decoration: underline;
   text-decoration-style: dashed;
   text-underline-offset: 3px;
-  cursor: pointer;
+  cursor: default;
   color: ${COLOR_MAP.GREY_4};
-`;
 
-export const SmallTooltipAnchorText = styled.span`
-  ${tooltipAnchorText};
-  font-size: 0.875rem;
-`;
+  &:focus {
+    outline: none;
+  }
 
-export const LargeTooltipAnchorText = styled.span`
-  ${tooltipAnchorText};
-  font-size: 1rem;
+  &:focus-visible {
+    outline: rgb(0, 95, 204) 1px auto;
+  }
 `;

--- a/src/components/InfoTooltip/Tooltip.style.tsx
+++ b/src/components/InfoTooltip/Tooltip.style.tsx
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import InfoOutlinedIcon from '@material-ui/icons/InfoOutlined';
 import { COLOR_MAP } from 'common/colors';
 import { MarkdownBody } from 'components/Markdown';
@@ -84,9 +84,20 @@ export const StyledMarkdown = styled(MarkdownBody)`
   }
 `;
 
-export const StyledSpan = styled.span`
+const tooltipAnchorText = css`
   text-decoration: underline;
+  text-decoration-style: dashed;
+  text-underline-offset: 3px;
   cursor: pointer;
-  color: ${COLOR_MAP.GRAY_BODY_COPY};
+  color: ${COLOR_MAP.GREY_4};
+`;
+
+export const SmallTooltipAnchorText = styled.span`
+  ${tooltipAnchorText};
   font-size: 0.875rem;
+`;
+
+export const LargeTooltipAnchorText = styled.span`
+  ${tooltipAnchorText};
+  font-size: 1rem;
 `;

--- a/src/components/InfoTooltip/index.tsx
+++ b/src/components/InfoTooltip/index.tsx
@@ -1,15 +1,25 @@
-import React from 'react';
+import React, { ComponentType } from 'react';
 import InfoTooltip from './InfoTooltip';
-import DisclaimerTooltip from './DisclaimerTooltip';
+import TextTooltip from './TextTooltip';
 import { TooltipProps } from '@material-ui/core/Tooltip';
-import { StyledMarkdown } from './Tooltip.style';
 import { EventAction, EventCategory, trackEvent } from 'components/Analytics';
+import {
+  StyledMarkdown,
+  SmallTooltipAnchorText,
+  LargeTooltipAnchorText,
+} from './Tooltip.style';
 
-export { InfoTooltip, DisclaimerTooltip };
+export {
+  InfoTooltip,
+  TextTooltip,
+  SmallTooltipAnchorText,
+  LargeTooltipAnchorText,
+};
 
 export type StyledTooltipProps = Omit<TooltipProps, 'children'> & {
   trackOpenTooltip: () => void;
   mainCopy?: string;
+  altAnchorComponent?: ComponentType;
 };
 
 export function renderTooltipContent(body: string): React.ReactElement {

--- a/src/components/InfoTooltip/index.tsx
+++ b/src/components/InfoTooltip/index.tsx
@@ -3,23 +3,12 @@ import InfoTooltip from './InfoTooltip';
 import TextTooltip from './TextTooltip';
 import { TooltipProps } from '@material-ui/core/Tooltip';
 import { EventAction, EventCategory, trackEvent } from 'components/Analytics';
-import {
-  StyledMarkdown,
-  SmallTooltipAnchorText,
-  LargeTooltipAnchorText,
-} from './Tooltip.style';
-
-export {
-  InfoTooltip,
-  TextTooltip,
-  SmallTooltipAnchorText,
-  LargeTooltipAnchorText,
-};
+import { StyledMarkdown } from './Tooltip.style';
+export { InfoTooltip, TextTooltip };
 
 export type StyledTooltipProps = Omit<TooltipProps, 'children'> & {
   trackOpenTooltip: () => void;
   mainCopy?: string;
-  altAnchorComponent?: ComponentType;
 };
 
 export function renderTooltipContent(body: string): React.ReactElement {


### PR DESCRIPTION
Implements new styling for tooltip anchor text ([figma](https://www.figma.com/file/l4Lra5SwXH2NX6XtZdDVWd/Buttons-and-Links?node-id=66%3A607)), applies to data api table tooltips and chart disclaimer tooltips. Renames `DisclaimerTooltip` to `TextTooltip`

[Trello ticket](https://trello.com/c/jVsSBn7E/1068-implement-new-design-pattern-for-text-that-triggers-tooltips)