### PR TITLE
add getRegionsDB and useRegionsDB utilities

### DIFF
--- a/src/common/regions/region_db.ts
+++ b/src/common/regions/region_db.ts
@@ -12,7 +12,7 @@ import {
 } from './preprocessed_regions_data';
 import { assert } from 'common/utils';
 
-class RegionDB {
+export class RegionDB {
   public states: State[];
   public counties: County[];
   public metroAreas: MetroArea[];
@@ -148,5 +148,11 @@ const regions = new RegionDB(
   statesByStateCode,
 );
 
+/**
+ * Async helper for decoupling regions DB incrementally
+ */
+export const getRegionsDB = async () => {
+  return regions;
+};
+
 export default regions;
-export { RegionDB };

--- a/src/common/regions/region_hooks.ts
+++ b/src/common/regions/region_hooks.ts
@@ -1,10 +1,18 @@
+import { useState, useEffect } from 'react';
 import { useParams } from 'react-router';
-import regions from './region_db';
+import regions, { getRegionsDB, RegionDB } from './region_db';
 import { Region } from './types';
 
-// We are careful to never call `useRegion()` in components that are not
-// nested inside `<RegionContext.Provider>` so we cheat and pretend that the
-// value is non-nullable
+export const useRegionsDB = () => {
+  const [regions, setRegions] = useState<RegionDB | null>(null);
+  useEffect(() => {
+    const load = async () => {
+      setRegions(await getRegionsDB());
+    };
+    load();
+  }, []);
+  return regions;
+};
 
 export const useRegionFromParams = (): Region | null => {
   const {


### PR DESCRIPTION
These unblock a bunch other changes to defer loading the regions DB at build time.  This diff itself should not affect performance, as the functions aren't called anywhere yet.