### PR TITLE
Reorganize theme fonts

### DIFF
--- a/src/assets/theme/buttons.tsx
+++ b/src/assets/theme/buttons.tsx
@@ -1,5 +1,5 @@
 import { COLOR_MAP } from 'common/colors';
-import fonts from 'common/theme/fonts';
+import fontBlocks from './fontBlocks';
 import { FlattenSimpleInterpolation } from 'styled-components';
 
 export enum ButtonType {
@@ -40,7 +40,7 @@ const buttons: ButtonMap = {
     borderHover: newBlueDark,
     textHover: 'white',
     icon: 'white',
-    fontFamily: fonts.regularBookBold,
+    fontFamily: fontBlocks.regularBookBold,
     disabledBackground: COLOR_MAP.GREY_1,
     disabledText: COLOR_MAP.GRAY_BODY_COPY,
     disabledIcon: COLOR_MAP.GREY_3,
@@ -53,7 +53,7 @@ const buttons: ButtonMap = {
     borderHover: newBlueLight,
     textHover: newBlueDark,
     icon: COLOR_MAP.GRAY_BODY_COPY,
-    fontFamily: fonts.regularBookMidWeight,
+    fontFamily: fontBlocks.regularBookMidWeight,
     disabledBackground: 'white',
     disabledText: COLOR_MAP.GRAY_BODY_COPY,
     disabledIcon: COLOR_MAP.GREY_3,
@@ -66,7 +66,7 @@ const buttons: ButtonMap = {
     borderHover: 'transparent',
     textHover: newBlueDark,
     icon: COLOR_MAP.GRAY_BODY_COPY,
-    fontFamily: fonts.regularBook,
+    fontFamily: fontBlocks.regularBook,
     disabledBackground: COLOR_MAP.GREY_1, // TODO (chelsi) - ask UX about disable state
     disabledText: COLOR_MAP.GRAY_BODY_COPY, // ditto^
     disabledIcon: COLOR_MAP.GREY_3, // ditto^

--- a/src/assets/theme/buttons.tsx
+++ b/src/assets/theme/buttons.tsx
@@ -1,5 +1,5 @@
 import { COLOR_MAP } from 'common/colors';
-import fontBlocks from './fontBlocks';
+import { fonts } from 'assets/theme/fonts';
 import { FlattenSimpleInterpolation } from 'styled-components';
 
 export enum ButtonType {
@@ -40,7 +40,7 @@ const buttons: ButtonMap = {
     borderHover: newBlueDark,
     textHover: 'white',
     icon: 'white',
-    fontFamily: fontBlocks.regularBookBold,
+    fontFamily: fonts.regularBookBold,
     disabledBackground: COLOR_MAP.GREY_1,
     disabledText: COLOR_MAP.GRAY_BODY_COPY,
     disabledIcon: COLOR_MAP.GREY_3,
@@ -53,7 +53,7 @@ const buttons: ButtonMap = {
     borderHover: newBlueLight,
     textHover: newBlueDark,
     icon: COLOR_MAP.GRAY_BODY_COPY,
-    fontFamily: fontBlocks.regularBookMidWeight,
+    fontFamily: fonts.regularBookMidWeight,
     disabledBackground: 'white',
     disabledText: COLOR_MAP.GRAY_BODY_COPY,
     disabledIcon: COLOR_MAP.GREY_3,
@@ -66,7 +66,7 @@ const buttons: ButtonMap = {
     borderHover: 'transparent',
     textHover: newBlueDark,
     icon: COLOR_MAP.GRAY_BODY_COPY,
-    fontFamily: fontBlocks.regularBook,
+    fontFamily: fonts.regularBook,
     disabledBackground: COLOR_MAP.GREY_1, // TODO (chelsi) - ask UX about disable state
     disabledText: COLOR_MAP.GRAY_BODY_COPY, // ditto^
     disabledIcon: COLOR_MAP.GREY_3, // ditto^

--- a/src/assets/theme/buttons.tsx
+++ b/src/assets/theme/buttons.tsx
@@ -1,5 +1,5 @@
 import { COLOR_MAP } from 'common/colors';
-import { fonts } from 'assets/theme/fonts';
+import fonts from 'assets/theme/fonts';
 import { FlattenSimpleInterpolation } from 'styled-components';
 
 export enum ButtonType {

--- a/src/assets/theme/fontBlocks.ts
+++ b/src/assets/theme/fontBlocks.ts
@@ -1,6 +1,15 @@
-import { css } from 'styled-components';
+import { css, FlattenSimpleInterpolation } from 'styled-components';
 
-const fonts = {
+export interface FontBlocks {
+  regularBook: FlattenSimpleInterpolation;
+  regularBookMidWeight: FlattenSimpleInterpolation;
+  regularBookBold: FlattenSimpleInterpolation;
+  monospace: FlattenSimpleInterpolation;
+  monospaceMidWeight: FlattenSimpleInterpolation;
+  monospaceBold: FlattenSimpleInterpolation;
+}
+
+const fontBlocks: FontBlocks = {
   regularBook: css`
     font-family: Roboto;
     font-weight: 400;
@@ -27,4 +36,4 @@ const fonts = {
   `,
 };
 
-export default fonts;
+export default fontBlocks;

--- a/src/assets/theme/fonts.ts
+++ b/src/assets/theme/fonts.ts
@@ -9,7 +9,7 @@ export interface ThemeFonts {
   monospaceBold: FlattenSimpleInterpolation;
 }
 
-export const fonts: ThemeFonts = {
+const fonts: ThemeFonts = {
   regularBook: css`
     font-family: Roboto;
     font-weight: 400;
@@ -35,3 +35,5 @@ export const fonts: ThemeFonts = {
     font-weight: 700;
   `,
 };
+
+export default fonts;

--- a/src/assets/theme/fonts.ts
+++ b/src/assets/theme/fonts.ts
@@ -1,6 +1,6 @@
 import { css, FlattenSimpleInterpolation } from 'styled-components';
 
-export interface FontBlocks {
+export interface ThemeFonts {
   regularBook: FlattenSimpleInterpolation;
   regularBookMidWeight: FlattenSimpleInterpolation;
   regularBookBold: FlattenSimpleInterpolation;
@@ -9,7 +9,7 @@ export interface FontBlocks {
   monospaceBold: FlattenSimpleInterpolation;
 }
 
-const fontBlocks: FontBlocks = {
+export const fonts: ThemeFonts = {
   regularBook: css`
     font-family: Roboto;
     font-weight: 400;
@@ -35,5 +35,3 @@ const fontBlocks: FontBlocks = {
     font-weight: 700;
   `,
 };
-
-export default fontBlocks;

--- a/src/assets/theme/index.tsx
+++ b/src/assets/theme/index.tsx
@@ -6,6 +6,7 @@ import overrides from './overrides';
 import { COLOR_MAP } from 'common/colors';
 import { megaMenuFooter } from './customThemeBlocks';
 import buttons, { ButtonMap } from './buttons';
+import fontBlocks, { FontBlocks } from './fontBlocks';
 
 export { megaMenuFooter };
 
@@ -25,6 +26,7 @@ interface ThemeFonts {
   subtitle1: FlattenSimpleInterpolation;
   disclaimer: FlattenSimpleInterpolation;
   link: FlattenSimpleInterpolation;
+  fontBlocks: FontBlocks;
 }
 
 /**
@@ -46,6 +48,7 @@ const fonts: ThemeFonts = {
   link: css`
     color: ${colors.lightBlue};
   `,
+  fontBlocks,
 };
 
 declare module '@material-ui/core/styles/createMuiTheme' {

--- a/src/assets/theme/index.tsx
+++ b/src/assets/theme/index.tsx
@@ -9,6 +9,7 @@ import { fonts, ThemeFonts } from './fonts';
 
 export { megaMenuFooter };
 
+// todo (chelsi) - remove these colors from theme
 interface ThemeColors {
   green: string;
   greenDark: string;

--- a/src/assets/theme/index.tsx
+++ b/src/assets/theme/index.tsx
@@ -5,7 +5,7 @@ import overrides from './overrides';
 import { COLOR_MAP } from 'common/colors';
 import { megaMenuFooter } from './customThemeBlocks';
 import buttons, { ButtonMap } from './buttons';
-import { fonts, ThemeFonts } from './fonts';
+import fonts, { ThemeFonts } from './fonts';
 
 export { megaMenuFooter };
 

--- a/src/assets/theme/index.tsx
+++ b/src/assets/theme/index.tsx
@@ -1,12 +1,11 @@
 import { createMuiTheme } from '@material-ui/core';
-import { css, FlattenSimpleInterpolation } from 'styled-components';
 import palette from './palette';
 import typography from './typography';
 import overrides from './overrides';
 import { COLOR_MAP } from 'common/colors';
 import { megaMenuFooter } from './customThemeBlocks';
 import buttons, { ButtonMap } from './buttons';
-import fontBlocks, { FontBlocks } from './fontBlocks';
+import { fonts, ThemeFonts } from './fonts';
 
 export { megaMenuFooter };
 
@@ -20,35 +19,6 @@ const colors: ThemeColors = {
   green: COLOR_MAP.GREEN.BASE,
   greenDark: COLOR_MAP.GREEN.DARK,
   lightBlue: COLOR_MAP.BLUE,
-};
-
-interface ThemeFonts {
-  subtitle1: FlattenSimpleInterpolation;
-  disclaimer: FlattenSimpleInterpolation;
-  link: FlattenSimpleInterpolation;
-  fontBlocks: FontBlocks;
-}
-
-/**
- * High-level typography groups
- */
-const fonts: ThemeFonts = {
-  subtitle1: css`
-    color: ${COLOR_MAP.GRAY_BODY_COPY};
-    text-transform: uppercase;
-    letter-spacing: 0.01em;
-    font-size: 0.875rem;
-    line-height: 1.125;
-    margin-bottom: 0.75rem;
-  `,
-  disclaimer: css`
-    font-size: 0.875rem;
-    line-height: 1.6;
-  `,
-  link: css`
-    color: ${colors.lightBlue};
-  `,
-  fontBlocks,
 };
 
 declare module '@material-ui/core/styles/createMuiTheme' {

--- a/src/common/theme/index.ts
+++ b/src/common/theme/index.ts
@@ -1,3 +1,0 @@
-import fonts from './fonts';
-
-export { fonts };

--- a/src/components/AppBar/NavBar.style.ts
+++ b/src/components/AppBar/NavBar.style.ts
@@ -63,7 +63,7 @@ export const IconButton = styled(MuiIconButton).attrs(props => ({
   disableRipple: true,
   disableFocusRipple: true,
 }))`
-  ${props => props.theme.fonts.fontBlocks.regularBookMidWeight};
+  ${props => props.theme.fonts.regularBookMidWeight};
   color: black;
   font-size: 1rem;
   line-height: 1.4rem;

--- a/src/components/AppBar/NavBar.style.ts
+++ b/src/components/AppBar/NavBar.style.ts
@@ -9,7 +9,6 @@ import theme from 'assets/theme';
 import palette from 'assets/theme/palette';
 import { COLOR_MAP } from 'common/colors';
 import { materialSMBreakpoint } from 'assets/theme/sizes';
-import { fonts } from 'common/theme';
 
 const desktopNavHeight = 64;
 
@@ -64,7 +63,7 @@ export const IconButton = styled(MuiIconButton).attrs(props => ({
   disableRipple: true,
   disableFocusRipple: true,
 }))`
-  ${fonts.regularBookMidWeight};
+  ${props => props.theme.fonts.fontBlocks.regularBookMidWeight};
   color: black;
   font-size: 1rem;
   line-height: 1.4rem;

--- a/src/components/Compare/ModalFaq.style.tsx
+++ b/src/components/Compare/ModalFaq.style.tsx
@@ -2,7 +2,6 @@ import styled from 'styled-components';
 import { COLOR_MAP } from 'common/colors';
 import { Typography } from '@material-ui/core';
 import MuiCloseIcon from '@material-ui/icons/Close';
-import { fonts } from 'common/theme';
 
 export const Wrapper = styled.div`
   background-color: white;
@@ -40,7 +39,7 @@ export const Header = styled(Typography)`
 `;
 
 export const Subheader = styled(Typography)`
-  ${fonts.monospace};
+  ${props => props.theme.fonts.fontBlocks.monospace};
   font-size: 0.875rem;
   color: ${COLOR_MAP.GRAY.DARK};
   text-transform: uppercase;

--- a/src/components/Compare/ModalFaq.style.tsx
+++ b/src/components/Compare/ModalFaq.style.tsx
@@ -39,7 +39,7 @@ export const Header = styled(Typography)`
 `;
 
 export const Subheader = styled(Typography)`
-  ${props => props.theme.fonts.fontBlocks.monospace};
+  ${props => props.theme.fonts.monospace};
   font-size: 0.875rem;
   color: ${COLOR_MAP.GRAY.DARK};
   text-transform: uppercase;

--- a/src/components/LocationPage/Experiment/GetAlertsButton.style.tsx
+++ b/src/components/LocationPage/Experiment/GetAlertsButton.style.tsx
@@ -36,7 +36,7 @@ export const Column = styled.div`
 `;
 
 export const Subtext = styled.span`
-  ${props => props.theme.fonts.fontBlocks.regularBook};
+  ${props => props.theme.fonts.regularBook};
   color: ${COLOR_MAP.GREY_4};
   text-transform: none;
   line-height: 1.4;

--- a/src/components/LocationPage/Experiment/GetAlertsButton.style.tsx
+++ b/src/components/LocationPage/Experiment/GetAlertsButton.style.tsx
@@ -1,5 +1,4 @@
 import styled from 'styled-components';
-import fonts from 'common/theme/fonts';
 import MuiButton from '@material-ui/core/Button';
 import { COLOR_MAP } from 'common/colors';
 import ArrowForwardIcon from '@material-ui/icons/ArrowForward';
@@ -37,10 +36,10 @@ export const Column = styled.div`
 `;
 
 export const Subtext = styled.span`
+  ${props => props.theme.fonts.fontBlocks.regularBook};
   color: ${COLOR_MAP.GREY_4};
   text-transform: none;
   line-height: 1.4;
-  ${fonts.regularBook};
   text-align: left;
   font-size: 1rem;
   margin-top: 0.25rem;

--- a/src/components/MenuContent/Menu.style.tsx
+++ b/src/components/MenuContent/Menu.style.tsx
@@ -62,7 +62,7 @@ export const Section = styled.div`
 `;
 
 export const SectionHeader = styled.h2<{ $desktopOnly?: boolean }>`
-  ${props => props.theme.fonts.fontBlocks.regularBookMidWeight};
+  ${props => props.theme.fonts.regularBookMidWeight};
   color: ${props => props.theme.palette.megaMenu.gray};
   text-transform: uppercase;
   margin: 0 0 1.25rem;
@@ -92,7 +92,7 @@ export const Row = styled.div`
 `;
 
 export const BodyCopy = css`
-  ${props => props.theme.fonts.fontBlocks.regularBook};
+  ${props => props.theme.fonts.regularBook};
   line-height: 1.4;
   margin: 0;
 `;
@@ -115,7 +115,7 @@ export const AboutCopy = styled.p`
 `;
 
 export const ButtonBase = css`
-  ${props => props.theme.fonts.fontBlocks.regularBookMidWeight};
+  ${props => props.theme.fonts.regularBookMidWeight};
   width: fit-content;
   text-transform: none;
   line-height: 1.4;
@@ -123,7 +123,7 @@ export const ButtonBase = css`
 
 export const TextLink = styled(Link)`
   ${ButtonBase};
-  ${props => props.theme.fonts.fontBlocks.regularBookMidWeight};
+  ${props => props.theme.fonts.regularBookMidWeight};
   color: ${props => props.theme.palette.megaMenu.primaryText};
 
   font-size: 1rem;
@@ -226,5 +226,5 @@ export const LogoWrapper = styled(Link)`
 
 export const NonWrappingSpan = styled.span`
   white-space: nowrap;
-  ${props => props.theme.fonts.fontBlocks.regularBookMidWeight};
+  ${props => props.theme.fonts.regularBookMidWeight};
 `;

--- a/src/components/MenuContent/Menu.style.tsx
+++ b/src/components/MenuContent/Menu.style.tsx
@@ -4,7 +4,6 @@ import { COLOR_MAP } from 'common/colors';
 import { mobileBreakpoint } from 'assets/theme/sizes';
 import ArrowForwardIcon from '@material-ui/icons/ArrowForward';
 import LinkButton from 'components/LinkButton';
-import fonts from 'common/theme/fonts';
 
 export const mobileBreakpointPlus = '960px';
 
@@ -63,7 +62,7 @@ export const Section = styled.div`
 `;
 
 export const SectionHeader = styled.h2<{ $desktopOnly?: boolean }>`
-  ${fonts.regularBookMidWeight};
+  ${props => props.theme.fonts.fontBlocks.regularBookMidWeight};
   color: ${props => props.theme.palette.megaMenu.gray};
   text-transform: uppercase;
   margin: 0 0 1.25rem;
@@ -93,7 +92,7 @@ export const Row = styled.div`
 `;
 
 export const BodyCopy = css`
-  ${fonts.regularBook};
+  ${props => props.theme.fonts.fontBlocks.regularBook};
   line-height: 1.4;
   margin: 0;
 `;
@@ -116,7 +115,7 @@ export const AboutCopy = styled.p`
 `;
 
 export const ButtonBase = css`
-  ${fonts.regularBookMidWeight};
+  ${props => props.theme.fonts.fontBlocks.regularBookMidWeight};
   width: fit-content;
   text-transform: none;
   line-height: 1.4;
@@ -124,8 +123,7 @@ export const ButtonBase = css`
 
 export const TextLink = styled(Link)`
   ${ButtonBase};
-  ${fonts.regularBookMidWeight};
-
+  ${props => props.theme.fonts.fontBlocks.regularBookMidWeight};
   color: ${props => props.theme.palette.megaMenu.primaryText};
 
   font-size: 1rem;
@@ -228,5 +226,5 @@ export const LogoWrapper = styled(Link)`
 
 export const NonWrappingSpan = styled.span`
   white-space: nowrap;
-  ${fonts.regularBookMidWeight};
+  ${props => props.theme.fonts.fontBlocks.regularBookMidWeight};
 `;

--- a/src/components/Typography/Typography.style.ts
+++ b/src/components/Typography/Typography.style.ts
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 import Typography from '@material-ui/core/Typography';
+import { COLOR_MAP } from 'common/colors';
 
 /**
  * Notes:
@@ -29,5 +30,10 @@ import Typography from '@material-ui/core/Typography';
 export const Subtitle1 = styled(Typography).attrs(props => ({
   variant: 'body1',
 }))`
-  ${props => props.theme.fonts.subtitle1};
+  color: ${COLOR_MAP.GRAY_BODY_COPY};
+  text-transform: uppercase;
+  letter-spacing: 0.01em;
+  font-size: 0.875rem;
+  line-height: 1.125;
+  margin-bottom: 0.75rem;
 `;

--- a/src/screens/AlertUnsubscribe/AlertUnsubscribe.style.tsx
+++ b/src/screens/AlertUnsubscribe/AlertUnsubscribe.style.tsx
@@ -1,7 +1,6 @@
 import styled, { css } from 'styled-components';
 import { Typography, Box } from '@material-ui/core';
 import { COLOR_MAP } from 'common/colors';
-import { fonts } from 'common/theme';
 
 export const Wrapper = styled(Box)`
   max-width: 700px;
@@ -20,14 +19,14 @@ export const Wrapper = styled(Box)`
 `;
 
 export const UnsubscribeHeader = styled(Typography)`
-  ${fonts.regularBookBold};
+  ${props => props.theme.fonts.fontBlocks.regularBookBold};
   font-size: 2rem;
   margin-bottom: 2.5rem;
   line-height: 1.2;
 `;
 
 const Button = css`
-  ${fonts.regularBookBold};
+  ${props => props.theme.fonts.fontBlocks.regularBookBold};
   font-size: 0.875rem;
   line-height: 1.1rem;
   text-transform: uppercase;
@@ -67,7 +66,7 @@ export const UnsubscribeButton = styled.button`
 `;
 
 export const BodyCopy = styled(Typography)`
-  ${fonts.regularBook};
+  ${props => props.theme.fonts.fontBlocks.regularBook};
   font-size: 1.1rem;
   margin-bottom: 1.75rem;
   line-height: 1.4;

--- a/src/screens/AlertUnsubscribe/AlertUnsubscribe.style.tsx
+++ b/src/screens/AlertUnsubscribe/AlertUnsubscribe.style.tsx
@@ -19,14 +19,14 @@ export const Wrapper = styled(Box)`
 `;
 
 export const UnsubscribeHeader = styled(Typography)`
-  ${props => props.theme.fonts.fontBlocks.regularBookBold};
+  ${props => props.theme.fonts.regularBookBold};
   font-size: 2rem;
   margin-bottom: 2.5rem;
   line-height: 1.2;
 `;
 
 const Button = css`
-  ${props => props.theme.fonts.fontBlocks.regularBookBold};
+  ${props => props.theme.fonts.regularBookBold};
   font-size: 0.875rem;
   line-height: 1.1rem;
   text-transform: uppercase;
@@ -66,7 +66,7 @@ export const UnsubscribeButton = styled.button`
 `;
 
 export const BodyCopy = styled(Typography)`
-  ${props => props.theme.fonts.fontBlocks.regularBook};
+  ${props => props.theme.fonts.regularBook};
   font-size: 1.1rem;
   margin-bottom: 1.75rem;
   line-height: 1.4;


### PR DESCRIPTION
- Moves font blocks into main theme + updates implementations to call fonts using props instead of directly importing from `fonts.tsx`
- Deletes typography font styles -- 2/3 of them were unused. Moved the one used set (`subtitle1`) into `Typography.style.ts`