### PR TITLE
Make snapshot useEffect dependency to avoid continual fetching

### DIFF
--- a/src/common/location_summaries.ts
+++ b/src/common/location_summaries.ts
@@ -47,9 +47,9 @@ export async function fetchSummaries(snapshotNumber: number) {
 export function useSummaries(): SummariesMap | null {
   const [summaries, setSummaries] = useState<SummariesMap | null>(null);
 
-  const snapshot = getSnapshotOverride() || currentSnapshot();
   useEffect(() => {
     async function fetch() {
+      const snapshot = getSnapshotOverride() || currentSnapshot();
       let summaries;
       try {
         summaries = await fetchSummaries(snapshot);
@@ -62,7 +62,7 @@ export function useSummaries(): SummariesMap | null {
       setSummaries(summaries);
     }
     fetch();
-  }, [snapshot]);
+  }, []);
 
   return summaries;
 }

--- a/src/common/location_summaries.ts
+++ b/src/common/location_summaries.ts
@@ -47,9 +47,9 @@ export async function fetchSummaries(snapshotNumber: number) {
 export function useSummaries(): SummariesMap | null {
   const [summaries, setSummaries] = useState<SummariesMap | null>(null);
 
+  const snapshot = getSnapshotOverride() || currentSnapshot();
   useEffect(() => {
     async function fetch() {
-      const snapshot = getSnapshotOverride() || currentSnapshot();
       let summaries;
       try {
         summaries = await fetchSummaries(snapshot);
@@ -62,7 +62,7 @@ export function useSummaries(): SummariesMap | null {
       setSummaries(summaries);
     }
     fetch();
-  });
+  }, [snapshot]);
 
   return summaries;
 }


### PR DESCRIPTION
This re-fetches the snapshot every time.  We didn't notice when it was using the version provided by the bundle, but it's evident when using an override.

Setting the dependency to snapshot version should prevent re-fetching and object identity-based state update.