### PR TITLE
hide the last x-axis label if the date is beyond the chart range

### DIFF
--- a/src/components/Explore/Axes.tsx
+++ b/src/components/Explore/Axes.tsx
@@ -37,7 +37,7 @@ const Axes: React.FC<{
         top={height}
         scale={dateScale}
         tickValues={finalTickValues}
-        tickFormat={(date: Date) => getXTickFormat(date)}
+        tickFormat={(date: Date) => (date < dateTo ? getXTickFormat(date) : '')}
       />
     </AxisStyle>
   );

--- a/src/components/Explore/Axes.tsx
+++ b/src/components/Explore/Axes.tsx
@@ -28,7 +28,9 @@ const Axes: React.FC<{
   const [dateFrom, dateTo] = dateScale.domain();
   const timeTicks = getTimeAxisTicks(dateFrom, dateTo);
 
-  const finalTickValues = getFinalTicks(isMobile, timeTicks);
+  const finalTickValues = getFinalTicks(isMobile, timeTicks).filter(
+    date => date < dateTo,
+  );
 
   return (
     <AxisStyle>
@@ -37,7 +39,7 @@ const Axes: React.FC<{
         top={height}
         scale={dateScale}
         tickValues={finalTickValues}
-        tickFormat={(date: Date) => (date < dateTo ? getXTickFormat(date) : '')}
+        tickFormat={(date: Date) => getXTickFormat(date)}
       />
     </AxisStyle>
   );


### PR DESCRIPTION
[Trello](https://trello.com/c/u4gUsEyf/1232-explore-chart-hide-the-last-tick-mark-if-its-outside-the-charting-area) - Hide the last x-axis label if the date is outside the chart range

**Before**

![image](https://user-images.githubusercontent.com/114084/114082137-419da700-9862-11eb-8983-b083c29f3526.png)


**After**

![image](https://user-images.githubusercontent.com/114084/114082057-2df24080-9862-11eb-8eb4-67b39bc10155.png)
