### PR TITLE
clean up region classes some

### DIFF
--- a/scripts/prepare_regions_data/prepare-regions-data.ts
+++ b/scripts/prepare_regions_data/prepare-regions-data.ts
@@ -34,7 +34,7 @@ async function main() {
   for (const [destFile, regions] of Object.entries(files)) {
     await fs.writeJson(
       destFile,
-      _.mapValues(regions, r => r.toObject()),
+      _.mapValues(regions, r => r.toJSON()),
     );
   }
 }

--- a/scripts/prepare_regions_data/regions_data.ts
+++ b/scripts/prepare_regions_data/regions_data.ts
@@ -54,7 +54,7 @@ function buildCounties(
       countyInfo.county_url_name,
       countyFips,
       countyInfo.population,
-      state,
+      state.fipsCode,
       adjacentCounties || [],
     );
   });
@@ -83,8 +83,8 @@ function buildMetroAreas(
       metro.urlSegment,
       metro.cbsaCode,
       metro.population,
-      counties,
-      states,
+      counties.map(county => county.fipsCode),
+      states.map(state => state.fipsCode),
     );
   });
 }

--- a/scripts/prepare_regions_data/regions_data.ts
+++ b/scripts/prepare_regions_data/regions_data.ts
@@ -83,8 +83,8 @@ function buildMetroAreas(
       metro.urlSegment,
       metro.cbsaCode,
       metro.population,
-      counties.map(county => county.fipsCode),
       states.map(state => state.fipsCode),
+      counties.map(county => county.fipsCode),
     );
   });
 }

--- a/src/common/regions/preprocessed_regions_data.ts
+++ b/src/common/regions/preprocessed_regions_data.ts
@@ -2,37 +2,34 @@ import keyBy from 'lodash/keyBy';
 import values from 'lodash/values';
 import mapValues from 'lodash/mapValues';
 
-import statesByFipsJson from 'common/data/states_by_fips.json';
 import countiesByFipsJson from 'common/data/counties_by_fips.json';
 import metroAreasByFipsJson from 'common/data/metro_areas_by_fips.json';
 
 import {
+  statesByFips,
   State,
-  StateObject,
   County,
   CountyObject,
   MetroArea,
   MetroAreaObject,
 } from './types';
 
-export const statesByFips = mapValues(
-  statesByFipsJson as { [fips: string]: StateObject },
-  v => State.fromObject(v),
-);
-
 export const countiesByFips = mapValues(
   countiesByFipsJson as { [fips: string]: CountyObject },
   v => {
-    return County.fromObject(v, statesByFips);
+    return County.fromJSON(v);
   },
 );
 
 export const metroAreasByFips = mapValues(
   metroAreasByFipsJson as { [fips: string]: MetroAreaObject },
   v => {
-    return MetroArea.fromObject(v, statesByFips, countiesByFips);
+    return MetroArea.fromJSON(v);
   },
 );
+
+// re-export so others can import from the same place?
+export { statesByFips };
 
 export const statesByStateCode = keyBy(
   values(statesByFips),

--- a/src/common/regions/types.ts
+++ b/src/common/regions/types.ts
@@ -276,12 +276,12 @@ export class MetroArea extends Region {
       u: this.urlSegment,
       f: this.fipsCode,
       p: this.population,
-      c: this.countiesFips,
       s: this.states.map(state => state.fipsCode),
+      c: this.countiesFips,
     };
   }
 
   public static fromJSON(obj: MetroAreaObject): MetroArea {
-    return new MetroArea(obj.n, obj.u, obj.f, obj.p, obj.c, obj.s);
+    return new MetroArea(obj.n, obj.u, obj.f, obj.p, obj.s, obj.c);
   }
 }

--- a/src/common/regions/types.ts
+++ b/src/common/regions/types.ts
@@ -225,7 +225,14 @@ export class MetroArea extends Region {
     urlSegment: string,
     fipsCode: FipsCode,
     population: number,
+    // MetroAreas are constructed by FIPS for states, but the states are retrieved
+    // and stored as objects
     statesFips: FipsCode[],
+    // We intentionally only store counties by FIPS code instead of rich objects
+    // so we can construct MetroArea objects without loading the entire counties DB.
+    // This will be very useful for rendering things above the fold on location pages
+    // and deferred loading the big data for charts down below.
+    // If you need the county object, you  can look it up by FIPS from the regions_db.
     public readonly countiesFips: FipsCode[],
   ) {
     super(name, urlSegment, fipsCode, population, RegionType.MSA);

--- a/src/common/regions/types.ts
+++ b/src/common/regions/types.ts
@@ -25,11 +25,6 @@ const fipsToPrincipalCityRenames: FipsToPrincipalCityName = {
   [NY_METRO_FIPS]: 'New York City',
 };
 
-export const statesByFips = mapValues(
-  statesByFipsJson as { [fips: string]: StateObject },
-  v => State.fromJSON(v),
-);
-
 // JSON-serializable representation of a Region object
 export interface RegionObject {
   n: string;
@@ -124,6 +119,17 @@ export class State extends Region {
     return new State(obj.n, obj.u, obj.f, obj.p, obj.s);
   }
 }
+
+/**
+ * Construct this mapping here, so we can reference it to simplify reconstitution
+ * of County and MetroArea objects.  The overall size for ~50 states is quite small,
+ * so it's not worth trying to pull out of the main bundle, and having the lookup
+ * available is quite handy.
+ */
+export const statesByFips = mapValues(
+  statesByFipsJson as { [fips: string]: StateObject },
+  v => State.fromJSON(v),
+);
 
 /**
  * Shortens the county name by using the abbreviated version of 'county'

--- a/src/common/regions/utils.ts
+++ b/src/common/regions/utils.ts
@@ -110,7 +110,7 @@ export function getAutocompleteRegions(region?: Region): Region[] {
   // Location pages
   if (region instanceof MetroArea) {
     const [countiesInMetro, otherCounties] = partition(counties, county =>
-      region.counties.includes(county),
+      region.countiesFips.includes(county.fipsCode),
     );
     const sortedMetroCounties = sortByPopulation(countiesInMetro);
 
@@ -172,7 +172,7 @@ export function getMetroRegionFromZipCode(
 ): Region | undefined {
   const countyFromZip = getCountyRegionFromZipCode(zipCode, countyToZipMap);
   const metroFromZip = find(regions.metroAreas, (region: MetroArea) =>
-    region.counties.includes(countyFromZip as County),
+    region.countiesFips.includes((countyFromZip as County).fipsCode),
   );
   return metroFromZip;
 }

--- a/src/common/utils/compare.ts
+++ b/src/common/utils/compare.ts
@@ -53,7 +53,9 @@ export function getAllMetroAreas(): SummaryForCompare[] {
 export function getAllCountiesOfMetroArea(
   region: MetroArea,
 ): SummaryForCompare[] {
-  return region.counties.map(getLocationObj);
+  return region.countiesFips
+    .map(fips => regions.findByFipsCodeStrict(fips))
+    .map(getLocationObj);
 }
 
 export function getAllCountiesOfState(stateCode: string): SummaryForCompare[] {

--- a/src/components/RegionMap/RegionMap.tsx
+++ b/src/components/RegionMap/RegionMap.tsx
@@ -189,7 +189,7 @@ function buildCountyGeometries(
 
 function getCountyFipsList(region: Region): string[] {
   if (region instanceof MetroArea) {
-    return region.counties.map(c => c.fipsCode);
+    return region.countiesFips;
   } else if (region instanceof State) {
     return regions.counties
       .filter(c => c.state.fipsCode === region.fipsCode)

--- a/src/components/RegionVaccinationBlock/utils.ts
+++ b/src/components/RegionVaccinationBlock/utils.ts
@@ -19,7 +19,7 @@ export const getVaccinationRegions = (region: Region): Region[] => {
   if (region instanceof County) {
     const county = region as County;
     const metro = regions.metroAreas.find(metro =>
-      metro.counties.map(county => county.fipsCode).includes(county.fipsCode),
+      metro.countiesFips.includes(county.fipsCode),
     );
     if (metro) {
       return [county, metro, region.state];

--- a/src/components/Search/utils.ts
+++ b/src/components/Search/utils.ts
@@ -33,7 +33,7 @@ export function getFilterLimit(region?: Region) {
   }
 
   if (region instanceof MetroArea) {
-    return Math.max(20, region.counties.length);
+    return Math.max(20, region.countiesFips.length);
   } else if (region instanceof State || region instanceof County) {
     const stateFips = getStateFips(region);
     const countiesInState = regions.counties.filter(county =>


### PR DESCRIPTION
This embeds the `statesByFips` lookup so that we can construct counties and metroareas that reference states directly from the FIPS that we store, making toJSON and fromJSON possible with no additional parameters.  To make this work, `statesByFips` must be constructed in the `regions/types.ts` package, to void a circular dependency.  I was worried this would smell too bad to actually use, but after trying it, it wasn't as bad as I thought.

To unlock this, metroAreas must not refer directly to county objects, so this diff stores countyFips directly instead.  In all cases but one this actually simplified things, since we were mapping across counties to get the FIPS code.  In the one case it didn't, we already imported the regions DB so a lookup was straightforward.

While doing this I thought of another optimization, which might be a bridge too far or not worth it, but I may explore it a bit if it turns out to be easy -- the `urlsSegments` for counties and states derive directly from their names.  So if I can construct a simple function that matches the one used to generate them, we can regenerate them when constructing the region rather than storing the data.  I guess step one in that exploration would be exporting w/o urlsegments to see how much space would actually base saved.

Anyway, this PR isn't essential, but it illustrates what I was trying to describe to @mikelehen and figured I'd put it up.  If we decide to merge it, then great, if not, NBD.