### PR TITLE
remove region DB load from vaccines phases test

### DIFF
--- a/src/cms-content/vaccines/phases.test.ts
+++ b/src/cms-content/vaccines/phases.test.ts
@@ -1,9 +1,11 @@
 import sortBy from 'lodash/sortBy';
-import regions from 'common/regions';
+import values from 'lodash/values';
+
+import { statesByFips } from 'common/regions';
 import { getVaccineInfoByFips, verifyOneItemPerState } from './phases';
 
-describe('vaccination info is complete for each state', () => {
-  const states = sortBy(regions.states, state => state.fullName);
+describe('vaccination info is complete for each state', async () => {
+  const states = sortBy(values(statesByFips), state => state.fullName);
 
   for (const state of states) {
     const { fipsCode } = state;

--- a/src/cms-content/vaccines/phases.test.ts
+++ b/src/cms-content/vaccines/phases.test.ts
@@ -4,7 +4,7 @@ import values from 'lodash/values';
 import { statesByFips } from 'common/regions';
 import { getVaccineInfoByFips, verifyOneItemPerState } from './phases';
 
-describe('vaccination info is complete for each state', async () => {
+describe('vaccination info is complete for each state', () => {
   const states = sortBy(values(statesByFips), state => state.fullName);
 
   for (const state of states) {


### PR DESCRIPTION
We have a `stateByFips` lookup we can use now instead.