### PR TITLE
Fix "days ago" display on chart

### DIFF
--- a/src/components/Explore/DateMarker.tsx
+++ b/src/components/Explore/DateMarker.tsx
@@ -5,6 +5,11 @@ import { Series } from './interfaces';
 import { findPointByDate } from 'components/Explore/utils';
 import { getColumnDate } from 'components/Charts/utils';
 
+/**
+ * DateMarker uses findPointByDate function in the same manner as SingleLocationToolTip.
+ * This ensures that the delta between today and the date shown on hover ("x days ago")
+ * corresponds to the date shown in the tooltip (e.g. "Apr 1, 2021").
+ */
 const DateMarker: React.FC<{
   left: number;
   seriesList: Series[];

--- a/src/components/Explore/DateMarker.tsx
+++ b/src/components/Explore/DateMarker.tsx
@@ -1,12 +1,23 @@
 import React from 'react';
 import * as Styles from './Explore.style';
 import { weeksAgo } from './utils';
+import { Series } from './interfaces';
+import { findPointByDate } from 'components/Explore/utils';
+import { getColumnDate } from 'components/Charts/utils';
 
-const DateMarker: React.FC<{ left: number; date: Date }> = ({ left, date }) => {
+const DateMarker: React.FC<{
+  left: number;
+  seriesList: Series[];
+  date: Date;
+}> = ({ left, seriesList, date }) => {
+  const [, seriesSmooth] = seriesList;
+  const pointSmooth = findPointByDate(seriesSmooth.data, date);
+  const dateToCompareTo = pointSmooth ? getColumnDate(pointSmooth) : date;
   const today = new Date();
-  return today < date ? null : (
+  today.setHours(0, 0, 0, 0);
+  return today < dateToCompareTo ? null : (
     <Styles.DateMarker style={{ left }}>
-      {weeksAgo(date, today)}
+      {weeksAgo(dateToCompareTo, today)}
     </Styles.DateMarker>
   );
 };

--- a/src/components/Explore/MultipleLocationsChart.tsx
+++ b/src/components/Explore/MultipleLocationsChart.tsx
@@ -250,6 +250,7 @@ const MultipleLocationsChart: React.FC<{
           />
           <DateMarker
             left={getXPosition(tooltipData) + marginLeft}
+            seriesList={seriesList}
             date={new Date(tooltipData.x)}
           />
         </Fragment>

--- a/src/components/Explore/SingleLocationChart.tsx
+++ b/src/components/Explore/SingleLocationChart.tsx
@@ -216,6 +216,7 @@ const SingleLocationChart: React.FC<{
           />
           <DateMarker
             left={dateScale(tooltipData.date) + marginLeft}
+            seriesList={seriesList}
             date={tooltipData.date}
           />
         </Fragment>


### PR DESCRIPTION
This PR sets midnight as the baseline for date comparison. This is a WIP as I am still testing it further.