### PR TITLE
Spark lines selecting correct explore tab

### DIFF
--- a/src/components/LocationPage/ChartsHolder.tsx
+++ b/src/components/LocationPage/ChartsHolder.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect } from 'react';
+import React, { useRef, useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import {
   useCcviForFips,
@@ -9,6 +9,8 @@ import {
 import { ALL_METRICS } from 'common/metric';
 import { Metric } from 'common/metricEnum';
 import { Region, State, getStateName } from 'common/regions';
+import { useProjectionsFromRegion } from 'common/utils/model';
+import { LoadingScreen } from 'screens/LocationPage/LocationPage.style';
 import { EventCategory, EventAction, trackEvent } from 'components/Analytics';
 import CompareMain from 'components/Compare/CompareMain';
 import ErrorBoundary from 'components/ErrorBoundary';
@@ -20,10 +22,12 @@ import VulnerabilitiesBlock from 'components/VulnerabilitiesBlock';
 import ChartBlock from './ChartBlock';
 import LocationPageBlock from './LocationPageBlock';
 import { ChartContentWrapper } from './ChartsHolder.style';
-import { useProjectionsFromRegion } from 'common/utils/model';
-import { LoadingScreen } from 'screens/LocationPage/LocationPage.style';
 import { summaryToStats } from 'components/NewLocationPage/SummaryStat/utils';
 import AboveTheFold from 'components/NewLocationPage/AboveTheFold/AboveTheFold';
+import {
+  SparkLineMetric,
+  SparkLineToExploreMetric,
+} from 'components/NewLocationPage/SparkLineBlock/utils';
 
 // TODO: 100 is rough accounting for the navbar;
 // could make these constants so we don't have to manually update
@@ -62,10 +66,15 @@ const ChartsHolder = ({ region, chartId }: ChartsHolderProps) => {
   const { pathname, hash } = useLocation();
   const isRecommendationsShareUrl = pathname.includes('recommendations');
 
-  const defaultExploreMetric =
-    hash === '#explore-chart'
-      ? ExploreMetric.HOSPITALIZATIONS
-      : ExploreMetric.CASES;
+  const [defaultExploreMetric, setDefaultExploreMetric] = useState<
+    ExploreMetric
+  >(ExploreMetric.CASES);
+
+  useEffect(() => {
+    if (hash === '#explore-chart') {
+      setDefaultExploreMetric(ExploreMetric.HOSPITALIZATIONS);
+    }
+  }, [hash]);
 
   useEffect(() => {
     const scrollToChart = () => {
@@ -126,6 +135,16 @@ const ChartsHolder = ({ region, chartId }: ChartsHolderProps) => {
     scrollTo(metricRefs[metric].current);
   };
 
+  const onClickSparkLine = (metric: SparkLineMetric) => {
+    trackEvent(
+      EventCategory.METRICS,
+      EventAction.CLICK,
+      `Spark line: ${SparkLineMetric[metric]}`,
+    );
+    setDefaultExploreMetric(SparkLineToExploreMetric[metric]);
+    scrollTo(exploreChartRef.current);
+  };
+
   // TODO(pablo): Create separate refs for signup and share
   return (
     <>
@@ -136,6 +155,7 @@ const ChartsHolder = ({ region, chartId }: ChartsHolderProps) => {
           onClickMetric={(metric: Metric) => onClickMetric(metric)}
           onClickAlertSignup={onClickAlertSignup}
           onClickShare={onClickShare}
+          onClickSparkLine={onClickSparkLine}
         />
         <LocationPageBlock>
           <VaccinationEligibilityBlock region={region} />

--- a/src/components/NewLocationPage/AboveTheFold/AboveTheFold.stories.tsx
+++ b/src/components/NewLocationPage/AboveTheFold/AboveTheFold.stories.tsx
@@ -8,6 +8,12 @@ export default {
   component: AboveTheFold,
 };
 
+const onClickProps = {
+  onClickAlertSignup: () => {},
+  onClickShare: () => {},
+  onClickSparkLine: () => {},
+};
+
 export const California = () => {
   const region = regions.findByFipsCodeStrict('06');
   const locationSummary = useLocationSummariesForFips(region.fipsCode);
@@ -20,8 +26,7 @@ export const California = () => {
     <AboveTheFold
       region={region}
       locationSummary={locationSummary}
-      onClickAlertSignup={() => {}}
-      onClickShare={() => {}}
+      {...onClickProps}
     />
   );
 };
@@ -38,8 +43,7 @@ export const Missouri = () => {
     <AboveTheFold
       region={region}
       locationSummary={locationSummary}
-      onClickAlertSignup={() => {}}
-      onClickShare={() => {}}
+      {...onClickProps}
     />
   );
 };
@@ -56,8 +60,7 @@ export const MaricopaCounty = () => {
     <AboveTheFold
       region={region}
       locationSummary={locationSummary}
-      onClickAlertSignup={() => {}}
-      onClickShare={() => {}}
+      {...onClickProps}
     />
   );
 };
@@ -74,8 +77,7 @@ export const EastBatonRougeParish = () => {
     <AboveTheFold
       region={region}
       locationSummary={locationSummary}
-      onClickAlertSignup={() => {}}
-      onClickShare={() => {}}
+      {...onClickProps}
     />
   );
 };
@@ -92,8 +94,7 @@ export const AtlantaMetro = () => {
     <AboveTheFold
       region={region}
       locationSummary={locationSummary}
-      onClickAlertSignup={() => {}}
-      onClickShare={() => {}}
+      {...onClickProps}
     />
   );
 };
@@ -110,8 +111,7 @@ export const BostonMetro = () => {
     <AboveTheFold
       region={region}
       locationSummary={locationSummary}
-      onClickAlertSignup={() => {}}
-      onClickShare={() => {}}
+      {...onClickProps}
     />
   );
 };

--- a/src/components/NewLocationPage/AboveTheFold/AboveTheFold.tsx
+++ b/src/components/NewLocationPage/AboveTheFold/AboveTheFold.tsx
@@ -22,8 +22,7 @@ import { LocationSummary } from 'common/location_summaries';
 import { DesktopOnly, MobileOnly } from '../Shared/Shared.style';
 import VaccineButton from 'components/NewLocationPage/HeaderButtons/VaccineButton';
 import { Metric } from 'common/metricEnum';
-
-const noop = () => {};
+import { SparkLineMetric } from '../SparkLineBlock/utils';
 
 interface AboveTheFoldProps {
   region: Region;
@@ -31,6 +30,7 @@ interface AboveTheFoldProps {
   onClickAlertSignup: () => void;
   onClickShare: () => void;
   onClickMetric?: (metric: Metric) => void;
+  onClickSparkLine: (metric: SparkLineMetric) => void;
 }
 
 const AboveTheFold: React.FC<AboveTheFoldProps> = ({
@@ -39,6 +39,7 @@ const AboveTheFold: React.FC<AboveTheFoldProps> = ({
   onClickMetric,
   onClickAlertSignup,
   onClickShare,
+  onClickSparkLine,
 }) => {
   return (
     <MainWrapper>
@@ -58,12 +59,12 @@ const AboveTheFold: React.FC<AboveTheFoldProps> = ({
           <LocationOverview
             region={region}
             locationSummary={locationSummary}
-            onClickMetric={onClickMetric || noop}
-            onClickShare={onClickShare || noop}
+            onClickMetric={onClickMetric}
+            onClickShare={onClickShare}
           />
         </GridItemOverview>
         <GridItemSparkLines>
-          <SparkLineBlock region={region} />
+          <SparkLineBlock region={region} onClickSparkLine={onClickSparkLine} />
         </GridItemSparkLines>
         <GridItemAlerts>
           <GetAlertsBlock

--- a/src/components/NewLocationPage/LocationOverview/LocationOverview.style.tsx
+++ b/src/components/NewLocationPage/LocationOverview/LocationOverview.style.tsx
@@ -49,7 +49,8 @@ const ItemBasePadding = css`
   }
 `;
 
-const ClickableMetric = css`
+const ClickableItemStyles = css`
+  ${ItemBasePadding};
   cursor: pointer;
   &:hover {
     ${Chevron} {
@@ -72,7 +73,7 @@ export const GridItemLevel = styled.div`
 `;
 
 export const GridItemProgress = styled.div`
-  ${ItemBasePadding};
+  ${ClickableItemStyles};
   grid-area: progress;
   padding-bottom: 1.5rem;
   border-bottom: 1px solid ${COLOR_MAP.GREY_1};
@@ -84,27 +85,23 @@ export const GridItemProgress = styled.div`
 `;
 
 export const GridItemMetric1 = styled.div`
-  ${ItemBasePadding};
-  ${ClickableMetric};
+  ${ClickableItemStyles};
   grid-area: metric1;
   cursor: pointer;
 `;
 
 export const GridItemMetric2 = styled.div`
-  ${ItemBasePadding};
-  ${ClickableMetric};
+  ${ClickableItemStyles};
   grid-area: metric2;
 `;
 
 export const GridItemMetric3 = styled.div`
-  ${ItemBasePadding};
-  ${ClickableMetric};
+  ${ClickableItemStyles};
   grid-area: metric3;
 `;
 
 export const GridItemMetricVax = styled.div`
-  ${ItemBasePadding};
-  ${ClickableMetric};
+  ${ClickableItemStyles};
   grid-area: metricVax;
   padding-top: 1.5rem;
   border-top: 1px solid ${COLOR_MAP.GREY_1};

--- a/src/components/NewLocationPage/LocationOverview/LocationOverview.style.tsx
+++ b/src/components/NewLocationPage/LocationOverview/LocationOverview.style.tsx
@@ -54,7 +54,7 @@ const ClickableItemStyles = css`
   cursor: pointer;
   &:hover {
     ${Chevron} {
-      transform: translate(6px, -2px);
+      transform: translate(6px, -3px);
       transition: transform 0.06s ease-in-out;
     }
   }

--- a/src/components/NewLocationPage/LocationOverview/LocationOverview.style.tsx
+++ b/src/components/NewLocationPage/LocationOverview/LocationOverview.style.tsx
@@ -54,7 +54,7 @@ const ClickableItemStyles = css`
   cursor: pointer;
   &:hover {
     ${Chevron} {
-      transform: translate(6px, -3px);
+      transform: translate(6px, -1px);
       transition: transform 0.06s ease-in-out;
     }
   }

--- a/src/components/NewLocationPage/LocationOverview/LocationOverview.tsx
+++ b/src/components/NewLocationPage/LocationOverview/LocationOverview.tsx
@@ -40,7 +40,7 @@ const LocationOverview: React.FC<{
             locationName={region.name}
           />
         </GridItemLevel>
-        <GridItemProgress>
+        <GridItemProgress onClick={() => onClickMetric(Metric.VACCINATIONS)}>
           {projections && projections.primary && (
             <VaccinationProgressBarBlock
               locationName={region.name}

--- a/src/components/NewLocationPage/NotesBlock/NotesBlock.style.tsx
+++ b/src/components/NewLocationPage/NotesBlock/NotesBlock.style.tsx
@@ -12,7 +12,7 @@ export const TextContainer = styled.div`
 
 export const TextComponent = styled.p`
   color: ${COLOR_MAP.GREY_4};
-  margin: 0.63rem 0 0;
+  margin: 0.7rem 0 0;
 `;
 
 export const IconWrapper = styled.div`

--- a/src/components/NewLocationPage/OverallRiskBlock/OverallLevelText/OverallLevelText.style.tsx
+++ b/src/components/NewLocationPage/OverallRiskBlock/OverallLevelText/OverallLevelText.style.tsx
@@ -4,7 +4,7 @@ import {
   CircleIcon,
 } from 'components/NewLocationPage/Shared/Shared.style';
 import { InfoIcon } from 'components/InfoTooltip';
-import { materialSMBreakpoint } from 'assets/theme/sizes';
+import { materialSMBreakpoint, smallPhoneBreakpoint } from 'assets/theme/sizes';
 
 export const Wrapper = styled.div`
   display: flex;
@@ -31,9 +31,13 @@ export const Row = styled.div`
 
 export const LevelLabel = styled.span`
   ${props => props.theme.fonts.monospaceBold};
-  font-size: 1.5rem;
+  font-size: 1.4rem;
   text-transform: uppercase;
   line-height: 1;
+
+  @media (min-width: ${smallPhoneBreakpoint}) {
+    font-size: 1.5rem;
+  }
 `;
 
 export const Title = styled(GrayTitle)`

--- a/src/components/NewLocationPage/Shared/LabelWithChevron.tsx
+++ b/src/components/NewLocationPage/Shared/LabelWithChevron.tsx
@@ -4,7 +4,7 @@ import TextAndIconWithSpecialWrapping from 'components/TextAndIconWithSpecialWra
 
 const LabelWithChevron: React.FC<{ text: string }> = ({ text }) => {
   return (
-    <div>
+    <div style={{ lineHeight: 1.2 }}>
       <TextAndIconWithSpecialWrapping text={text} icon={<Chevron />} />
     </div>
   );

--- a/src/components/NewLocationPage/SparkLineBlock/SparkLineBlock.stories.tsx
+++ b/src/components/NewLocationPage/SparkLineBlock/SparkLineBlock.stories.tsx
@@ -22,7 +22,7 @@ export const Michigan = () => {
     return null;
   }
 
-  return <SparkLineBlock region={testRegion} />;
+  return <SparkLineBlock region={testRegion} onClickSparkLine={() => {}} />;
 };
 
 export const BostonMetro = () => {
@@ -38,7 +38,7 @@ export const BostonMetro = () => {
     return null;
   }
 
-  return <SparkLineBlock region={testRegion} />;
+  return <SparkLineBlock region={testRegion} onClickSparkLine={() => {}} />;
 };
 
 export const MaricopaCounty = () => {
@@ -54,5 +54,5 @@ export const MaricopaCounty = () => {
     return null;
   }
 
-  return <SparkLineBlock region={testRegion} />;
+  return <SparkLineBlock region={testRegion} onClickSparkLine={() => {}} />;
 };

--- a/src/components/NewLocationPage/SparkLineBlock/SparkLineBlock.style.tsx
+++ b/src/components/NewLocationPage/SparkLineBlock/SparkLineBlock.style.tsx
@@ -8,6 +8,7 @@ export const ChartTitleWrapper = styled.div`
   display: flex;
   margin-bottom: 0.5rem;
   line-height: 1.2;
+  letter-spacing: 0;
   ${Chevron} {
     transform: none;
     margin-left: 0.25rem;

--- a/src/components/NewLocationPage/SparkLineBlock/SparkLineBlock.style.tsx
+++ b/src/components/NewLocationPage/SparkLineBlock/SparkLineBlock.style.tsx
@@ -1,11 +1,13 @@
 import styled from 'styled-components';
 import { Link } from 'react-router-dom';
 import { Chevron } from '../Shared/Shared.style';
+import { BaseButton } from 'components/Button';
 import { mobileBreakpoint } from 'assets/theme/sizes';
 
 export const ChartTitleWrapper = styled.div`
   display: flex;
   margin-bottom: 0.5rem;
+  line-height: 1.2;
   ${Chevron} {
     transform: none;
     margin-left: 0.25rem;
@@ -41,6 +43,23 @@ export const StyledLink = styled(Link)`
   }
 
   &:hover {
+    ${Chevron} {
+      transform: translateX(6px);
+      transition: transform 0.06s ease-in-out;
+    }
+  }
+`;
+
+export const WrappingButton = styled(BaseButton)`
+  ${props => props.theme.fonts.regularBookMidWeight};
+  font-size: inherit;
+  text-transform: inherit;
+  text-align: left;
+  display: inherit;
+  padding: 0;
+
+  &:hover {
+    background-color: transparent;
     ${Chevron} {
       transform: translateX(6px);
       transition: transform 0.06s ease-in-out;

--- a/src/components/NewLocationPage/SparkLineBlock/SparkLineBlock.tsx
+++ b/src/components/NewLocationPage/SparkLineBlock/SparkLineBlock.tsx
@@ -4,8 +4,12 @@ import { SectionContainer, GrayTitle } from '../Shared/Shared.style';
 import { daysToChart } from './utils';
 import { useProjectionsFromRegion } from 'common/utils/model';
 import { Region } from 'common/regions';
+import { SparkLineMetric } from './utils';
 
-const SparkLineBlock: React.FC<{ region: Region }> = ({ region }) => {
+const SparkLineBlock: React.FC<{
+  region: Region;
+  onClickSparkLine: (metric: SparkLineMetric) => void;
+}> = ({ region, onClickSparkLine }) => {
   const projections = useProjectionsFromRegion(region);
 
   if (!projections || !projections.primary) {
@@ -15,7 +19,10 @@ const SparkLineBlock: React.FC<{ region: Region }> = ({ region }) => {
   return (
     <SectionContainer>
       <GrayTitle>Past {daysToChart} days</GrayTitle>
-      <SparkLineSet projection={projections.primary} />
+      <SparkLineSet
+        projection={projections.primary}
+        onClickSparkLine={onClickSparkLine}
+      />
     </SectionContainer>
   );
 };

--- a/src/components/NewLocationPage/SparkLineBlock/SparkLineSet.tsx
+++ b/src/components/NewLocationPage/SparkLineBlock/SparkLineSet.tsx
@@ -2,7 +2,11 @@ import React from 'react';
 import SparkLine from './SparkLine';
 import { ParentSize } from '@vx/responsive';
 import ChartTitle from './ChartTitle';
-import { StyledLink, GridContainer, GridItem } from './SparkLineBlock.style';
+import {
+  WrappingButton,
+  GridContainer,
+  GridItem,
+} from './SparkLineBlock.style';
 import { Projection } from 'common/models/Projection';
 import {
   SPARK_LINE_METRICS,
@@ -16,7 +20,10 @@ import { subtractTime, TimeUnit } from 'common/utils/time-utils';
 
 // TODO (chelsi) - update onClick scrolling functionality
 
-const SparkLineSet: React.FC<{ projection: Projection }> = ({ projection }) => {
+const SparkLineSet: React.FC<{
+  projection: Projection;
+  onClickSparkLine: (metric: SparkLineMetric) => void;
+}> = ({ projection, onClickSparkLine }) => {
   const dateTo = new Date();
   const dateFrom = subtractTime(dateTo, daysToChart, TimeUnit.DAYS);
   return (
@@ -34,7 +41,10 @@ const SparkLineSet: React.FC<{ projection: Projection }> = ({ projection }) => {
             <ParentSize>
               {({ width }) => (
                 <div style={{ width }}>
-                  <StyledLink to="#explore-chart" key={title}>
+                  <WrappingButton
+                    style={{ width }}
+                    onClick={() => onClickSparkLine(metric)}
+                  >
                     <ChartTitle title={title} />
                     <SparkLine
                       rawData={rawData}
@@ -42,7 +52,7 @@ const SparkLineSet: React.FC<{ projection: Projection }> = ({ projection }) => {
                       dateFrom={dateFrom}
                       dateTo={dateTo}
                     />
-                  </StyledLink>
+                  </WrappingButton>
                 </div>
               )}
             </ParentSize>

--- a/src/components/NewLocationPage/SparkLineBlock/utils.ts
+++ b/src/components/NewLocationPage/SparkLineBlock/utils.ts
@@ -1,5 +1,6 @@
 import { max as d3Max } from 'd3-array';
 import { cleanSeries } from 'components/Explore/utils';
+import { ExploreMetric } from 'components/Explore';
 import { Column, DatasetId, Projection } from 'common/models/Projection';
 import { fetchProjectionsRegion } from 'common/utils/model';
 import { assert } from 'common/utils';
@@ -24,6 +25,15 @@ export const SPARK_LINE_METRICS = [
   SparkLineMetric.DEATHS,
   SparkLineMetric.HOSPITALIZATIONS,
 ];
+
+// Used to select explore tab when clicking corresponding metric's spark line:
+export const SparkLineToExploreMetric: {
+  [metric in SparkLineMetric]: ExploreMetric;
+} = {
+  [SparkLineMetric.CASES]: ExploreMetric.CASES,
+  [SparkLineMetric.DEATHS]: ExploreMetric.DEATHS,
+  [SparkLineMetric.HOSPITALIZATIONS]: ExploreMetric.HOSPITALIZATIONS,
+};
 
 export interface Series {
   datasetId: DatasetId;

--- a/src/components/NewLocationPage/SummaryStat/DesktopSummaryStat.tsx
+++ b/src/components/NewLocationPage/SummaryStat/DesktopSummaryStat.tsx
@@ -23,7 +23,11 @@ const DesktopSummaryStat: React.FC<SummaryStatProps> = ({
         <StyledChevron />
       </Row>
       <Row>
-        <MetricValue value={formattedValue} iconColor={levelInfo.color} />
+        <MetricValue
+          value={formattedValue}
+          iconColor={levelInfo.color}
+          metric={metric}
+        />
         {hasSubLabel && <MetricSubLabel text={metricSubLabelText[metric]} />}
       </Row>
     </StatContent>

--- a/src/components/NewLocationPage/SummaryStat/MetricValue.tsx
+++ b/src/components/NewLocationPage/SummaryStat/MetricValue.tsx
@@ -1,14 +1,16 @@
 import React from 'react';
 import { Value, ValueWrapper } from './SummaryStat.style';
 import { CircleIcon } from '../Shared/Shared.style';
+import { Metric } from 'common/metricEnum';
 
-const MetricValue: React.FC<{ value: string; iconColor: string }> = ({
-  value,
-  iconColor,
-}) => {
+const MetricValue: React.FC<{
+  value: string;
+  iconColor: string;
+  metric: Metric;
+}> = ({ value, iconColor, metric }) => {
   return (
     <ValueWrapper>
-      <CircleIcon $iconColor={iconColor} />
+      {metric !== Metric.VACCINATIONS && <CircleIcon $iconColor={iconColor} />}
       <Value>{value}</Value>
     </ValueWrapper>
   );

--- a/src/components/NewLocationPage/SummaryStat/MobileSummaryStat.tsx
+++ b/src/components/NewLocationPage/SummaryStat/MobileSummaryStat.tsx
@@ -29,7 +29,11 @@ const MobileSummaryStat: React.FC<SummaryStatProps> = ({
         )}
       </Row>
       <Row>
-        <MetricValue value={formattedValue} iconColor={levelInfo.color} />
+        <MetricValue
+          value={formattedValue}
+          iconColor={levelInfo.color}
+          metric={metric}
+        />
         <StyledChevron />
       </Row>
     </StatContent>

--- a/src/components/NewLocationPage/SummaryStat/SummaryStat.style.tsx
+++ b/src/components/NewLocationPage/SummaryStat/SummaryStat.style.tsx
@@ -15,7 +15,7 @@ export const StatContent = styled.div`
 
 // put this somewhere in Shared:
 export const StyledChevron = styled(Chevron)`
-  transform: translateY(-2px);
+  transform: translateY(-3px);
   margin-left: 0.5rem;
 `;
 

--- a/src/components/NewLocationPage/SummaryStat/SummaryStat.style.tsx
+++ b/src/components/NewLocationPage/SummaryStat/SummaryStat.style.tsx
@@ -49,6 +49,7 @@ export const MetricLabel = styled.span`
   ${props => props.theme.fonts.regularBookMidWeight};
   font-size: 1rem;
   margin-right: 0.5rem;
+  letter-spacing: 0;
 
   @media (min-width: ${materialSMBreakpoint}) {
     margin-right: 0;

--- a/src/components/NewLocationPage/SummaryStat/SummaryStat.style.tsx
+++ b/src/components/NewLocationPage/SummaryStat/SummaryStat.style.tsx
@@ -15,7 +15,7 @@ export const StatContent = styled.div`
 
 // put this somewhere in Shared:
 export const StyledChevron = styled(Chevron)`
-  transform: translateY(-3px);
+  transform: translateY(-1px);
   margin-left: 0.5rem;
 `;
 
@@ -50,6 +50,7 @@ export const MetricLabel = styled.span`
   font-size: 1rem;
   margin-right: 0.5rem;
   letter-spacing: 0;
+  line-height: 1.2;
 
   @media (min-width: ${materialSMBreakpoint}) {
     margin-right: 0;


### PR DESCRIPTION
- Uses ref instead of hash link + maps `SparkLineMetric` to `ExploreMetric`
- Fixes alignment of chevron icons in spark line and summary stat labels
- Makes vax progress bar clickable
- Remove grey circle icon from percent vaccinated summary stat
- Fixes line height of notes block title
- Drops font weight of overall risk level label to 1.4 rem on iphone5