### PR TITLE
A/B testing: metro vs. state in geolocation cards

### DIFF
--- a/src/common/hooks/useGeolocation.ts
+++ b/src/common/hooks/useGeolocation.ts
@@ -28,8 +28,7 @@ export default function useGeolocation(): UseGeolocationReturn {
   useEffect(() => {
     const fetchIpData = () => {
       setIsLoading(true);
-      //fetchGeolocationData()
-      mockGeolocationData()
+      fetchGeolocationData()
         .then(data =>
           setIpData({
             zipCode: data.zip,
@@ -51,39 +50,39 @@ export default function useGeolocation(): UseGeolocationReturn {
   return geolocationReturnObj;
 }
 
-// function fetchGeolocationData() {
-//   return fetch(
-//     `https://pro.ip-api.com/json/?key=${IP_API_KEY}`,
-//   ).then(response => response.json());
-// }
+function fetchGeolocationData() {
+  return fetch(
+    `https://pro.ip-api.com/json/?key=${IP_API_KEY}`,
+  ).then(response => response.json());
+}
 
 // Use this mock to simulate fetchGeolocationData, other data can be obtained from
 // https://ip-api.com/#<IP_ADDRESS> (https://ip-api.com/#8.8.8.8)
 
-function mockGeolocationData() {
-  return Promise.resolve({
-    query: '8.8.8.8',
-    status: 'success',
-    continent: 'North America',
-    continentCode: 'NA',
-    country: 'United States',
-    countryCode: 'US',
-    region: 'VA',
-    regionName: 'Virginia',
-    city: 'Ashburn',
-    district: '',
-    zip: '20149',
-    lat: 39.03,
-    lon: -77.5,
-    timezone: 'America/New_York',
-    offset: -18000,
-    currency: 'USD',
-    isp: 'Google LLC',
-    org: 'Google Public DNS',
-    as: 'AS15169 Google LLC',
-    asname: 'GOOGLE',
-    mobile: false,
-    proxy: false,
-    hosting: true,
-  });
-}
+// function mockGeolocationData() {
+//   return Promise.resolve({
+//     query: '8.8.8.8',
+//     status: 'success',
+//     continent: 'North America',
+//     continentCode: 'NA',
+//     country: 'United States',
+//     countryCode: 'US',
+//     region: 'VA',
+//     regionName: 'Virginia',
+//     city: 'Ashburn',
+//     district: '',
+//     zip: '20149',
+//     lat: 39.03,
+//     lon: -77.5,
+//     timezone: 'America/New_York',
+//     offset: -18000,
+//     currency: 'USD',
+//     isp: 'Google LLC',
+//     org: 'Google Public DNS',
+//     as: 'AS15169 Google LLC',
+//     asname: 'GOOGLE',
+//     mobile: false,
+//     proxy: false,
+//     hosting: true,
+//   });
+// }

--- a/src/common/hooks/useGeolocation.ts
+++ b/src/common/hooks/useGeolocation.ts
@@ -28,7 +28,8 @@ export default function useGeolocation(): UseGeolocationReturn {
   useEffect(() => {
     const fetchIpData = () => {
       setIsLoading(true);
-      fetchGeolocationData()
+      //fetchGeolocationData()
+      mockGeolocationData()
         .then(data =>
           setIpData({
             zipCode: data.zip,
@@ -50,39 +51,39 @@ export default function useGeolocation(): UseGeolocationReturn {
   return geolocationReturnObj;
 }
 
-function fetchGeolocationData() {
-  return fetch(
-    `https://pro.ip-api.com/json/?key=${IP_API_KEY}`,
-  ).then(response => response.json());
-}
+// function fetchGeolocationData() {
+//   return fetch(
+//     `https://pro.ip-api.com/json/?key=${IP_API_KEY}`,
+//   ).then(response => response.json());
+// }
 
 // Use this mock to simulate fetchGeolocationData, other data can be obtained from
 // https://ip-api.com/#<IP_ADDRESS> (https://ip-api.com/#8.8.8.8)
 
-// function mockGeolocationData() {
-//   return Promise.resolve({
-//     query: '8.8.8.8',
-//     status: 'success',
-//     continent: 'North America',
-//     continentCode: 'NA',
-//     country: 'United States',
-//     countryCode: 'US',
-//     region: 'VA',
-//     regionName: 'Virginia',
-//     city: 'Ashburn',
-//     district: '',
-//     zip: '20149',
-//     lat: 39.03,
-//     lon: -77.5,
-//     timezone: 'America/New_York',
-//     offset: -18000,
-//     currency: 'USD',
-//     isp: 'Google LLC',
-//     org: 'Google Public DNS',
-//     as: 'AS15169 Google LLC',
-//     asname: 'GOOGLE',
-//     mobile: false,
-//     proxy: false,
-//     hosting: true,
-//   });
-// }
+function mockGeolocationData() {
+  return Promise.resolve({
+    query: '8.8.8.8',
+    status: 'success',
+    continent: 'North America',
+    continentCode: 'NA',
+    country: 'United States',
+    countryCode: 'US',
+    region: 'VA',
+    regionName: 'Virginia',
+    city: 'Ashburn',
+    district: '',
+    zip: '20149',
+    lat: 39.03,
+    lon: -77.5,
+    timezone: 'America/New_York',
+    offset: -18000,
+    currency: 'USD',
+    isp: 'Google LLC',
+    org: 'Google Public DNS',
+    as: 'AS15169 Google LLC',
+    asname: 'GOOGLE',
+    mobile: false,
+    proxy: false,
+    hosting: true,
+  });
+}

--- a/src/components/Experiment/Experiment.tsx
+++ b/src/components/Experiment/Experiment.tsx
@@ -32,6 +32,7 @@ import {
 export enum ExperimentID {
   HAMBURGER_MENU_DESKTOP = 'ValZVSToRlOxvqM1QYtjIA',
   HAMBURGER_MENU_VARIATIONS = 'Osj4ZMGVTia8fMsmubSdnQ',
+  GEOLOCATED_LINKS = '9S4Moj7WSseah7fzFlAJYQ',
 }
 
 export type ExperimentProps = Omit<OptimizeExperimentProps, 'id'> & {

--- a/src/components/Experiment/Experiment.tsx
+++ b/src/components/Experiment/Experiment.tsx
@@ -32,7 +32,7 @@ import {
 export enum ExperimentID {
   HAMBURGER_MENU_DESKTOP = 'ValZVSToRlOxvqM1QYtjIA',
   HAMBURGER_MENU_VARIATIONS = 'Osj4ZMGVTia8fMsmubSdnQ',
-  GEOLOCATED_LINKS = '9S4Moj7WSseah7fzFlAJYQ',
+  GEOLOCATED_LINKS = 'Xel9axsHQgGPr5h0tcXRxA',
 }
 
 export type ExperimentProps = Omit<OptimizeExperimentProps, 'id'> & {

--- a/src/components/RegionItem/HomepageItems.tsx
+++ b/src/components/RegionItem/HomepageItems.tsx
@@ -50,11 +50,11 @@ const HomepageItems: React.FC<{
 
 function getRegionList(
   geolocatedRegions: GeolocatedRegions,
-  getMetro: boolean = true,
+  showMetro: boolean = true,
 ): Region[] {
   const { county, state, metroArea } = geolocatedRegions;
   const items = [];
-  if (getMetro) {
+  if (showMetro) {
     if (metroArea) items.push(metroArea);
     if (county) items.push(county);
     if (state && items.length < 2) items.push(state);

--- a/src/components/RegionItem/HomepageItems.tsx
+++ b/src/components/RegionItem/HomepageItems.tsx
@@ -13,7 +13,8 @@ enum ItemsState {
 const HomepageItems: React.FC<{
   userRegions: GeolocatedRegions | null;
   isLoading: boolean;
-}> = ({ userRegions, isLoading }) => {
+  showMetro: boolean;
+}> = ({ userRegions, isLoading, showMetro }) => {
   const itemsState = isLoading
     ? ItemsState.LOADING
     : userRegions
@@ -24,7 +25,9 @@ const HomepageItems: React.FC<{
     return null;
   }
 
-  const visibleRegions = userRegions ? getRegionList(userRegions) : [];
+  const visibleRegions = userRegions
+    ? getRegionList(userRegions, showMetro)
+    : [];
 
   return (
     <RegionItemsWrapper>
@@ -45,23 +48,22 @@ const HomepageItems: React.FC<{
   );
 };
 
-function getRegionList(geolocatedRegions: GeolocatedRegions): Region[] {
+function getRegionList(
+  geolocatedRegions: GeolocatedRegions,
+  getMetro: boolean = true,
+): Region[] {
   const { county, state, metroArea } = geolocatedRegions;
-
   const items = [];
-
-  if (metroArea) {
-    items.push(metroArea);
+  if (getMetro) {
+    if (metroArea) items.push(metroArea);
+    if (county) items.push(county);
+    if (state && items.length < 2) items.push(state);
+  } else {
+    if (state) items.push(state);
+    if (county) items.push(county);
+    // Only show metro if at least one of state or county is unavailable.
+    if (metroArea && items.length < 2) items.push(metroArea);
   }
-
-  if (county) {
-    items.push(county);
-  }
-
-  if (state && items.length < 2) {
-    items.push(state);
-  }
-
   return items;
 }
 

--- a/src/components/RegionItem/HomepageItems.tsx
+++ b/src/components/RegionItem/HomepageItems.tsx
@@ -50,7 +50,7 @@ const HomepageItems: React.FC<{
 
 function getRegionList(
   geolocatedRegions: GeolocatedRegions,
-  showMetro: boolean = true,
+  showMetro: boolean,
 ): Region[] {
   const { county, state, metroArea } = geolocatedRegions;
   const items = [];

--- a/src/screens/HomePage/HomePage.tsx
+++ b/src/screens/HomePage/HomePage.tsx
@@ -32,6 +32,12 @@ import Toggle from './Toggle/Toggle';
 import HorizontalThermometer from 'components/HorizontalThermometer';
 import HomepageItems from 'components/RegionItem/HomepageItems';
 import { useBreakpoint, useCountyToZipMap } from 'common/hooks';
+import {
+  Experiment,
+  ExperimentID,
+  Variant,
+  VariantID,
+} from 'components/Experiment';
 
 function getPageDescription() {
   const date = formatMetatagDate();
@@ -133,11 +139,22 @@ export default function HomePage() {
                 )}
                 filterLimit={getFilterLimit()}
               />
-              <HomepageItems
-                isLoading={isLoading}
-                userRegions={userRegions}
-                showMetro={false}
-              />
+              <Experiment id={ExperimentID.GEOLOCATED_LINKS}>
+                <Variant id={VariantID.A}>
+                  <HomepageItems
+                    isLoading={isLoading}
+                    userRegions={userRegions}
+                    showMetro={true}
+                  />
+                </Variant>
+                <Variant id={VariantID.B}>
+                  <HomepageItems
+                    isLoading={isLoading}
+                    userRegions={userRegions}
+                    showMetro={false}
+                  />
+                </Variant>
+              </Experiment>
               <Toggle
                 showCounties={showCounties}
                 onClickSwitch={onClickSwitch}

--- a/src/screens/HomePage/HomePage.tsx
+++ b/src/screens/HomePage/HomePage.tsx
@@ -144,7 +144,7 @@ export default function HomePage() {
                   <HomepageItems
                     isLoading={isLoading}
                     userRegions={userRegions}
-                    showMetro={true}
+                    showMetro
                   />
                 </Variant>
                 <Variant id={VariantID.B}>

--- a/src/screens/HomePage/HomePage.tsx
+++ b/src/screens/HomePage/HomePage.tsx
@@ -133,7 +133,11 @@ export default function HomePage() {
                 )}
                 filterLimit={getFilterLimit()}
               />
-              <HomepageItems isLoading={isLoading} userRegions={userRegions} />
+              <HomepageItems
+                isLoading={isLoading}
+                userRegions={userRegions}
+                showMetro={false}
+              />
               <Toggle
                 showCounties={showCounties}
                 onClickSwitch={onClickSwitch}


### PR DESCRIPTION
This PR adds a parameter to the `HomePageItems` component which enables one to select whether the component will show metro and county side by side or state and county side by side.

The default behavior is the page showing metro and county. However, if one passes `False` as the `showMetro` parameter to `HomePageItems`, then the page will show state and county instead. This shall enable A/B testing for showing metro and county side by side versus state and county side by side.