### PR TITLE
New risk thermometers

### DIFF
--- a/src/components/NewLocationPage/RiskThermometer/DesktopThermometer.stories.tsx
+++ b/src/components/NewLocationPage/RiskThermometer/DesktopThermometer.stories.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import DesktopThermometer from './DesktopThermometer';
+import { Level } from 'common/level';
+
+export default {
+  title: 'Location page redesign/Desktop thermometer',
+  component: DesktopThermometer,
+};
+
+export const LevelKnown = () => {
+  return <DesktopThermometer currentLevel={Level.LOW} />;
+};
+
+export const LevelUnknown = () => {
+  return <DesktopThermometer currentLevel={Level.UNKNOWN} />;
+};

--- a/src/components/NewLocationPage/RiskThermometer/DesktopThermometer.tsx
+++ b/src/components/NewLocationPage/RiskThermometer/DesktopThermometer.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { Level } from 'common/level';
+import { DesktopThermometer as Thermometer } from './RiskThermometer.style';
+
+const DesktopThermometer: React.FC<{ currentLevel: Level }> = ({
+  currentLevel,
+}) => {
+  const levelUnknown = currentLevel === Level.UNKNOWN;
+  const imageDescription = `Thermometer image showing the colors corresponding to Covid Act Now's COVID risk levels`;
+
+  return (
+    <Thermometer
+      $levelUnknown={levelUnknown}
+      role="img"
+      aria-label={imageDescription}
+    />
+  );
+};
+
+export default DesktopThermometer;

--- a/src/components/NewLocationPage/RiskThermometer/MobileThermometer.stories.tsx
+++ b/src/components/NewLocationPage/RiskThermometer/MobileThermometer.stories.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import MobileThermometer from './MobileThermometer';
+import { Level } from 'common/level';
+
+export default {
+  title: 'Location page redesign/Mobile thermometer',
+  component: MobileThermometer,
+};
+
+export const Low = () => {
+  return <MobileThermometer currentLevel={Level.LOW} locationName="New York" />;
+};
+
+export const Medium = () => {
+  return (
+    <MobileThermometer currentLevel={Level.MEDIUM} locationName="New York" />
+  );
+};
+
+export const SuperCritical = () => {
+  return (
+    <MobileThermometer
+      currentLevel={Level.SUPER_CRITICAL}
+      locationName="New York"
+    />
+  );
+};
+
+export const Unknown = () => {
+  return (
+    <MobileThermometer currentLevel={Level.UNKNOWN} locationName="New York" />
+  );
+};

--- a/src/components/NewLocationPage/RiskThermometer/MobileThermometer.tsx
+++ b/src/components/NewLocationPage/RiskThermometer/MobileThermometer.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { Level } from 'common/level';
+import { LEVEL_COLOR } from 'common/colors';
+import { LOCATION_SUMMARY_LEVELS } from 'common/metrics/location_summary';
+import {
+  ColorBlock,
+  MobileThermometerContainer,
+} from './RiskThermometer.style';
+
+const orderedLevels: Level[] = [
+  Level.LOW,
+  Level.MEDIUM,
+  Level.HIGH,
+  Level.CRITICAL,
+  Level.SUPER_CRITICAL,
+];
+
+const MobileThermometer: React.FC<{
+  currentLevel: Level;
+  locationName: string;
+}> = ({ currentLevel, locationName }) => {
+  const levelUnknown = currentLevel === Level.UNKNOWN;
+  const levelName = LOCATION_SUMMARY_LEVELS[currentLevel].name;
+  const imageDescription = `Thermometer image showing that ${locationName}'s COVID risk level is ${levelName}.`;
+
+  return (
+    <MobileThermometerContainer role="img" aria-label={imageDescription}>
+      {orderedLevels.map((level: Level) => (
+        <ColorBlock
+          key={level}
+          color={LEVEL_COLOR[level]}
+          $levelUnknown={levelUnknown}
+          $isCurrentLevel={level === currentLevel}
+        />
+      ))}
+    </MobileThermometerContainer>
+  );
+};
+
+export default MobileThermometer;

--- a/src/components/NewLocationPage/RiskThermometer/RiskThermometer.style.tsx
+++ b/src/components/NewLocationPage/RiskThermometer/RiskThermometer.style.tsx
@@ -18,10 +18,11 @@ export const ColorBlock = styled.div<{
   align-self: center;
   background: ${({ color, $levelUnknown }) =>
     $levelUnknown ? LEVEL_COLOR[Level.UNKNOWN] : color};
-  border: ${({ $isCurrentLevel }) => $isCurrentLevel && `4px solid black`};
+  border: ${({ $isCurrentLevel }) => $isCurrentLevel && `3px solid black`};
   border-radius: ${({ $isCurrentLevel }) => ($isCurrentLevel ? '1px' : '0')};
   height: ${({ $isCurrentLevel }) => ($isCurrentLevel ? '20px' : '16px')};
-  width: 100%;
+  width: ${({ $isCurrentLevel }) =>
+    $isCurrentLevel ? 'calc(100% - 6px)' : '100%'};
 
   &:first-child {
     border-radius: 99px 0 0 99px;

--- a/src/components/NewLocationPage/RiskThermometer/RiskThermometer.style.tsx
+++ b/src/components/NewLocationPage/RiskThermometer/RiskThermometer.style.tsx
@@ -1,0 +1,59 @@
+import styled, { css } from 'styled-components';
+import { Level } from 'common/level';
+import { LEVEL_COLOR } from 'common/colors';
+
+// Mobile:
+export const MobileThermometerContainer = styled.div`
+  display: flex;
+  width: 160px;
+`;
+
+export const ColorBlock = styled.div<{
+  color: string;
+  $isCurrentLevel?: boolean;
+  $levelUnknown?: boolean;
+}>`
+  display: flex;
+  align-self: center;
+  background: ${({ color, $levelUnknown }) =>
+    $levelUnknown ? LEVEL_COLOR[Level.UNKNOWN] : color};
+  border: ${({ $isCurrentLevel }) => $isCurrentLevel && `4px solid black`};
+  border-radius: ${({ $isCurrentLevel }) => ($isCurrentLevel ? '1px' : '0')};
+  height: ${({ $isCurrentLevel }) => ($isCurrentLevel ? '20px' : '16px')};
+  width: 100%;
+
+  &:first-child {
+    border-radius: 99px 0 0 99px;
+  }
+
+  &:last-child {
+    border-radius: 0 99px 99px 0;
+  }
+`;
+
+// Desktop:
+const GradientBackground = css`
+  background: linear-gradient(
+    ${LEVEL_COLOR[Level.LOW]} 20%,
+    ${LEVEL_COLOR[Level.MEDIUM]} 20%,
+    ${LEVEL_COLOR[Level.MEDIUM]} 40%,
+    ${LEVEL_COLOR[Level.HIGH]} 40%,
+    ${LEVEL_COLOR[Level.HIGH]} 60%,
+    ${LEVEL_COLOR[Level.CRITICAL]} 60%,
+    ${LEVEL_COLOR[Level.CRITICAL]} 80%,
+    ${LEVEL_COLOR[Level.SUPER_CRITICAL]} 80%,
+    ${LEVEL_COLOR[Level.SUPER_CRITICAL]} 100%
+  );
+`;
+
+const UnknownBackground = css`
+  background: ${LEVEL_COLOR[Level.UNKNOWN]};
+`;
+
+export const DesktopThermometer = styled.div<{ $levelUnknown?: boolean }>`
+  height: 60px;
+  width: 12px;
+  border-radius: 99px;
+  ${({ $levelUnknown }) =>
+    $levelUnknown ? UnknownBackground : GradientBackground};
+`;

--- a/src/components/NewLocationPage/RiskThermometer/RiskThermometer.style.tsx
+++ b/src/components/NewLocationPage/RiskThermometer/RiskThermometer.style.tsx
@@ -5,7 +5,8 @@ import { LEVEL_COLOR } from 'common/colors';
 // Mobile:
 export const MobileThermometerContainer = styled.div`
   display: flex;
-  width: 160px;
+  max-width: 160px;
+  width: 100%;
 `;
 
 export const ColorBlock = styled.div<{

--- a/src/components/NewLocationPage/RiskThermometer/RiskThermometer.style.tsx
+++ b/src/components/NewLocationPage/RiskThermometer/RiskThermometer.style.tsx
@@ -34,15 +34,15 @@ export const ColorBlock = styled.div<{
 // Desktop:
 const GradientBackground = css`
   background: linear-gradient(
-    ${LEVEL_COLOR[Level.LOW]} 20%,
-    ${LEVEL_COLOR[Level.MEDIUM]} 20%,
-    ${LEVEL_COLOR[Level.MEDIUM]} 40%,
+    ${LEVEL_COLOR[Level.SUPER_CRITICAL]} 20%,
+    ${LEVEL_COLOR[Level.CRITICAL]} 20%,
+    ${LEVEL_COLOR[Level.CRITICAL]} 40%,
     ${LEVEL_COLOR[Level.HIGH]} 40%,
     ${LEVEL_COLOR[Level.HIGH]} 60%,
-    ${LEVEL_COLOR[Level.CRITICAL]} 60%,
-    ${LEVEL_COLOR[Level.CRITICAL]} 80%,
-    ${LEVEL_COLOR[Level.SUPER_CRITICAL]} 80%,
-    ${LEVEL_COLOR[Level.SUPER_CRITICAL]} 100%
+    ${LEVEL_COLOR[Level.MEDIUM]} 60%,
+    ${LEVEL_COLOR[Level.MEDIUM]} 80%,
+    ${LEVEL_COLOR[Level.LOW]} 80%,
+    ${LEVEL_COLOR[Level.LOW]} 100%
   );
 `;
 


### PR DESCRIPTION
[Location page redesign figma](https://www.figma.com/file/JGqemgZwlG9e5DQbZpdKgy/Redesign?node-id=1742%3A120358)
Keeps desktop + mobile separate. Desktop is just a single vertical div, mobile is horizontal and outlines the current risk level's color
(storybook only)