### PR TITLE
accessibility: add aria labels to map elements with img role

### DIFF
--- a/src/components/Map/MapCounties.tsx
+++ b/src/components/Map/MapCounties.tsx
@@ -22,6 +22,7 @@ const MapCounties: React.FC<{
             fill={getFillColor(geo.id)}
             strokeWidth={0}
             role="img"
+            aria-label={geo.properties.name}
           />
         ))
       }

--- a/src/components/Map/USACountyMap.tsx
+++ b/src/components/Map/USACountyMap.tsx
@@ -105,6 +105,7 @@ const USACountyMap = React.memo(
                               strokeOpacity={expandTapArea ? 0 : 1}
                               role="img"
                               tabIndex={-1}
+                              aria-label={fullName}
                             />
                           )}
                         </Link>

--- a/src/components/RegionMap/RegionMap.tsx
+++ b/src/components/RegionMap/RegionMap.tsx
@@ -57,48 +57,63 @@ const RegionMap: React.FC<{
       >
         <Geographies key="states" geography={statesTopoJson}>
           {({ geographies }) =>
-            geographies.map(geo => {
-              const region = regions.findByFipsCode(geo.id);
-              return (
-                <Link
-                  key={geo.id}
-                  to={region ? region.relativeUrl : '/'}
-                  aria-label={region?.fullName || ''}
-                  onMouseEnter={() => onMouseEnter(region?.fullName || '')}
-                  onMouseLeave={onMouseLeave}
-                >
-                  <Styles.StateShape key={geo.id} geography={geo} />
-                </Link>
-              );
-            })
+            geographies
+              .filter(geo => regions.findByFipsCode(geo.id))
+              .map(geo => {
+                const region = regions.findByFipsCode(geo.id);
+                return (
+                  <Link
+                    key={geo.id}
+                    to={region ? region.relativeUrl : '/'}
+                    aria-label={region?.fullName || ''}
+                    onMouseEnter={() => onMouseEnter(region?.fullName || '')}
+                    onMouseLeave={onMouseLeave}
+                  >
+                    <Styles.StateShape
+                      key={geo.id}
+                      geography={geo}
+                      aria-label={region?.fullName}
+                    />
+                  </Link>
+                );
+              })
           }
         </Geographies>
         <Geographies key="counties" geography={countiesTopoJson}>
           {({ geographies }) =>
-            geographies.map(geo => {
-              const region = regions.findByFipsCode(geo.id);
-              return (
-                <Link
-                  key={geo.id}
-                  to={region ? region.relativeUrl : '/'}
-                  aria-label={region?.shortName || ''}
-                  onMouseEnter={() => onMouseEnter(region?.shortName || '')}
-                  onMouseLeave={onMouseLeave}
-                >
-                  <Styles.CountyWithLevel
-                    geography={geo}
-                    $locationSummary={LocationSummariesByFIPS[geo.id] || null}
-                  />
-                </Link>
-              );
-            })
+            geographies
+              .filter(geo => regions.findByFipsCode(geo.id))
+              .map(geo => {
+                const region = regions.findByFipsCode(geo.id);
+                return (
+                  <Link
+                    key={geo.id}
+                    to={region ? region.relativeUrl : '/'}
+                    aria-label={region?.shortName || ''}
+                    onMouseEnter={() => onMouseEnter(region?.shortName || '')}
+                    onMouseLeave={onMouseLeave}
+                  >
+                    <Styles.CountyWithLevel
+                      geography={geo}
+                      $locationSummary={LocationSummariesByFIPS[geo.id] || null}
+                      aria-label={region?.shortName}
+                    />
+                  </Link>
+                );
+              })
           }
         </Geographies>
         <Geographies key="state-borders" geography={statesTopoJson}>
           {({ geographies }) =>
-            geographies.map(geo => (
-              <Styles.StateBorder key={geo.id} geography={geo} />
-            ))
+            geographies
+              .filter(geo => regions.findByFipsCode(geo.id))
+              .map(geo => (
+                <Styles.StateBorder
+                  key={geo.id}
+                  geography={geo}
+                  aria-hidden="true"
+                />
+              ))
           }
         </Geographies>
         {/* Highlight the current county if needed */}
@@ -108,7 +123,11 @@ const RegionMap: React.FC<{
               geographies
                 .filter(geo => geo.id === region.fipsCode)
                 .map(geo => (
-                  <Styles.CountyBorder key={geo.id} geography={geo} />
+                  <Styles.CountyBorder
+                    key={geo.id}
+                    geography={geo}
+                    aria-hidden="true"
+                  />
                 ))
             }
           </Geographies>


### PR DESCRIPTION
SVG paths with `role="img"` need to have labels. Adding `aria-label` for those elements! Also filter out geographies that are in the TopoJSON file but that we don't have in regions (American Samoa and Guam I think?)