### PR TITLE
Mega menu mobile bug fix

### DIFF
--- a/src/components/NewFooter/Menu.style.tsx
+++ b/src/components/NewFooter/Menu.style.tsx
@@ -30,8 +30,8 @@ export const StyledMegaMenu = styled.nav`
   top: 0;
   left: 0;
   right: 0;
-  padding: 2rem 1.5rem 6rem;
-  height: calc(100vh - 192px);
+  padding: 2rem 1.5rem 7rem;
+  height: calc(100vh - 208px);
   overflow-y: auto;
   box-sizing: content-box;
   box-shadow: 0px 15px 30px -15px rgba(0, 0, 0, 0.2);

--- a/src/components/NewFooter/Menu.style.tsx
+++ b/src/components/NewFooter/Menu.style.tsx
@@ -30,8 +30,8 @@ export const StyledMegaMenu = styled.nav`
   top: 0;
   left: 0;
   right: 0;
-  padding: 2rem 1.5rem;
-  height: calc(100vh - 128px);
+  padding: 2rem 1.5rem 4rem;
+  height: calc(100vh - 160px);
   overflow-y: auto;
   box-sizing: content-box;
   box-shadow: 0px 15px 30px -15px rgba(0, 0, 0, 0.2);

--- a/src/components/NewFooter/Menu.style.tsx
+++ b/src/components/NewFooter/Menu.style.tsx
@@ -21,6 +21,8 @@ export const StyledFooter = styled.footer`
   }
 `;
 
+// Need to add a good amount of bottom padding for mobile screens to make sure the bottom
+// of the mega menu isn't covered by the browser's menu bar
 export const StyledMegaMenu = styled.nav`
   background: white;
   border-top: 1px solid ${COLOR_MAP.GREY_2};

--- a/src/components/NewFooter/Menu.style.tsx
+++ b/src/components/NewFooter/Menu.style.tsx
@@ -30,8 +30,8 @@ export const StyledMegaMenu = styled.nav`
   top: 0;
   left: 0;
   right: 0;
-  padding: 2rem 1.5rem 4rem;
-  height: calc(100vh - 160px);
+  padding: 2rem 1.5rem 6rem;
+  height: calc(100vh - 192px);
   overflow-y: auto;
   box-sizing: content-box;
   box-shadow: 0px 15px 30px -15px rgba(0, 0, 0, 0.2);

--- a/src/components/NewFooter/Menu.style.tsx
+++ b/src/components/NewFooter/Menu.style.tsx
@@ -30,8 +30,8 @@ export const StyledMegaMenu = styled.nav`
   top: 0;
   left: 0;
   right: 0;
-  padding: 2rem 1.5rem 7rem;
-  height: calc(100vh - 208px);
+  padding: 2rem 1.5rem 8rem;
+  height: calc(100vh - 224px);
   overflow-y: auto;
   box-sizing: content-box;
   box-shadow: 0px 15px 30px -15px rgba(0, 0, 0, 0.2);


### PR DESCRIPTION
The browser's menu bar was covering the bottom of the mega menu. This increases the mega menu's bottom padding to account for this