### PR TITLE
Remove geolocated metro region, end API link experiment

### DIFF
--- a/src/components/MenuContent/MenuContent.tsx
+++ b/src/components/MenuContent/MenuContent.tsx
@@ -1,53 +1,10 @@
 import React, { ComponentType } from 'react';
-import keyBy from 'lodash/keyBy';
 import { menuContent } from 'cms-content/footer';
 import FeaturedSection from './FeaturedSection';
 import LearnSection from './LearnSection';
 import AboutUsSection from './AboutUsSection';
 import { ContentWrapper } from './Menu.style';
 import { useBreakpoint } from 'common/hooks';
-import {
-  Experiment,
-  ExperimentID,
-  Variant,
-  VariantID,
-} from 'components/Experiment';
-import { FeaturedItem, SectionId } from 'cms-content/footer';
-
-const FeaturedSectionVariant: React.FC<{
-  featuredSections: FeaturedItem[];
-  onClick: (label: string) => void;
-}> = ({ featuredSections, onClick }) => {
-  const sectionById = keyBy(featuredSections, section => section.iconId);
-
-  const orderedSectionsA = [
-    sectionById[SectionId.ALERTS],
-    sectionById[SectionId.DAILY_DOWNLOAD],
-    sectionById[SectionId.API],
-  ];
-  const orderedSectionsB = [
-    sectionById[SectionId.API],
-    sectionById[SectionId.ALERTS],
-    sectionById[SectionId.DAILY_DOWNLOAD],
-  ];
-
-  return (
-    <Experiment id={ExperimentID.MEGA_MENU_API_LINK}>
-      <Variant id={VariantID.A}>
-        <FeaturedSection
-          featuredSections={orderedSectionsA}
-          onClick={onClick}
-        />
-      </Variant>
-      <Variant id={VariantID.B}>
-        <FeaturedSection
-          featuredSections={orderedSectionsB}
-          onClick={onClick}
-        />
-      </Variant>
-    </Experiment>
-  );
-};
 
 const MenuContent: React.FC<{
   onClick: (label: string) => void;
@@ -61,7 +18,7 @@ const MenuContent: React.FC<{
     <ContentWrapper>
       {isMobile ? (
         <>
-          <FeaturedSectionVariant
+          <FeaturedSection
             featuredSections={featuredSections}
             onClick={onClick}
           />
@@ -71,11 +28,10 @@ const MenuContent: React.FC<{
       ) : (
         <>
           <LearnSection learnLinks={learnLinks} onClick={onClick} />
-          <FeaturedSectionVariant
+          <FeaturedSection
             featuredSections={featuredSections}
             onClick={onClick}
           />
-
           <AboutUsSection aboutUsCopy={aboutUs} onClick={onClick} Logo={Logo} />
         </>
       )}

--- a/src/components/RegionItem/HomepageItems.tsx
+++ b/src/components/RegionItem/HomepageItems.tsx
@@ -13,8 +13,7 @@ enum ItemsState {
 const HomepageItems: React.FC<{
   userRegions: GeolocatedRegions | null;
   isLoading: boolean;
-  showMetro: boolean;
-}> = ({ userRegions, isLoading, showMetro }) => {
+}> = ({ userRegions, isLoading }) => {
   const itemsState = isLoading
     ? ItemsState.LOADING
     : userRegions
@@ -25,9 +24,7 @@ const HomepageItems: React.FC<{
     return null;
   }
 
-  const visibleRegions = userRegions
-    ? getRegionList(userRegions, showMetro)
-    : [];
+  const visibleRegions = userRegions ? getRegionList(userRegions) : [];
 
   return (
     <RegionItemsWrapper>
@@ -48,21 +45,19 @@ const HomepageItems: React.FC<{
   );
 };
 
-function getRegionList(
-  geolocatedRegions: GeolocatedRegions,
-  showMetro: boolean,
-): Region[] {
+function getRegionList(geolocatedRegions: GeolocatedRegions): Region[] {
   const { county, state, metroArea } = geolocatedRegions;
   const items = [];
-  if (showMetro) {
-    if (metroArea) items.push(metroArea);
-    if (county) items.push(county);
-    if (state && items.length < 2) items.push(state);
-  } else {
-    if (state) items.push(state);
-    if (county) items.push(county);
-    // Only show metro if at least one of state or county is unavailable.
-    if (metroArea && items.length < 2) items.push(metroArea);
+  if (state) {
+    items.push(state);
+  }
+  if (county) {
+    items.push(county);
+  }
+  // **only if for some strange reason** a state or a county item is missing from
+  // the geolocated regions but there is a metroArea, we show the metroArea
+  if (metroArea && items.length < 2) {
+    items.push(metroArea);
   }
   return items;
 }

--- a/src/screens/HomePage/HomePage.tsx
+++ b/src/screens/HomePage/HomePage.tsx
@@ -38,12 +38,6 @@ import Toggle from './Toggle/Toggle';
 import HorizontalThermometer from 'components/HorizontalThermometer';
 import HomepageItems from 'components/RegionItem/HomepageItems';
 import { useBreakpoint, useCountyToZipMap } from 'common/hooks';
-import {
-  Experiment,
-  ExperimentID,
-  Variant,
-  VariantID,
-} from 'components/Experiment';
 import { DonateButtonHeart } from 'components/DonateButton';
 
 function getPageDescription() {
@@ -175,22 +169,7 @@ export default function HomePage() {
                 filterLimit={getFilterLimit()}
                 menuOpen={menuOpen}
               />
-              <Experiment id={ExperimentID.GEOLOCATED_LINKS}>
-                <Variant id={VariantID.A}>
-                  <HomepageItems
-                    isLoading={isLoading}
-                    userRegions={userRegions}
-                    showMetro
-                  />
-                </Variant>
-                <Variant id={VariantID.B}>
-                  <HomepageItems
-                    isLoading={isLoading}
-                    userRegions={userRegions}
-                    showMetro={false}
-                  />
-                </Variant>
-              </Experiment>
+              <HomepageItems isLoading={isLoading} userRegions={userRegions} />
               <Toggle
                 showCounties={showCounties}
                 onClickSwitch={onClickSwitch}
@@ -202,7 +181,6 @@ export default function HomePage() {
             <ColumnCentered $topBottomSpacing={true}>
               <HorizontalThermometer />
             </ColumnCentered>
-
             <Section>
               <CompareMain
                 locationsViewable={8}


### PR DESCRIPTION
- Ends experiment testing state/county vs. metro/county geolocated items on the homepage
- Ships state/county combo to all users
- Ends experiment testing the placement of the data API link in the mega menu (first in list vs. last in list)
- Ships last in list to all users