### PR TITLE
Update FB Pixel with one from Jess to track API ad conversions.

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -137,13 +137,6 @@
       fbq('init', '538941662941644');
       fbq('track', 'PageView');
     </script>
-    <noscript
-      ><img
-        height="1"
-        width="1"
-        style="display: none;"
-        src="https://www.facebook.com/tr?id=538941662941644&ev=PageView&noscript=1"
-    /></noscript>
     <!-- End Facebook Pixel Code -->
 
     <!-- Global site tag (gtag.js) - Google Ads: 527465415 -->

--- a/public/index.html
+++ b/public/index.html
@@ -110,7 +110,7 @@
     <!-- End Twitter universal website tag code -->
 
     <!-- Facebook Pixel Code -->
-    <script async>
+    <script>
       !(function (f, b, e, v, n, t, s) {
         if (f.fbq) return;
         n = f.fbq = function () {
@@ -134,9 +134,17 @@
         'script',
         'https://connect.facebook.net/en_US/fbevents.js',
       );
-      fbq('init', '692591964861759');
+      fbq('init', '538941662941644');
       fbq('track', 'PageView');
     </script>
+    <noscript
+      ><img
+        height="1"
+        width="1"
+        style="display: none;"
+        src="https://www.facebook.com/tr?id=538941662941644&ev=PageView&noscript=1"
+    /></noscript>
+    <!-- End Facebook Pixel Code -->
 
     <!-- Global site tag (gtag.js) - Google Ads: 527465415 -->
     <script


### PR DESCRIPTION
I'm not 100% sure where our old pixel code came from.  I've pinged Anya and Mike McDonald (who made the [original change](https://github.com/covid-projections/covid-projections/commit/b88c3517a453cc233632227603889e48f5bcf851) but is no longer on the team).  If I don't hear back from them, I'll just merge this tonight or tomorrow and we'll see if anything breaks / people complain. 😬 