### PR TITLE
Remove finally() usage that breaks Firefox 59.2

### DIFF
--- a/src/common/hooks/useGeolocation.ts
+++ b/src/common/hooks/useGeolocation.ts
@@ -29,15 +29,18 @@ export default function useGeolocation(): UseGeolocationReturn {
     const fetchIpData = () => {
       setIsLoading(true);
       fetchGeolocationData()
-        .then(data =>
+        .then(data => {
           setIpData({
             zipCode: data.zip,
             stateCode: data.region,
             country: data.country,
-          }),
-        )
-        .catch(e => console.error(e))
-        .finally(() => setIsLoading(false));
+          });
+          setIsLoading(false);
+        })
+        .catch(e => {
+          console.error(e);
+          setIsLoading(false);
+        });
     };
     fetchIpData();
   }, [setIpData, setIsLoading]);


### PR DESCRIPTION
Alternative option would be to install a polyfill like https://www.npmjs.com/package/promise.prototype.finally which is more future-proof but so far we don't have a precedent of using polyfills.