### PR TITLE
accessibility: add label and aria-label for the county-state switch

### DIFF
--- a/src/components/SharedComponents/SwitchComponent.tsx
+++ b/src/components/SharedComponents/SwitchComponent.tsx
@@ -26,9 +26,14 @@ const SwitchComponent = (props: {
         <Switch
           checked={checked}
           onChange={event => onChange(event.target.checked)}
-          value="checked"
+          value={checked ? rightLabel : leftLabel}
           size="small"
           disableRipple
+          inputProps={{
+            'aria-label': 'Select states (off) or counties (on)',
+            'aria-checked': checked,
+            role: 'switch',
+          }}
         />
       </Grid>
       <SwitchLabel onClick={() => onChange(true)} item>


### PR DESCRIPTION
VoiceOver doesn't read the state of the checkbox using the labels, it still reads them as on/off, so I added that to the label for the checkbox.