### PR TITLE
Revert "Switch from using moment to time utils in projection.ts (#3222)"

### DIFF
--- a/src/common/models/Projection.ts
+++ b/src/common/models/Projection.ts
@@ -2,6 +2,7 @@ import first from 'lodash/first';
 import last from 'lodash/last';
 import findIndex from 'lodash/findIndex';
 import findLastIndex from 'lodash/findLastIndex';
+import moment from 'moment';
 import { ActualsTimeseries } from 'api';
 import {
   ActualsTimeseriesRow,
@@ -17,14 +18,6 @@ import { assert, formatPercent } from 'common/utils';
 import { Metric } from 'common/metricEnum';
 import { Region } from 'common/regions';
 import { getRegionMetricOverride } from 'cms-content/region-overrides';
-import {
-  TimeUnit,
-  DateFormat,
-  parseDateString,
-  getTimeDiff,
-  formatDateTime,
-  addTime,
-} from 'common/utils/time-utils';
 
 /**
  * Override any disabled metrics and make them reenabled. Used by internal tools.
@@ -497,14 +490,14 @@ export class Projection {
     // TODO(chris): Is there a reason that this was bound to the projections timeseries first?
     // It cuts off some of the earlier dates
     if (metricsTimeseriesRaw.length > 0) {
-      earliestDate = parseDateString(first(metricsTimeseriesRaw)!.date);
-      latestDate = parseDateString(last(metricsTimeseriesRaw)!.date);
+      earliestDate = moment.utc(first(metricsTimeseriesRaw)!.date);
+      latestDate = moment.utc(last(metricsTimeseriesRaw)!.date);
     } else {
-      earliestDate = parseDateString(first(actualsTimeseriesRaw)!.date);
-      latestDate = parseDateString(last(actualsTimeseriesRaw)!.date);
+      earliestDate = moment.utc(first(actualsTimeseriesRaw)!.date);
+      latestDate = moment.utc(last(actualsTimeseriesRaw)!.date);
     }
 
-    earliestDate = parseDateString('2020-03-01');
+    earliestDate = moment.utc('2020-03-01');
 
     const actualsTimeseries: Array<ActualsTimeseriesRow | null> = [];
     const metricsTimeseries: Array<MetricsTimeseriesRow | null> = [];
@@ -517,9 +510,9 @@ export class Projection {
       metricsTimeseriesRaw,
     );
 
-    let currDate = earliestDate;
-    while (getTimeDiff(currDate, latestDate, TimeUnit.DAYS) <= 0) {
-      const ts = formatDateTime(currDate, DateFormat.YYYY_MM_DD);
+    let currDate = earliestDate.clone();
+    while (currDate.diff(latestDate) <= 0) {
+      const ts = currDate.format('YYYY-MM-DD');
       const actualsTimeseriesrowForDate = actualsTimeseriesDictionary[
         ts
       ] as ActualsTimeseriesRow;
@@ -528,10 +521,10 @@ export class Projection {
       ] as MetricsTimeseriesRow;
       actualsTimeseries.push(actualsTimeseriesrowForDate || null);
       metricsTimeseries.push(metricsTimeseriesRowForDate || null);
-      dates.push(currDate);
+      dates.push(currDate.toDate());
 
       // increment the date by one
-      currDate = addTime(currDate, 1, TimeUnit.DAYS);
+      currDate = currDate.clone().add(1, 'days');
     }
 
     // only keep futureDaysToInclude days ahead of today

--- a/src/common/utils/time-utils.test.ts
+++ b/src/common/utils/time-utils.test.ts
@@ -75,18 +75,13 @@ describe('utc time formatting', () => {
 });
 
 describe('date string parsing', () => {
-  test('ISO format in UTC to date object', () => {
-    expect(parseDateString('2020-03-01T00:00:00.000Z')).toEqual(
-      new Date(2020, 1, 29, 16),
-    );
-  });
-  test('ISO format to UTC date object with time', () => {
-    expect(parseDateString('2020-12-31T23:59:59.999Z')).toEqual(
-      new Date(2020, 11, 31, 15, 59, 59, 999),
+  test('ISO format to date object', () => {
+    expect(parseDateString('2020-03-01T00:00:00.000')).toEqual(
+      new Date(2020, 2, 1),
     );
   });
   test('Date string to date object', () => {
-    expect(parseDateString('2020-03-01')).toEqual(new Date(2020, 1, 29, 16));
+    expect(parseDateString('2020-03-01')).toEqual(new Date(2020, 2, 1));
   });
   test('Invalid date string', () => {
     expect(() => parseDateString('Hello')).toThrow();

--- a/src/common/utils/time-utils.ts
+++ b/src/common/utils/time-utils.ts
@@ -27,7 +27,7 @@ export enum TimeUnit {
  * Example: parseDateString('2020-03-01') // Return JS date object for March 1st 2020.
  */
 export function parseDateString(dateString: string): Date {
-  const parsedDate = DateTime.fromISO(dateString, { zone: 'utc' });
+  const parsedDate = DateTime.fromISO(dateString);
   assert(parsedDate.isValid, `Invalid input date string: ${dateString}`);
   return parsedDate.toJSDate();
 }


### PR DESCRIPTION
This reverts commit 53994c4153022d644dacf7c04d78823c7536fc0c.

It turns out this regressed some charts so that they were missing the last data point. Strangely not all places were affected (e.g. Washington and King County seem okay, but Monroe Metro, MI loses the last data point in the chart).

E.g.:

![image](https://user-images.githubusercontent.com/206364/113315245-eef04800-92c1-11eb-85ea-13b83e9d5ee4.png)
![image](https://user-images.githubusercontent.com/206364/113315301-fb74a080-92c1-11eb-91d3-458b442bcbe5.png)
![image](https://user-images.githubusercontent.com/206364/113315504-34ad1080-92c2-11eb-8996-2c62d5746233.png)

