### PR TITLE
Correct dom validation issue in location page header

### DIFF
--- a/src/components/LocationPage/LocationPageHeader.style.tsx
+++ b/src/components/LocationPage/LocationPageHeader.style.tsx
@@ -294,7 +294,9 @@ export const SectionColumn = styled(Box)<{ $isUpdateCopy?: boolean }>`
   }
 `;
 
+// inline-block to allow the tooltip following to appear on the same line
 export const ColumnTitle = styled(Typography)<{ $isUpdateCopy?: boolean }>`
+  display: inline-block;
   font-family: Roboto;
   font-size: ${({ $isUpdateCopy }) => ($isUpdateCopy ? '13px' : '12px')};
   text-transform: uppercase;

--- a/src/components/LocationPage/LocationPageHeader.tsx
+++ b/src/components/LocationPage/LocationPageHeader.tsx
@@ -120,7 +120,10 @@ const LocationPageHeader = (props: {
             <SectionHalf>
               <ThermometerImage currentLevel={alarmLevel} />
               <SectionColumn>
-                <ColumnTitle>Covid risk level {tooltip}</ColumnTitle>
+                <div>
+                  <ColumnTitle>Covid risk level</ColumnTitle>
+                  {tooltip}
+                </div>
                 <LevelDescription>{levelInfo.summary}</LevelDescription>
                 <Copy>
                   {levelInfo.detail(


### PR DESCRIPTION
The tooltip div in the header was inside a `<p>`, which is a no-no.  The fix is to move it outside the `<p>`, and change the style to `inline-block` so that it remains on the same line, instead of automatically being put on the next one.

Before: 
![image](https://user-images.githubusercontent.com/351548/115648786-eb594b00-a2da-11eb-9f4e-71325278396d.png)

After:
![image](https://user-images.githubusercontent.com/351548/115648816-fa3ffd80-a2da-11eb-890b-1df77937211e.png)

