### PR TITLE
Make eslint fail on warnings.

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "cy.run": "cypress run",
     "jest": "TZ=America/Los_Angeles react-scripts test",
     "jest.ci": "CI=true yarn jest",
-    "lint": "eslint --ext .js,.ts,tsx src",
+    "lint": "eslint --ext .js,.ts,tsx src --max-warnings=0",
     "lint-fix": "eslint --ext .js,.ts,tsx --fix src",
     "tsc": "tsc",
     "tsc-watch": "tsc --watch",


### PR DESCRIPTION
Sometimes we accidentally check in unused variables and it breaks our staging / prod deploys (e.g. https://github.com/covid-projections/covid-projections/actions/runs/731082728) even though CI doesn't complain.  This should fix that.  May want to do the same for the climate repo.

