### PR TITLE
update the version and link of the CRS

### DIFF
--- a/public/covid-response-simulator-version.txt
+++ b/public/covid-response-simulator-version.txt
@@ -1,2 +1,2 @@
-Version 1.65
-https://docs.google.com/spreadsheets/d/1iUQvuY-DGbuxGBDrj1fvaDjk-peunHm89sMJe0z24U8/copy?usp=sharing
+Version 1.75
+https://docs.google.com/spreadsheets/d/1S1l4E-mVdxJoczTkxAsDOQatuNujhW2hsuDmSkr4UJU/edit?usp=sharing


### PR DESCRIPTION
[Trello](https://trello.com/c/qQ8H2TOH/1191-release-175-for-crs-fixing-api-change-issue-current-165-version-does-not-work-anymore-and-users-complained-https-docsgooglecom-s) - Update CRS version number and link