### PR TITLE
Move button inside of NotesBlock container

### DIFF
--- a/src/components/NewLocationPage/NotesBlock/NotesBlock.stories.tsx
+++ b/src/components/NewLocationPage/NotesBlock/NotesBlock.stories.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
 import NotesBlock from './NotesBlock';
 import VulnerabilityIcon from 'assets/images/VulnerabilityIcon';
-import { StyledBaseButton } from './NotesBlock.style';
-import { EventAction, EventCategory } from 'components/Analytics';
 import { isHighVulnerability } from './utils';
+import { EventCategory } from 'components/Analytics';
 
 export default {
   title: 'Location page redesign/Notes Block',
@@ -20,16 +19,15 @@ export const Example = () => {
   if (!highVulnerability) {
     return null;
   }
+
   return (
-    <StyledBaseButton
-      trackingCategory={EventCategory.NONE}
-      trackingAction={EventAction.NAVIGATE}
-      trackingLabel="Test vulnerability block"
-      href={redirectUrl}
+    <NotesBlock
+      icon={<VulnerabilityIcon />}
+      title={title}
+      redirectUrl={redirectUrl}
+      trackingCategory={EventCategory.VULNERABILITIES}
     >
-      <NotesBlock icon={<VulnerabilityIcon />} title={title}>
-        {body}
-      </NotesBlock>
-    </StyledBaseButton>
+      {body}
+    </NotesBlock>
   );
 };

--- a/src/components/NewLocationPage/NotesBlock/NotesBlock.style.tsx
+++ b/src/components/NewLocationPage/NotesBlock/NotesBlock.style.tsx
@@ -25,4 +25,8 @@ export const StyledBaseButton = styled(BaseButton)`
   text-transform: none;
   letter-spacing: 0;
   padding: 0;
+
+  &:hover {
+    background-color: transparent;
+  }
 `;

--- a/src/components/NewLocationPage/NotesBlock/NotesBlock.tsx
+++ b/src/components/NewLocationPage/NotesBlock/NotesBlock.tsx
@@ -6,22 +6,45 @@ import {
   IconWrapper,
   TextContainer,
   TextComponent,
+  StyledBaseButton,
 } from './NotesBlock.style';
+import { EventAction, EventCategory } from 'components/Analytics';
 
-const NotesBlock: React.FC<{ icon: any; title: string }> = ({
+interface NotesProps {
+  icon: any;
+  title: string;
+  redirectUrl?: string;
+  trackingCategory?: EventCategory;
+}
+
+const NotesBlock: React.FC<NotesProps> = ({
   icon,
   title,
+  redirectUrl,
+  trackingCategory = EventCategory.NONE,
   children,
 }) => {
+  // If there is no href/to/onClick prop passed,
+  // BaseButton knows to render as a span and not a button
+  const buttonProps = redirectUrl ? { href: redirectUrl } : {};
+
   return (
     <SectionContainer>
-      <SectionContentContainer>
-        <IconWrapper>{icon}</IconWrapper>
-        <TextContainer>
-          <LabelWithChevron text={title} />
-          <TextComponent>{children}</TextComponent>
-        </TextContainer>
-      </SectionContentContainer>
+      <StyledBaseButton
+        trackingCategory={trackingCategory}
+        trackingAction={EventAction.CLICK}
+        trackingLabel={`Header notes block: ${title}`}
+        style={{ cursor: redirectUrl ? 'pointer' : 'default' }}
+        {...buttonProps}
+      >
+        <SectionContentContainer>
+          <IconWrapper>{icon}</IconWrapper>
+          <TextContainer>
+            <LabelWithChevron text={title} />
+            <TextComponent>{children}</TextComponent>
+          </TextContainer>
+        </SectionContentContainer>
+      </StyledBaseButton>
     </SectionContainer>
   );
 };


### PR DESCRIPTION
This moves `StyledBaseButton` inside of `SectionContainer` so `SectionContainer` is always the parent div of each location page module above the fold

(not yet on prod, just storybook- Location page redesign/Notes Block)