### PR TITLE
Make EmailAlertsFooter use Fips for defaultRegions

### DIFF
--- a/src/components/EmailAlertsFooter/EmailAlertsFooter.stories.tsx
+++ b/src/components/EmailAlertsFooter/EmailAlertsFooter.stories.tsx
@@ -8,5 +8,10 @@ export default {
 };
 
 export const Example = () => (
-  <EmailAlertsFooter defaultRegions={[regions.states[0], regions.states[10]]} />
+  <EmailAlertsFooter
+    defaultRegionsFips={[
+      regions.states[0].fipsCode,
+      regions.states[10].fipsCode,
+    ]}
+  />
 );

--- a/src/components/EmailAlertsFooter/EmailAlertsFooter.tsx
+++ b/src/components/EmailAlertsFooter/EmailAlertsFooter.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import regions, { Region } from 'common/regions';
+import regions, { FipsCode } from 'common/regions';
 import {
   Container,
   Content,
@@ -10,9 +10,10 @@ import {
 } from './EmailAlertsFooter.style';
 import EmailAlertsForm from 'components/EmailAlertsForm';
 
-const EmailAlertsFooter: React.FC<{ defaultRegions: Region[] }> = ({
-  defaultRegions,
+const EmailAlertsFooter: React.FC<{ defaultRegionsFips: FipsCode[] }> = ({
+  defaultRegionsFips,
 }) => {
+  const defaultRegions = defaultRegionsFips.map(regions.findByFipsCodeStrict);
   return (
     <Container>
       <Content>

--- a/src/components/EmailAlertsForm/utils.ts
+++ b/src/components/EmailAlertsForm/utils.ts
@@ -1,14 +1,14 @@
 import { getFirestore, getFirestoreFieldValue } from 'common/firebase';
-import { Region, County, MetroArea } from 'common/regions';
+import { Region, County, MetroArea, FipsCode } from 'common/regions';
 
-export function getDefaultRegions(region: Region): Region[] {
+export function getDefaultRegions(region: Region): FipsCode[] {
   if (region instanceof MetroArea) {
-    return [region, ...region.states];
+    return [region.fipsCode, ...region.states.map(state => state.fipsCode)];
   }
   if (region instanceof County) {
-    return [region, region.state];
+    return [region.fipsCode, region.state.fipsCode];
   } else {
-    return [region];
+    return [region.fipsCode];
   }
 }
 

--- a/src/components/ShareBlock/ShareBlock.tsx
+++ b/src/components/ShareBlock/ShareBlock.tsx
@@ -76,13 +76,13 @@ const ShareBlock = ({
       <SocialLocationPreviewMap isEmbedPreview />
     );
 
-  const defaultSignupRegions = region
+  const defaultSignupRegionsFips = region
     ? getDefaultRegions(region)
-    : geolocatedRegions;
+    : geolocatedRegions.map((region: Region) => region.fipsCode);
 
   return (
     <ShareContainer id="share">
-      <EmailAlertsFooter defaultRegions={defaultSignupRegions} />
+      <EmailAlertsFooter defaultRegionsFips={defaultSignupRegionsFips} />
       <ShareRow newsletter={false}>
         <ShareRowContentArea
           $isMatchingProjectionsRoute={isMatchingProjectionsRoute !== null}


### PR DESCRIPTION
This is part of a larger plan to eliminate nested regions in region DB, to allow simpler partial loading of region data.

The email alerts footer component already had a dependency on the regions database, so we can look things up by FIPS ode and just pass FIPS code in, instead of the whole region.