### PR TITLE
Stop input field from toggling open and closed

### DIFF
--- a/src/components/Search/Homepage/HomepageSearchAutocomplete.tsx
+++ b/src/components/Search/Homepage/HomepageSearchAutocomplete.tsx
@@ -147,9 +147,13 @@ const HomepageSearchAutocomplete: React.FC<{
             }
           }}
           onClose={() => {
-            setIsOpen(false);
-            if (setHideMapToggle) {
-              setHideMapToggle(false);
+            // Only close the dropdown if the user clicks outside the dropdown
+            // (i.e. Element in focus will not have a 'placeholder' attribute).
+            if (!document.activeElement?.hasAttribute('placeholder')) {
+              setIsOpen(false);
+              if (setHideMapToggle) {
+                setHideMapToggle(false);
+              }
             }
           }}
           PaperComponent={StyledPaper}


### PR DESCRIPTION
This PR adds a condition to check whether the user clicks outside the location search dropdown on the homepage. This enables us to differentiate when to close the dropdown and when to leave it open. The dropdown should only close if the user clicks outside the dropdown.

Not sure whether this is the ideal solution but `Autocomplete` seems to generically recognize a click (whether inside or outside the dropdown) as an `onClose`. Hence the explicit check for a `placeholder` attribute, which is unique to the dropdown.