### PR TITLE
Add timeout to correct scrolling position

### DIFF
--- a/src/components/Markdown/MarkdownLink.tsx
+++ b/src/components/Markdown/MarkdownLink.tsx
@@ -25,7 +25,7 @@ import EmbedPreview from '../ShareBlock/EmbedPreview';
 export const scrollWithTimeout = (element: any, offset: number) => {
   return setTimeout(() => {
     scrollWithOffset(element, offset);
-  }, 600);
+  }, 1000);
 };
 
 const EmbedBox: React.FC<{ href: string }> = ({ href }) => {


### PR DESCRIPTION
This PR adds timeout to correct the scrolling position. Unfortunately, I also tried 700, 800, and 900 milliseconds. They did not give reliable scroll behaviour. Also tried other scrolling methods (e.g. `scrollIntoView`, `scrollTo`, etc.) and the incorrect scrolling persisted. Adjusting the timeout to 1000 milliseconds seems to be the only reliable fix so far.