### PR TITLE
New overall risk block

### DIFF
--- a/src/components/InfoTooltip/Tooltip.style.tsx
+++ b/src/components/InfoTooltip/Tooltip.style.tsx
@@ -79,6 +79,13 @@ export const StyledMarkdown = styled(MarkdownBody)`
     margin: 0;
   }
 
+  a {
+    text-decoration: underline;
+    &:hover {
+      color: white;
+    }
+  }
+
   ul {
     margin-bottom: 0.5rem;
     a {

--- a/src/components/InfoTooltip/index.tsx
+++ b/src/components/InfoTooltip/index.tsx
@@ -3,8 +3,10 @@ import InfoTooltip from './InfoTooltip';
 import TextTooltip from './TextTooltip';
 import { TooltipProps } from '@material-ui/core/Tooltip';
 import { EventAction, EventCategory, trackEvent } from 'components/Analytics';
-import { StyledMarkdown } from './Tooltip.style';
+import { StyledMarkdown, InfoIcon } from './Tooltip.style';
 export { InfoTooltip, TextTooltip };
+
+export { InfoIcon };
 
 export type StyledTooltipProps = Omit<TooltipProps, 'children'> & {
   trackOpenTooltip: () => void;

--- a/src/components/LocationPage/LocationPageHeader.style.tsx
+++ b/src/components/LocationPage/LocationPageHeader.style.tsx
@@ -7,7 +7,7 @@ import { Level } from 'common/level';
 import MuiWarningIcon from '@material-ui/icons/Warning';
 import MuiInfoIcon from '@material-ui/icons/Info';
 import Button from '@material-ui/core/Button';
-import { InfoIcon } from 'components/InfoTooltip/Tooltip.style';
+import { InfoIcon } from 'components/InfoTooltip';
 
 export const ColoredHeaderBanner = styled(Box)`
   display: flex;

--- a/src/components/NewLocationPage/OverallRiskBlock/OverallLevelText/OverallLevelText.stories.tsx
+++ b/src/components/NewLocationPage/OverallRiskBlock/OverallLevelText/OverallLevelText.stories.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import OverallLevelText from './OverallLevelText';
+import { Level } from 'common/level';
+
+export default {
+  title: 'Location page redesign/Overall risk block/Level label',
+  component: OverallLevelText,
+};
+
+export const Low = () => {
+  return <OverallLevelText currentLevel={Level.LOW} />;
+};
+
+export const Medium = () => {
+  return <OverallLevelText currentLevel={Level.MEDIUM} />;
+};
+
+export const SuperCritical = () => {
+  return <OverallLevelText currentLevel={Level.SUPER_CRITICAL} />;
+};

--- a/src/components/NewLocationPage/OverallRiskBlock/OverallLevelText/OverallLevelText.stories.tsx
+++ b/src/components/NewLocationPage/OverallRiskBlock/OverallLevelText/OverallLevelText.stories.tsx
@@ -7,14 +7,14 @@ export default {
   component: OverallLevelText,
 };
 
-export const Low = () => {
+export const LowLabel = () => {
   return <OverallLevelText currentLevel={Level.LOW} />;
 };
 
-export const Medium = () => {
+export const MediumLabel = () => {
   return <OverallLevelText currentLevel={Level.MEDIUM} />;
 };
 
-export const SuperCritical = () => {
+export const SuperCriticalLabel = () => {
   return <OverallLevelText currentLevel={Level.SUPER_CRITICAL} />;
 };

--- a/src/components/NewLocationPage/OverallRiskBlock/OverallLevelText/OverallLevelText.style.tsx
+++ b/src/components/NewLocationPage/OverallRiskBlock/OverallLevelText/OverallLevelText.style.tsx
@@ -1,0 +1,45 @@
+import styled from 'styled-components';
+import {
+  GrayTitle,
+  CircleIcon,
+} from 'components/NewLocationPage/Shared/Shared.style';
+import { InfoIcon } from 'components/InfoTooltip/Tooltip.style';
+import { materialSMBreakpoint } from 'assets/theme/sizes';
+
+export const Wrapper = styled.div`
+  display: flex;
+  flex-direction: row-reverse;
+  align-items: center;
+
+  ${CircleIcon} {
+    margin-right: 0.25rem;
+  }
+
+  ${InfoIcon} {
+    margin-left: 0.75rem;
+  }
+
+  @media (min-width: ${materialSMBreakpoint}) {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+`;
+
+export const Row = styled.div`
+  display: flex;
+`;
+
+export const LevelLabel = styled.span`
+  ${props => props.theme.fonts.monospaceBold};
+  font-size: 1.5rem;
+  text-transform: uppercase;
+  line-height: 1;
+`;
+
+export const Title = styled(GrayTitle)`
+  display: none;
+  @media (min-width: ${materialSMBreakpoint}) {
+    display: unset;
+    margin-bottom: 0.5rem;
+  }
+`;

--- a/src/components/NewLocationPage/OverallRiskBlock/OverallLevelText/OverallLevelText.style.tsx
+++ b/src/components/NewLocationPage/OverallRiskBlock/OverallLevelText/OverallLevelText.style.tsx
@@ -3,7 +3,7 @@ import {
   GrayTitle,
   CircleIcon,
 } from 'components/NewLocationPage/Shared/Shared.style';
-import { InfoIcon } from 'components/InfoTooltip/Tooltip.style';
+import { InfoIcon } from 'components/InfoTooltip';
 import { materialSMBreakpoint } from 'assets/theme/sizes';
 
 export const Wrapper = styled.div`

--- a/src/components/NewLocationPage/OverallRiskBlock/OverallLevelText/OverallLevelText.tsx
+++ b/src/components/NewLocationPage/OverallRiskBlock/OverallLevelText/OverallLevelText.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { CircleIcon } from 'components/NewLocationPage/Shared/Shared.style';
+import { trackOpenTooltip } from 'components/InfoTooltip';
+import { InfoTooltip, renderTooltipContent } from 'components/InfoTooltip';
+import { Row, LevelLabel, Wrapper, Title } from './OverallLevelText.style';
+import { locationPageHeaderTooltipContent } from 'cms-content/tooltips';
+import { LOCATION_SUMMARY_LEVELS } from 'common/metrics/location_summary';
+import { Level } from 'common/level';
+import { useBreakpoint } from 'common/hooks';
+
+export function renderInfoTooltip(): React.ReactElement {
+  const { body } = locationPageHeaderTooltipContent;
+
+  return (
+    <InfoTooltip
+      title={renderTooltipContent(body)}
+      aria-label="Description of risk levels"
+      trackOpenTooltip={() => trackOpenTooltip('Location page header')}
+    />
+  );
+}
+
+const OverallLevelText: React.FC<{ currentLevel: Level }> = ({
+  currentLevel,
+}) => {
+  const isMobile = useBreakpoint(600);
+  const levelInfo = LOCATION_SUMMARY_LEVELS[currentLevel];
+  const levelName = isMobile ? levelInfo.summary : levelInfo.name;
+
+  return (
+    <Wrapper>
+      <Row>
+        <Title>Risk level</Title>
+        {renderInfoTooltip()}
+      </Row>
+      <Row>
+        <CircleIcon $iconColor={levelInfo.color} />
+        <LevelLabel>{levelName}</LevelLabel>
+      </Row>
+    </Wrapper>
+  );
+};
+
+export default OverallLevelText;

--- a/src/components/NewLocationPage/OverallRiskBlock/OverallRiskBlock.stories.tsx
+++ b/src/components/NewLocationPage/OverallRiskBlock/OverallRiskBlock.stories.tsx
@@ -17,6 +17,16 @@ export const Medium = () => {
   );
 };
 
+export const High = () => {
+  return <OverallRiskBlock currentLevel={Level.HIGH} locationName="New York" />;
+};
+
+export const Critical = () => {
+  return (
+    <OverallRiskBlock currentLevel={Level.CRITICAL} locationName="New York" />
+  );
+};
+
 export const SuperCritical = () => {
   return (
     <OverallRiskBlock

--- a/src/components/NewLocationPage/OverallRiskBlock/OverallRiskBlock.stories.tsx
+++ b/src/components/NewLocationPage/OverallRiskBlock/OverallRiskBlock.stories.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import OverallRiskBlock from './OverallRiskBlock';
+import { Level } from 'common/level';
+
+export default {
+  title: 'Location page redesign/Overall risk block',
+  component: OverallRiskBlock,
+};
+
+export const Low = () => {
+  return <OverallRiskBlock currentLevel={Level.LOW} locationName="New York" />;
+};
+
+export const Medium = () => {
+  return (
+    <OverallRiskBlock currentLevel={Level.MEDIUM} locationName="New York" />
+  );
+};
+
+export const SuperCritical = () => {
+  return (
+    <OverallRiskBlock
+      currentLevel={Level.SUPER_CRITICAL}
+      locationName="New York"
+    />
+  );
+};

--- a/src/components/NewLocationPage/OverallRiskBlock/OverallRiskBlock.style.tsx
+++ b/src/components/NewLocationPage/OverallRiskBlock/OverallRiskBlock.style.tsx
@@ -1,0 +1,28 @@
+import styled from 'styled-components';
+import { materialSMBreakpoint } from 'assets/theme/sizes';
+
+export const BlockWrapper = styled.div`
+  display: flex;
+  flex-direction: column-reverse;
+  width: fit-content;
+
+  @media (min-width: ${materialSMBreakpoint}) {
+    flex-direction: row;
+    align-items: center;
+  }
+`;
+
+export const Section = styled.div`
+  display: flex;
+  &:first-child {
+    margin-top: 1rem;
+    justify-content: center;
+  }
+
+  @media (min-width: ${materialSMBreakpoint}) {
+    &:first-child {
+      margin-right: 1.25rem;
+      margin-top: 0;
+    }
+  }
+`;

--- a/src/components/NewLocationPage/OverallRiskBlock/OverallRiskBlock.tsx
+++ b/src/components/NewLocationPage/OverallRiskBlock/OverallRiskBlock.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { BlockWrapper as Wrapper, Section } from './OverallRiskBlock.style';
+import RiskThermometer from '../RiskThermometer';
+import OverallLevelText from './OverallLevelText/OverallLevelText';
+import { Level } from 'common/level';
+
+const OverallRiskBlock: React.FC<{
+  currentLevel: Level;
+  locationName: string;
+}> = ({ currentLevel, locationName }) => {
+  return (
+    <Wrapper>
+      <Section>
+        <RiskThermometer
+          currentLevel={currentLevel}
+          locationName={locationName}
+        />
+      </Section>
+      <Section>
+        <OverallLevelText currentLevel={currentLevel} />
+      </Section>
+    </Wrapper>
+  );
+};
+
+export default OverallRiskBlock;

--- a/src/components/NewLocationPage/RiskThermometer/RiskThermometer.tsx
+++ b/src/components/NewLocationPage/RiskThermometer/RiskThermometer.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { MobileOnly, DesktopOnly } from '../Shared/Shared.style';
+import MobileThermometer from './MobileThermometer';
+import DesktopThermometer from './DesktopThermometer';
+import { Level } from 'common/level';
+
+const RiskThermometer: React.FC<{
+  currentLevel: Level;
+  locationName: string;
+}> = ({ currentLevel, locationName }) => {
+  const props = {
+    currentLevel,
+    locationName,
+  };
+
+  return (
+    <>
+      <MobileOnly>
+        <MobileThermometer {...props} />
+      </MobileOnly>
+      <DesktopOnly>
+        <DesktopThermometer {...props} />
+      </DesktopOnly>
+    </>
+  );
+};
+
+export default RiskThermometer;

--- a/src/components/NewLocationPage/RiskThermometer/index.ts
+++ b/src/components/NewLocationPage/RiskThermometer/index.ts
@@ -1,0 +1,3 @@
+import RiskThermometer from './RiskThermometer';
+
+export default RiskThermometer;

--- a/src/components/NewLocationPage/Shared/Shared.style.tsx
+++ b/src/components/NewLocationPage/Shared/Shared.style.tsx
@@ -1,5 +1,7 @@
 import styled from 'styled-components';
-import { mobileBreakpoint } from 'assets/theme/sizes';
+import FiberManualRecordIcon from '@material-ui/icons/FiberManualRecord';
+import Hidden from '@material-ui/core/Hidden';
+import { mobileBreakpoint, materialSMBreakpoint } from 'assets/theme/sizes';
 import MuiChevronRightIcon from '@material-ui/icons/ChevronRight';
 import { COLOR_MAP } from 'common/colors';
 
@@ -29,3 +31,23 @@ export const GrayTitle = styled.h2`
   color: ${COLOR_MAP.GRAY_BODY_COPY};
   text-transform: uppercase;
 `;
+
+export const CircleIcon = styled(FiberManualRecordIcon)<{ $iconColor: string }>`
+  color: ${({ $iconColor }) => $iconColor};
+  circle {
+    r: 4;
+  }
+
+  @media (min-width: ${materialSMBreakpoint}) {
+    // counteracts the svg's built-in padding, so the icon is aligned with the text above it:
+    margin-left: -6px;
+  }
+`;
+
+export const MobileOnly = styled(Hidden).attrs(props => ({
+  smUp: true,
+}))``;
+
+export const DesktopOnly = styled(Hidden).attrs(props => ({
+  xsDown: true,
+}))``;

--- a/src/components/NewLocationPage/SummaryStatsBlock/MetricValue.tsx
+++ b/src/components/NewLocationPage/SummaryStatsBlock/MetricValue.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { CircleIcon, Value, ValueWrapper } from './SummaryStatsBlock.style';
+import { Value, ValueWrapper } from './SummaryStatsBlock.style';
+import { CircleIcon } from '../Shared/Shared.style';
 
 const MetricValue: React.FC<{ value: string; iconColor: string }> = ({
   value,

--- a/src/components/NewLocationPage/SummaryStatsBlock/SummaryStat.tsx
+++ b/src/components/NewLocationPage/SummaryStatsBlock/SummaryStat.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import MobileSummaryStat from './MobileSummaryStat';
 import DesktopSummaryStat from './DesktopSummaryStat';
-import { MobileOnly, DesktopOnly } from './SummaryStatsBlock.style';
+import { MobileOnly, DesktopOnly } from '../Shared/Shared.style';
 import { formatValue, getLevelInfo } from 'common/metric';
 import { Metric } from 'common/metricEnum';
 import { useBreakpoint } from 'common/hooks';

--- a/src/components/NewLocationPage/SummaryStatsBlock/SummaryStatsBlock.style.tsx
+++ b/src/components/NewLocationPage/SummaryStatsBlock/SummaryStatsBlock.style.tsx
@@ -1,6 +1,4 @@
 import styled from 'styled-components';
-import FiberManualRecordIcon from '@material-ui/icons/FiberManualRecord';
-import Hidden from '@material-ui/core/Hidden';
 import { Chevron } from '../Shared/Shared.style';
 import { COLOR_MAP } from 'common/colors';
 import { materialSMBreakpoint } from 'assets/theme/sizes';
@@ -37,18 +35,6 @@ export const StatContent = styled.div`
 // put this somewhere in Shared:
 export const StyledChevron = styled(Chevron)`
   transform: none;
-`;
-
-export const CircleIcon = styled(FiberManualRecordIcon)<{ $iconColor: string }>`
-  color: ${({ $iconColor }) => $iconColor};
-  circle {
-    r: 4;
-  }
-
-  @media (min-width: ${materialSMBreakpoint}) {
-    // counteracts the svg's built-in padding, so the icon is aligned with the text above it:
-    margin-left: -6px;
-  }
 `;
 
 export const ValueWrapper = styled.div`
@@ -105,11 +91,3 @@ export const Row = styled.div`
     }
   }
 `;
-
-export const MobileOnly = styled(Hidden).attrs(props => ({
-  smUp: true,
-}))``;
-
-export const DesktopOnly = styled(Hidden).attrs(props => ({
-  xsDown: true,
-}))``;


### PR DESCRIPTION
[Figma mocks](https://www.figma.com/file/JGqemgZwlG9e5DQbZpdKgy/Redesign?node-id=1742%3A120358)

`Location page redesign/Overall risk block` in storybook

Mobile:
<img width="321" alt="Screen Shot 2021-04-26 at 11 18 24 AM" src="https://user-images.githubusercontent.com/44076375/116107609-2d8adf80-a681-11eb-9729-128483827731.png">

Desktop:
<img width="262" alt="Screen Shot 2021-04-26 at 11 18 14 AM" src="https://user-images.githubusercontent.com/44076375/116107628-31b6fd00-a681-11eb-9748-85d7bb9ce0ac.png">