### PR TITLE
Add updated date to location name header

### DIFF
--- a/src/common/utils/time-utils.ts
+++ b/src/common/utils/time-utils.ts
@@ -10,6 +10,7 @@ export enum DateFormat {
   MMM_YY = 'MMM yy', // Mar 20
   MMMM_D = 'MMMM d', // March 1
   MMM = 'MMM', // Mar
+  H_A_ZZZZ = 'h a ZZZZ', // 8 AM PDT
 }
 
 // Luxon accepts both singular and plural properties of DurationObjects (e.g. hour and hours are valid).

--- a/src/components/InfoTooltip/Tooltip.style.tsx
+++ b/src/components/InfoTooltip/Tooltip.style.tsx
@@ -100,7 +100,7 @@ export const StyledMarkdown = styled(MarkdownBody)`
 
 export const TooltipAnchorText = styled.span`
   text-decoration: underline;
-  text-decoration-style: dashed;
+  text-decoration-style: dotted;
   text-underline-offset: 3px;
   cursor: default;
   color: ${COLOR_MAP.GREY_4};

--- a/src/components/NewLocationPage/LocationName/LocationName.style.tsx
+++ b/src/components/NewLocationPage/LocationName/LocationName.style.tsx
@@ -23,7 +23,6 @@ export const MultiStateText = styled.div`
 
 export const UpdatedOnText = styled.h2`
   font-size: 1rem;
-  text-transform: uppercase;
   line-height: 1;
   margin: 0.25rem 0;
   color: ${COLOR_MAP.GREY_4};

--- a/src/components/NewLocationPage/LocationName/LocationName.style.tsx
+++ b/src/components/NewLocationPage/LocationName/LocationName.style.tsx
@@ -21,9 +21,9 @@ export const MultiStateText = styled.div`
   font-weight: 500;
 `;
 
-export const UpdatedOnText = styled.h2`
+export const UpdatedOnText = styled.span`
   font-size: 1rem;
   line-height: 1;
-  margin: 0.25rem 0;
+  margin-top: 0.5rem;
   color: ${COLOR_MAP.GREY_4};
 `;

--- a/src/components/NewLocationPage/LocationName/LocationName.style.tsx
+++ b/src/components/NewLocationPage/LocationName/LocationName.style.tsx
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 import { materialSMBreakpoint } from 'assets/theme/sizes';
+import { COLOR_MAP } from 'common/colors';
 
 export const RegionNameContainer = styled.div`
   text-align: center;
@@ -18,4 +19,12 @@ export const RegionNameText = styled.h1`
 export const MultiStateText = styled.div`
   font-size: 1rem;
   font-weight: 500;
+`;
+
+export const UpdatedOnText = styled.h2`
+  font-size: 1rem;
+  text-transform: uppercase;
+  line-height: 1;
+  margin: 0.25rem 0;
+  color: ${COLOR_MAP.GREY_4};
 `;

--- a/src/components/NewLocationPage/LocationName/LocationName.tsx
+++ b/src/components/NewLocationPage/LocationName/LocationName.tsx
@@ -4,8 +4,30 @@ import { isMultiStateMetro, getRegionName } from './utils';
 import {
   RegionNameContainer,
   RegionNameText,
-  MultiStateText,
+  UpdatedOnText,
 } from './LocationName.style';
+import { useModelLastUpdatedDate } from 'common/utils/model';
+import { DateFormat, formatDateTime } from 'common/utils/time-utils';
+import { TextTooltip, trackOpenTooltip } from 'components/InfoTooltip';
+
+const UpdatedDate: React.FC = () => {
+  const updatedDate = useModelLastUpdatedDate() || new Date();
+  const updatedTimeStamp = updatedDate;
+  updatedTimeStamp.setUTCHours(17, 0, 0, 0);
+  const updatedTimeStr = formatDateTime(updatedTimeStamp, DateFormat.H_A_ZZZZ);
+  const content = `We aim to update our data by ${updatedTimeStr} daily. Occasionally, when additional review is required, an update can be delayed by several hours. Note that certain data sources that we use (eg. ICU hospitalizations) are only updated once per week.`;
+  return (
+    <UpdatedOnText>
+      {'Updated on '}
+      <TextTooltip
+        title={content}
+        mainCopy={formatDateTime(updatedDate, DateFormat.MMMM_D)}
+        aria-label="Description of when data is updated"
+        trackOpenTooltip={() => trackOpenTooltip(`Updated date`)}
+      />
+    </UpdatedOnText>
+  );
+};
 
 const LocationName: React.FC<{ region: Region }> = ({ region }) => {
   if (region instanceof State) {
@@ -14,6 +36,7 @@ const LocationName: React.FC<{ region: Region }> = ({ region }) => {
         <RegionNameText>
           <strong>{getRegionName(region)}</strong>
         </RegionNameText>
+        <UpdatedDate />
       </RegionNameContainer>
     );
   } else if (region instanceof County) {
@@ -22,9 +45,9 @@ const LocationName: React.FC<{ region: Region }> = ({ region }) => {
       <RegionNameContainer>
         <RegionNameText>
           <strong>{countyName}</strong>
-          {` ${countySuffix}, `}
-          <strong>{region.state.stateCode}</strong>
+          {` ${countySuffix}, ${region.state.stateCode}`}
         </RegionNameText>
+        <UpdatedDate />
       </RegionNameContainer>
     );
   } else if (region instanceof MetroArea) {
@@ -34,9 +57,9 @@ const LocationName: React.FC<{ region: Region }> = ({ region }) => {
         <RegionNameContainer>
           <RegionNameText>
             <strong>{metroName}</strong>
-            {` ${metroSuffix}`}
+            {` ${metroSuffix}, ${region.stateCodes}`}
           </RegionNameText>
-          <MultiStateText>{region.stateCodes}</MultiStateText>
+          <UpdatedDate />
         </RegionNameContainer>
       );
     } else {
@@ -46,6 +69,7 @@ const LocationName: React.FC<{ region: Region }> = ({ region }) => {
             <strong>{`${metroName}, ${region.stateCodes}`}</strong>
             {` ${metroSuffix}`}
           </RegionNameText>
+          <UpdatedDate />
         </RegionNameContainer>
       );
     }


### PR DESCRIPTION
This PR adds an "Updated on <DATE>" component below the region name in the new location page header.

We also add a new date-time format to enable usage of the new time util (time formatting as "8 AM PDT", which will be displayed in the tooltip.

All tooltip links site wide are also updated to have a dotted line underneath, not a dashed line underneath, as per new design.