### PR TITLE
Quick fix to scroll issue

### DIFF
--- a/src/screens/HomePage/HomePage.tsx
+++ b/src/screens/HomePage/HomePage.tsx
@@ -58,8 +58,6 @@ export default function HomePage() {
 
   const isMobile = useBreakpoint(600);
 
-  const indicatorsRef = useRef(null);
-
   const { geolocationData, isLoading: geoIsLoading } = useGeolocation();
   const { result: countyToZipMap, pending: zipIsLoading } = useCountyToZipMap();
 
@@ -220,7 +218,7 @@ export default function HomePage() {
                 nationalSummaryText={getNationalText()}
               />
             </Section>
-            <SectionWrapper ref={indicatorsRef}>
+            <SectionWrapper>
               <CriteriaExplanation isMobile={isMobile} />
             </SectionWrapper>
             <Announcements />

--- a/src/screens/HomePage/HomePage.tsx
+++ b/src/screens/HomePage/HomePage.tsx
@@ -95,14 +95,6 @@ export default function HomePage() {
   const compareShowVulnerabilityFirst =
     location.hash === '#compare-vulnerabilities';
 
-  const scrollTo = (div: null | HTMLDivElement) =>
-    div &&
-    window.scrollTo({
-      left: 0,
-      top: div.offsetTop - 48,
-      behavior: 'smooth',
-    });
-
   useEffect(() => {
     if (location.pathname.includes('alert_signup')) {
       window.location.href = '#alert_signup';

--- a/src/screens/HomePage/HomePage.tsx
+++ b/src/screens/HomePage/HomePage.tsx
@@ -106,10 +106,10 @@ export default function HomePage() {
     });
 
   useEffect(() => {
-    if (location.pathname.includes('alert_signup') && shareBlockRef.current) {
-      scrollTo(shareBlockRef.current);
+    if (location.pathname.includes('alert_signup')) {
+      window.location.href = '#alert_signup';
     }
-  }, [location.pathname, shareBlockRef]);
+  }, [location.pathname]);
 
   const exploreSectionRef = useRef(null);
 
@@ -226,7 +226,7 @@ export default function HomePage() {
             <Announcements />
           </Content>
           <PartnersSection />
-          <div ref={shareBlockRef}>
+          <div ref={shareBlockRef} id="alert_signup">
             <ShareModelBlock />
           </div>
         </div>


### PR DESCRIPTION
some refactoring was merged last week that adds more lazy loading. as a result, links that scroll to a particular element using refs (rather than hashLinks) aren't scrolling to the right places. this is a quick fix for [the alerts signup link](http://covidactnow.org/alert_signup). adding a trello ticket to address the bug as a whole

using git bisect--[this looks like the PR](https://github.com/covid-projections/covid-projections/pull/3357) where the scroll bug originated