### PR TITLE
Compare highlight fix

### DIFF
--- a/src/components/Compare/Compare.style.tsx
+++ b/src/components/Compare/Compare.style.tsx
@@ -1,11 +1,12 @@
 import styled, { css } from 'styled-components';
-import isNumber from 'lodash/isNumber';
-import { TableHead, TableCell, TableRow, Modal } from '@material-ui/core';
-import { COLOR_MAP, LEVEL_COLOR } from 'common/colors';
-import { COLORS } from 'common';
-import { Level } from 'common/level';
-import { ChartLocationName } from 'components/LocationPage/ChartsHolder.style';
 import { Link } from 'react-router-dom';
+import { TableHead, TableCell, TableRow, Modal } from '@material-ui/core';
+import isNumber from 'lodash/isNumber';
+import { ChartLocationName } from 'components/LocationPage/ChartsHolder.style';
+import { Wrapper as LocationName } from 'components/SharedComponents/StyledRegionName/StyledRegionName.style';
+import { COLORS } from 'common';
+import { COLOR_MAP, LEVEL_COLOR } from 'common/colors';
+import { Level } from 'common/level';
 
 // TODO (Chelsi): consolidate into a theme:
 
@@ -408,6 +409,9 @@ export const Row = styled(TableRow)<{
       ${Tag} {
         color: ${COLOR_MAP.BLUE};
       }
+    }
+    ${LocationName} {
+      color: ${COLOR_MAP.BLUE};
     }
   }
 `;

--- a/src/components/Compare/LocationTable.style.tsx
+++ b/src/components/Compare/LocationTable.style.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 import { locationNameCellWidth, metricCellWidth } from './Compare.style';
-import { RankedLocationSummary } from 'common/utils/compare';
 import { orderedColumns } from './columns';
+import { RankedLocationSummary } from 'common/utils/compare';
 
 const minTableWidth =
   locationNameCellWidth + orderedColumns.length * metricCellWidth;

--- a/src/components/Compare/LocationTable.tsx
+++ b/src/components/Compare/LocationTable.tsx
@@ -1,21 +1,21 @@
 import React from 'react';
 import { Table, TableBody } from '@material-ui/core';
+import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
+import ExpandLessIcon from '@material-ui/icons/ExpandLess';
+import CompareTableRow from './CompareTableRow';
+import HeaderCell from './HeaderCell';
+import * as Styles from './LocationTable.style';
+import * as CompareStyles from './Compare.style';
+import { SCREENSHOT_CLASS } from 'components/Screenshot';
+import { EventAction } from 'components/Analytics';
 import {
   RankedLocationSummary,
   GeoScopeFilter,
   SummaryForCompare,
   HomepageLocationScope,
 } from 'common/utils/compare';
-import CompareTableRow from './CompareTableRow';
-import HeaderCell from './HeaderCell';
-import * as Styles from './LocationTable.style';
-import * as CompareStyles from './Compare.style';
 import { COLOR_MAP } from 'common/colors';
-import ExpandLessIcon from '@material-ui/icons/ExpandLess';
-import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
-import { SCREENSHOT_CLASS } from 'components/Screenshot';
 import { trackCompareEvent } from 'common/utils/compare';
-import { EventAction } from 'components/Analytics';
 import { Region, MetroArea } from 'common/regions';
 import { ColumnDefinition } from './columns';
 


### PR DESCRIPTION
[Reorganizing compare row elements in this PR](https://github.com/covid-projections/covid-projections/pull/3408) made it so that the location name was no longer turning blue when hovering the row ([see here](https://covidactnow.org/?s=1783703) on prod when hovering a compare row). This fixes + also reorders some imports