### PR TITLE
Fix bug on TextAndIconWithSpecialWrapping

### DIFF
--- a/src/components/MenuContent/LearnSection.tsx
+++ b/src/components/MenuContent/LearnSection.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { LinkItem } from 'cms-content/footer';
-import TextAndIconWithSpecialWrapping from './TextAndIconWithSpecialWrapping';
+import TextAndIconWithSpecialWrapping from 'components/TextAndIconWithSpecialWrapping/TextAndIconWithSpecialWrapping';
 import {
   Section,
   Column,

--- a/src/components/MenuContent/Menu.style.tsx
+++ b/src/components/MenuContent/Menu.style.tsx
@@ -222,8 +222,3 @@ export const LogoWrapper = styled(Link)`
     margin: 0 0 1.25rem;
   }
 `;
-
-export const NonWrappingSpan = styled.span`
-  white-space: nowrap;
-  ${props => props.theme.fonts.regularBookMidWeight};
-`;

--- a/src/components/MenuContent/index.ts
+++ b/src/components/MenuContent/index.ts
@@ -1,5 +1,3 @@
 import MenuContent from './MenuContent';
-import TextAndIconWithSpecialWrapping from './TextAndIconWithSpecialWrapping';
 
-export { TextAndIconWithSpecialWrapping };
 export default MenuContent;

--- a/src/components/NewLocationPage/Shared/LabelWithChevron.tsx
+++ b/src/components/NewLocationPage/Shared/LabelWithChevron.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Chevron } from './Shared.style';
-import { TextAndIconWithSpecialWrapping } from 'components/MenuContent';
+import TextAndIconWithSpecialWrapping from 'components/TextAndIconWithSpecialWrapping/TextAndIconWithSpecialWrapping';
 
 const LabelWithChevron: React.FC<{ text: string }> = ({ text }) => {
   return <TextAndIconWithSpecialWrapping text={text} icon={<Chevron />} />;

--- a/src/components/TextAndIconWithSpecialWrapping/TextAndIconWithSpecialWrapping.tsx
+++ b/src/components/TextAndIconWithSpecialWrapping/TextAndIconWithSpecialWrapping.tsx
@@ -13,7 +13,12 @@
  */
 
 import React from 'react';
-import { NonWrappingSpan } from './Menu.style';
+import styled from 'styled-components';
+
+const SpanWithWrappingRule = styled.span<{ nonWrapping?: boolean }>`
+  ${props => props.theme.fonts.regularBookMidWeight};
+  white-space: ${({ nonWrapping }) => nonWrapping && 'nowrap'};
+`;
 
 const TextAndIconWithSpecialWrapping: React.FC<{ text: string; icon: any }> = ({
   text,
@@ -25,11 +30,11 @@ const TextAndIconWithSpecialWrapping: React.FC<{ text: string; icon: any }> = ({
 
   return (
     <>
-      <span>{reversedRest} </span>
-      <NonWrappingSpan>
+      <SpanWithWrappingRule>{reversedRest} </SpanWithWrappingRule>
+      <SpanWithWrappingRule nonWrapping>
         {first}
         {icon}
-      </NonWrappingSpan>
+      </SpanWithWrappingRule>
     </>
   );
 };


### PR DESCRIPTION
the correct font weight wasnt being applied to both spans. this fixes + moves the component out of the `MenuContent` folder, since it is now being used outside of the menu