### PR TITLE
Some location page feedback/fixes

### DIFF
--- a/src/components/LocationPage/ChartsHolder.tsx
+++ b/src/components/LocationPage/ChartsHolder.tsx
@@ -104,6 +104,19 @@ const ChartsHolder = ({ region, chartId }: ChartsHolderProps) => {
   }
   const stats = summaryToStats(locationSummary);
 
+  const onClickAlertSignup = () => {
+    trackEvent(
+      EventCategory.ENGAGEMENT,
+      EventAction.CLICK,
+      `Location Header: Receive Alerts`,
+    );
+    scrollTo(shareBlockRef.current);
+  };
+
+  const onClickShare = () => {
+    scrollTo(shareBlockRef.current, -352);
+  };
+
   const onClickMetric = (metric: Metric) => {
     trackEvent(
       EventCategory.METRICS,
@@ -121,6 +134,8 @@ const ChartsHolder = ({ region, chartId }: ChartsHolderProps) => {
           region={region}
           locationSummary={locationSummary}
           onClickMetric={(metric: Metric) => onClickMetric(metric)}
+          onClickAlertSignup={onClickAlertSignup}
+          onClickShare={onClickShare}
         />
         <LocationPageBlock>
           <VaccinationEligibilityBlock region={region} />

--- a/src/components/NewLocationPage/AboveTheFold/AboveTheFold.stories.tsx
+++ b/src/components/NewLocationPage/AboveTheFold/AboveTheFold.stories.tsx
@@ -16,7 +16,14 @@ export const California = () => {
     return null;
   }
 
-  return <AboveTheFold region={region} locationSummary={locationSummary} />;
+  return (
+    <AboveTheFold
+      region={region}
+      locationSummary={locationSummary}
+      onClickAlertSignup={() => {}}
+      onClickShare={() => {}}
+    />
+  );
 };
 
 export const Missouri = () => {
@@ -27,7 +34,14 @@ export const Missouri = () => {
     return null;
   }
 
-  return <AboveTheFold region={region} locationSummary={locationSummary} />;
+  return (
+    <AboveTheFold
+      region={region}
+      locationSummary={locationSummary}
+      onClickAlertSignup={() => {}}
+      onClickShare={() => {}}
+    />
+  );
 };
 
 export const MaricopaCounty = () => {
@@ -38,7 +52,14 @@ export const MaricopaCounty = () => {
     return null;
   }
 
-  return <AboveTheFold region={region} locationSummary={locationSummary} />;
+  return (
+    <AboveTheFold
+      region={region}
+      locationSummary={locationSummary}
+      onClickAlertSignup={() => {}}
+      onClickShare={() => {}}
+    />
+  );
 };
 
 export const EastBatonRougeParish = () => {
@@ -49,7 +70,14 @@ export const EastBatonRougeParish = () => {
     return null;
   }
 
-  return <AboveTheFold region={region} locationSummary={locationSummary} />;
+  return (
+    <AboveTheFold
+      region={region}
+      locationSummary={locationSummary}
+      onClickAlertSignup={() => {}}
+      onClickShare={() => {}}
+    />
+  );
 };
 
 export const AtlantaMetro = () => {
@@ -60,7 +88,14 @@ export const AtlantaMetro = () => {
     return null;
   }
 
-  return <AboveTheFold region={region} locationSummary={locationSummary} />;
+  return (
+    <AboveTheFold
+      region={region}
+      locationSummary={locationSummary}
+      onClickAlertSignup={() => {}}
+      onClickShare={() => {}}
+    />
+  );
 };
 
 export const BostonMetro = () => {
@@ -71,5 +106,12 @@ export const BostonMetro = () => {
     return null;
   }
 
-  return <AboveTheFold region={region} locationSummary={locationSummary} />;
+  return (
+    <AboveTheFold
+      region={region}
+      locationSummary={locationSummary}
+      onClickAlertSignup={() => {}}
+      onClickShare={() => {}}
+    />
+  );
 };

--- a/src/components/NewLocationPage/AboveTheFold/AboveTheFold.style.tsx
+++ b/src/components/NewLocationPage/AboveTheFold/AboveTheFold.style.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 import { COLOR_MAP } from 'common/colors';
 import { maxContentWidth } from 'components/NewLocationPage/Shared/Shared.style';
-import { materialSMBreakpoint } from 'assets/theme/sizes';
+import { materialSMBreakpoint, mobileBreakpoint } from 'assets/theme/sizes';
 import { mapToFixedBreakpoint } from '../CountyMap';
 
 export const MainWrapper = styled.div`
@@ -29,6 +29,15 @@ export const GridContainer = styled.div`
   @media (min-width: ${materialSMBreakpoint}) {
     grid-template-columns: 2fr 1fr;
     grid-gap: 1.75rem;
+    grid-template-areas:
+      'header header'
+      'overview overview'
+      'spark map'
+      'alerts alerts'
+      'note note';
+  }
+
+  @media (min-width: ${mobileBreakpoint}) {
     grid-template-areas:
       'header header'
       'overview overview'

--- a/src/components/NewLocationPage/AboveTheFold/AboveTheFold.tsx
+++ b/src/components/NewLocationPage/AboveTheFold/AboveTheFold.tsx
@@ -28,6 +28,8 @@ const noop = () => {};
 interface AboveTheFoldProps {
   region: Region;
   locationSummary: LocationSummary;
+  onClickAlertSignup: () => void;
+  onClickShare: () => void;
   onClickMetric?: (metric: Metric) => void;
 }
 
@@ -35,6 +37,8 @@ const AboveTheFold: React.FC<AboveTheFoldProps> = ({
   region,
   locationSummary,
   onClickMetric,
+  onClickAlertSignup,
+  onClickShare,
 }) => {
   return (
     <MainWrapper>
@@ -43,7 +47,7 @@ const AboveTheFold: React.FC<AboveTheFoldProps> = ({
           <HeaderContainer>
             <LocationName region={region} />
             <DesktopOnly>
-              <HeaderButtons />
+              <HeaderButtons onClickShare={onClickShare} />
             </DesktopOnly>
             <MobileOnly>
               <VaccineButton />
@@ -55,19 +59,26 @@ const AboveTheFold: React.FC<AboveTheFoldProps> = ({
             region={region}
             locationSummary={locationSummary}
             onClickMetric={onClickMetric || noop}
+            onClickShare={onClickShare || noop}
           />
         </GridItemOverview>
         <GridItemSparkLines>
           <SparkLineBlock region={region} />
         </GridItemSparkLines>
         <GridItemAlerts>
-          <GetAlertsBlock region={region} onClickGetAlerts={() => {}} />
+          <GetAlertsBlock
+            region={region}
+            onClickGetAlerts={onClickAlertSignup}
+          />
         </GridItemAlerts>
         <GridItemMap>
           <CountyMap region={region} />
         </GridItemMap>
         <GridItemNote>
-          <VulnerabilityNote ccviScore={locationSummary.ccvi} />
+          <VulnerabilityNote
+            ccviScore={locationSummary.ccvi}
+            locationName={region.shortName}
+          />
         </GridItemNote>
       </GridContainer>
     </MainWrapper>

--- a/src/components/NewLocationPage/HeaderButtons/HeaderButtons.tsx
+++ b/src/components/NewLocationPage/HeaderButtons/HeaderButtons.tsx
@@ -2,10 +2,12 @@ import React from 'react';
 import ShareButton from './ShareButton';
 import VaccineButton from './VaccineButton';
 
-const HeaderButtons: React.FC = () => {
+const HeaderButtons: React.FC<{ onClickShare: () => void }> = ({
+  onClickShare,
+}) => {
   return (
     <div style={{ display: 'flex' }}>
-      <ShareButton />
+      <ShareButton onClickShare={onClickShare} />
       <VaccineButton />
     </div>
   );

--- a/src/components/NewLocationPage/HeaderButtons/ShareButton.stories.tsx
+++ b/src/components/NewLocationPage/HeaderButtons/ShareButton.stories.tsx
@@ -7,5 +7,5 @@ export default {
 };
 
 export const Share = () => {
-  return <ShareButton />;
+  return <ShareButton onClickShare={() => {}} />;
 };

--- a/src/components/NewLocationPage/HeaderButtons/ShareButton.tsx
+++ b/src/components/NewLocationPage/HeaderButtons/ShareButton.tsx
@@ -4,13 +4,15 @@ import { EventCategory } from 'components/Analytics';
 import { LargeOutlinedButton } from 'components/ButtonSystem';
 import { ShareButtonWrapper as Wrapper } from './HeaderButtons.style';
 
-const ShareButton: React.FC = () => {
+const ShareButton: React.FC<{ onClickShare: () => void }> = ({
+  onClickShare,
+}) => {
   return (
     <Wrapper>
       <LargeOutlinedButton
         trackingCategory={EventCategory.ENGAGEMENT}
         trackingLabel="Location page header: Share"
-        to="#share"
+        onClick={onClickShare}
         endIcon={<ShareOutlinedIcon />}
       >
         Share

--- a/src/components/NewLocationPage/LocationName/LocationName.style.tsx
+++ b/src/components/NewLocationPage/LocationName/LocationName.style.tsx
@@ -13,9 +13,10 @@ export const RegionNameText = styled.h1`
   ${props => props.theme.fonts.regularBook};
   font-size: 2rem;
   line-height: 1.3;
-  margin: 0 0 0.5rem;
+  margin: 0 0 0.25rem;
 `;
 
 export const UpdatedOnText = styled.span`
   color: ${COLOR_MAP.GREY_4};
+  font-size: 0.9rem;
 `;

--- a/src/components/NewLocationPage/LocationOverview/LocationOverview.stories.tsx
+++ b/src/components/NewLocationPage/LocationOverview/LocationOverview.stories.tsx
@@ -15,5 +15,11 @@ export const NewYork = () => {
   if (!locationSummary) {
     return null;
   }
-  return <LocationOverview region={region} locationSummary={locationSummary} />;
+  return (
+    <LocationOverview
+      region={region}
+      locationSummary={locationSummary}
+      onClickShare={() => {}}
+    />
+  );
 };

--- a/src/components/NewLocationPage/LocationOverview/LocationOverview.style.tsx
+++ b/src/components/NewLocationPage/LocationOverview/LocationOverview.style.tsx
@@ -14,7 +14,7 @@ export const OverviewSectionContainer = styled(SectionContainer)`
   padding: 0;
 
   @media (min-width: ${materialSMBreakpoint}) {
-    padding: 1.5rem;
+    padding: 1.75rem;
   }
 `;
 
@@ -29,7 +29,7 @@ export const GridContainer = styled.div`
     grid-template-areas:
       'level level progress progress'
       'metric1 metric2 metric3 metricVax';
-    row-gap: 2rem;
+    row-gap: 2.5rem;
     column-gap: 1.5rem;
   }
 

--- a/src/components/NewLocationPage/LocationOverview/LocationOverview.tsx
+++ b/src/components/NewLocationPage/LocationOverview/LocationOverview.tsx
@@ -26,7 +26,8 @@ const LocationOverview: React.FC<{
   region: Region;
   locationSummary: LocationSummary;
   onClickMetric?: (metric: Metric) => void;
-}> = ({ region, locationSummary, onClickMetric = noop }) => {
+  onClickShare: () => void;
+}> = ({ region, locationSummary, onClickMetric = noop, onClickShare }) => {
   const stats = summaryToStats(locationSummary);
   const projections = useProjectionsFromRegion(region);
 
@@ -59,21 +60,21 @@ const LocationOverview: React.FC<{
             value={stats[Metric.CASE_DENSITY]}
           />
         </GridItemMetric1>
-        <GridItemMetric2 onClick={() => onClickMetric(Metric.POSITIVE_TESTS)}>
-          <SummaryStat
-            metric={Metric.POSITIVE_TESTS}
-            value={stats[Metric.POSITIVE_TESTS]}
-          />
-        </GridItemMetric2>
-        <GridItemMetric3 onClick={() => onClickMetric(Metric.CASE_GROWTH_RATE)}>
+        <GridItemMetric2 onClick={() => onClickMetric(Metric.CASE_GROWTH_RATE)}>
           <SummaryStat
             metric={Metric.CASE_GROWTH_RATE}
             value={stats[Metric.CASE_GROWTH_RATE]}
           />
+        </GridItemMetric2>
+        <GridItemMetric3 onClick={() => onClickMetric(Metric.POSITIVE_TESTS)}>
+          <SummaryStat
+            metric={Metric.POSITIVE_TESTS}
+            value={stats[Metric.POSITIVE_TESTS]}
+          />
         </GridItemMetric3>
       </GridContainer>
       <MobileOnly>
-        <ShareButton />
+        <ShareButton onClickShare={onClickShare} />
       </MobileOnly>
     </OverviewSectionContainer>
   );

--- a/src/components/NewLocationPage/NotesBlock/NotesBlock.stories.tsx
+++ b/src/components/NewLocationPage/NotesBlock/NotesBlock.stories.tsx
@@ -7,5 +7,5 @@ export default {
 };
 
 export const VulnerabilityExample = () => {
-  return <VulnerabilityNote ccviScore={0.9} />;
+  return <VulnerabilityNote ccviScore={0.9} locationName="test" />;
 };

--- a/src/components/NewLocationPage/NotesBlock/VulnerabilityNote.tsx
+++ b/src/components/NewLocationPage/NotesBlock/VulnerabilityNote.tsx
@@ -5,17 +5,17 @@ import { hasVeryHighVulnerability } from './utils';
 import { EventCategory } from 'components/Analytics';
 import { useScrollToElement } from 'common/hooks';
 
-const title = 'Vulnerability is very high';
-const body =
-  'New York City metro is more likely to experience severe physical and economic suffering from COVID, and to face harder, longer recovery.';
-
-const VulnerabilityNote: React.FC<{ ccviScore: number | null }> = ({
-  ccviScore,
-}) => {
+const VulnerabilityNote: React.FC<{
+  ccviScore: number | null;
+  locationName: string;
+}> = ({ ccviScore, locationName }) => {
   const veryHighVulnerability =
     ccviScore && hasVeryHighVulnerability(ccviScore);
 
   useScrollToElement();
+
+  const title = 'Vulnerability is very high';
+  const body = `${locationName} is more likely to experience severe physical and economic suffering from COVID, and to face harder, longer recovery.`;
 
   if (!veryHighVulnerability) {
     return null;

--- a/src/components/NewLocationPage/Shared/Shared.style.tsx
+++ b/src/components/NewLocationPage/Shared/Shared.style.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 import FiberManualRecordIcon from '@material-ui/icons/FiberManualRecord';
 import Hidden from '@material-ui/core/Hidden';
-import { mobileBreakpoint, materialSMBreakpoint } from 'assets/theme/sizes';
+import { materialSMBreakpoint } from 'assets/theme/sizes';
 import MuiChevronRightIcon from '@material-ui/icons/ChevronRight';
 import { COLOR_MAP } from 'common/colors';
 
@@ -16,8 +16,8 @@ export const SectionContainer = styled.div`
   border-radius: 4px;
   padding: 1.25rem;
 
-  @media (min-width: ${mobileBreakpoint}) {
-    padding: 1.5rem;
+  @media (min-width: ${materialSMBreakpoint}) {
+    padding: 1.75rem;
   }
 `;
 
@@ -30,7 +30,7 @@ export const Chevron = styled(MuiChevronRightIcon)`
 
 export const GrayTitle = styled.h2`
   margin: 0 0 1.5rem;
-  font-size: 1rem;
+  font-size: 0.9rem;
   line-height: 1.4;
   color: ${COLOR_MAP.GRAY_BODY_COPY};
   text-transform: uppercase;

--- a/src/components/NewLocationPage/SparkLineBlock/SparkLineSet.tsx
+++ b/src/components/NewLocationPage/SparkLineBlock/SparkLineSet.tsx
@@ -14,7 +14,7 @@ import {
 } from './utils';
 import { subtractTime, TimeUnit } from 'common/utils/time-utils';
 
-// TODO (chelsi) - update link's 'to'
+// TODO (chelsi) - update onClick scrolling functionality
 
 const SparkLineSet: React.FC<{ projection: Projection }> = ({ projection }) => {
   const dateTo = new Date();

--- a/src/components/NewLocationPage/SummaryStat/SummaryStat.style.tsx
+++ b/src/components/NewLocationPage/SummaryStat/SummaryStat.style.tsx
@@ -42,7 +42,7 @@ export const SubLabelWrapper = styled.div`
 export const SubLabel = styled.span`
   color: ${COLOR_MAP.GRAY_BODY_COPY};
   text-transform: uppercase;
-  font-size: 1rem;
+  font-size: 0.9rem;
 `;
 
 export const MetricLabel = styled.span`


### PR DESCRIPTION
- Fixes order of top level metrics (swaps rt and pos test rate)
- Fixes order of spark lines (switches hospitalizations and deaths)
- Fixes scroll target for share button (was prev scrolling to alerts section) + mobile get alerts button (was prev not doing anything)
- Wires up region's location name to vulnerability note
- Makes alert section 2 columns wide when screen is between 600px and 800px