### PR TITLE
move key on chart holder

### DIFF
--- a/src/components/LocationPage/ChartsHolder.tsx
+++ b/src/components/LocationPage/ChartsHolder.tsx
@@ -181,12 +181,11 @@ const ChartsHolder = ({ region, chartId }: ChartsHolderProps) => {
             />
           )}
           {ALL_METRICS.map(metric => (
-            <ErrorBoundary>
+            <ErrorBoundary key={metric}>
               {!projections ? (
                 <LoadingScreen />
               ) : (
                 <ChartBlock
-                  key={metric}
                   metric={metric}
                   projections={projections}
                   chartRef={metricRefs[metric]}


### PR DESCRIPTION
This eliminates a react "key" warning.