### PR TITLE
wip: update link colors

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,6 +28,7 @@ import PageviewTracker, {
 } from 'components/Analytics';
 import { SuspenseFallback, ErrorBoundary } from 'components/LazyLoading';
 import HomePage from 'screens/HomePage/HomePage';
+import GlobalStyles from 'components/GlobalStyles';
 
 /* We dynamically import the following components on initial visit to their respective routes: */
 const About = lazy(() => import('screens/About/About'));
@@ -52,6 +53,7 @@ export default function App() {
       <ScThemeProvider theme={theme}>
         <StylesProvider injectFirst>
           <CssBaseline />
+          <GlobalStyles />
           <BrowserRouter>
             <PageviewTracker />
             <ScrollToTop />

--- a/src/assets/theme/buttons.tsx
+++ b/src/assets/theme/buttons.tsx
@@ -22,9 +22,6 @@ export interface ButtonsTheme {
   fontFamily: FlattenSimpleInterpolation;
 }
 
-const newBlue = '#3567FD';
-const newBlueDark = '#002CB4';
-const newBlueLight = 'rgba(53, 103, 253, .15)';
 const lightGrayFigma = '#e0e0e0';
 
 export type ButtonMap = {
@@ -33,11 +30,11 @@ export type ButtonMap = {
 
 const buttons: ButtonMap = {
   [ButtonType.FILL]: {
-    background: newBlue,
-    border: newBlue,
+    background: COLOR_MAP.interactiveBase,
+    border: COLOR_MAP.interactiveBase,
     text: 'white',
-    backgroundHover: newBlueDark,
-    borderHover: newBlueDark,
+    backgroundHover: COLOR_MAP.interactiveHover,
+    borderHover: COLOR_MAP.interactiveHover,
     textHover: 'white',
     icon: 'white',
     fontFamily: fonts.regularBookBold,
@@ -48,10 +45,10 @@ const buttons: ButtonMap = {
   [ButtonType.OUTLINE]: {
     background: 'white',
     border: lightGrayFigma,
-    text: newBlue,
-    backgroundHover: newBlueLight,
-    borderHover: newBlueLight,
-    textHover: newBlueDark,
+    text: COLOR_MAP.interactiveBase,
+    backgroundHover: COLOR_MAP.interactiveLight,
+    borderHover: COLOR_MAP.interactiveLight,
+    textHover: COLOR_MAP.interactiveHover,
     icon: COLOR_MAP.GRAY_BODY_COPY,
     fontFamily: fonts.regularBookMidWeight,
     disabledBackground: 'white',
@@ -61,10 +58,10 @@ const buttons: ButtonMap = {
   [ButtonType.TEXT]: {
     background: 'transparent',
     border: 'transparent',
-    text: newBlue,
+    text: COLOR_MAP.interactiveBase,
     backgroundHover: 'transparent',
     borderHover: 'transparent',
-    textHover: newBlueDark,
+    textHover: COLOR_MAP.interactiveHover,
     icon: COLOR_MAP.GRAY_BODY_COPY,
     fontFamily: fonts.regularBook,
     disabledBackground: COLOR_MAP.GREY_1, // TODO (chelsi) - ask UX about disable state

--- a/src/assets/theme/index.tsx
+++ b/src/assets/theme/index.tsx
@@ -13,12 +13,21 @@ interface ThemeColors {
   green: string;
   greenDark: string;
   lightBlue: string;
+  // Interactive colors
+  interactiveBase: string;
+  interactiveHover: string;
+  interactiveMedium: string;
+  interactiveLight: string;
 }
 
 const colors: ThemeColors = {
   green: COLOR_MAP.GREEN.BASE,
   greenDark: COLOR_MAP.GREEN.DARK,
   lightBlue: COLOR_MAP.BLUE,
+  interactiveBase: COLOR_MAP.interactiveBase,
+  interactiveHover: COLOR_MAP.interactiveHover,
+  interactiveMedium: COLOR_MAP.interactiveMedium,
+  interactiveLight: COLOR_MAP.interactiveLight,
 };
 
 interface ThemeFonts {

--- a/src/common/colors.ts
+++ b/src/common/colors.ts
@@ -72,6 +72,13 @@ export const COLOR_MAP = {
   LIGHT_YELLOW: '#FFF1BF',
   LIGHT_YELLOW_EMAIL: 'rgba(255, 201, 0, 0.12)',
   BLACK: '#000000',
+
+  // Interactive Colors
+  // https://www.figma.com/file/h2CLX3VWnldAU3vfxFdrWV/Colors?node-id=454%3A17
+  interactiveBase: '#3567FD',
+  interactiveHover: '#002CB4',
+  interactiveMedium: 'rgba(53, 103, 253, 0.6)',
+  interactiveLight: 'rgba(53, 103, 253, .15)',
 };
 
 export const LEVEL_COLOR = {

--- a/src/components/GlobalStyles/GlobalStyles.style.ts
+++ b/src/components/GlobalStyles/GlobalStyles.style.ts
@@ -1,0 +1,18 @@
+import { createGlobalStyle } from 'styled-components';
+import theme from 'assets/theme';
+
+// TODO(pablo): We want to grab these from the ThemeProvider:
+// color: ${props => props.theme.colors.interactiveBase} but TS
+// complains if we do
+const GlobalStyle = createGlobalStyle`
+  a {
+    color: ${theme.colors.interactiveBase};
+  }
+
+  a:hover {
+    color: ${theme.colors.interactiveHover};
+    text-decoration: underline;
+  }
+`;
+
+export default GlobalStyle;

--- a/src/components/GlobalStyles/GlobalStyles.style.ts
+++ b/src/components/GlobalStyles/GlobalStyles.style.ts
@@ -4,6 +4,7 @@ import theme from 'assets/theme';
 // TODO(pablo): We want to grab these from the ThemeProvider:
 // color: ${props => props.theme.colors.interactiveBase} but TS
 // complains if we do
+// See https://github.com/styled-components/styled-components/issues/1589#issuecomment-578294784
 const GlobalStyle = createGlobalStyle`
   a {
     color: ${theme.colors.interactiveBase};

--- a/src/components/GlobalStyles/index.ts
+++ b/src/components/GlobalStyles/index.ts
@@ -1,0 +1,3 @@
+import GlobalStyles from './GlobalStyles.style';
+
+export default GlobalStyles;

--- a/src/components/Markdown/Markdown.style.ts
+++ b/src/components/Markdown/Markdown.style.ts
@@ -110,7 +110,7 @@ export const StylesMarkdown = css`
     margin-top: ${theme.spacing(1)}px;
     margin-bottom: ${theme.spacing(1)}px;
     a {
-      color: ${COLOR_MAP.BLUE};
+      color: ${props => props.theme.colors.interactiveBase};
     }
   }
 


### PR DESCRIPTION
_work in progress_

Ideally, we want to grab the colors from the `ThemeProvider` theme, not from `assets/theme`. I tried that but TS complains (it seems that we need to overwrite the type definitions for `styled-components`, see https://github.com/styled-components/styled-components/issues/1589)

### TODO
- This overwrites the hover style on the footer
- Some links are missing