### PR TITLE
Spark line fix

### DIFF
--- a/src/components/NewLocationPage/SparkLineBlock/SparkLineBlock.style.tsx
+++ b/src/components/NewLocationPage/SparkLineBlock/SparkLineBlock.style.tsx
@@ -74,8 +74,7 @@ export const GridContainer = styled.div`
   grid-gap: 1.25rem;
 
   @media (min-width: ${mobileBreakpoint}) {
-    grid-template-rows: minmax(0, 1fr);
-    grid-auto-columns: minmax(0, 1fr);
+    grid-template-columns: repeat(auto-fit, minmax(5rem, 1fr));
   }
 `;
 

--- a/src/components/NewLocationPage/SparkLineBlock/SparkLineBlock.style.tsx
+++ b/src/components/NewLocationPage/SparkLineBlock/SparkLineBlock.style.tsx
@@ -70,13 +70,12 @@ export const WrappingButton = styled(BaseButton)`
 
 export const GridContainer = styled.div`
   display: grid;
-  grid-template-rows: repeat(2, minmax(0, 1fr));
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 10px;
+  grid-gap: 1.25rem;
 
   @media (min-width: ${mobileBreakpoint}) {
     grid-template-rows: minmax(0, 1fr);
-    grid-template-columns: repeat(3, minmax(0, 1fr));
+    grid-auto-columns: minmax(0, 1fr);
   }
 `;
 

--- a/src/components/NewLocationPage/SparkLineBlock/SparkLineSet.tsx
+++ b/src/components/NewLocationPage/SparkLineBlock/SparkLineSet.tsx
@@ -36,6 +36,9 @@ const SparkLineSet: React.FC<{
         );
         const rawData = getDataFromSeries(metricSeries[0], dateFrom);
         const smoothedData = getDataFromSeries(metricSeries[1], dateFrom);
+        if (!rawData.length || !smoothedData.length) {
+          return null;
+        }
         return (
           <GridItem key={title}>
             <ParentSize>

--- a/src/components/NewLocationPage/SparkLineBlock/utils.ts
+++ b/src/components/NewLocationPage/SparkLineBlock/utils.ts
@@ -90,7 +90,8 @@ export const sparkLinesMetricData: {
  * Returns both the raw and smoothed series for the given metric.
  * Raw series used by bar chart, smoothed series used by line chart.
  */
-export function getAllSeriesForMetric(
+
+export function getSparkLineSeriesFromProjection(
   seriesList: Series[],
   projection: Projection,
 ): SeriesWithData[] {
@@ -98,13 +99,6 @@ export function getAllSeriesForMetric(
     ...item,
     data: cleanSeries(projection.getDataset(item.datasetId)),
   }));
-}
-
-export function getSparkLineSeriesFromProjection(
-  seriesList: Series[],
-  projection: Projection,
-) {
-  return getAllSeriesForMetric(seriesList, projection);
 }
 
 function getMaxY(series: Column[]) {


### PR DESCRIPTION
Spark lines were causing whole page to crash in the case of there being no data for any of the 3 metrics. This fixes

To test-
-  [Inyo county, CA is crashing in the main preview link](https://covid-projections-git-casulin-redesign-demo-covidactnow.vercel.app/us/california-ca/county/inyo_county?s=1793712)
- [this includes the fix](https://covid-projections-git-casulin-sparklines-fix-covidactnow.vercel.app/us/california-ca/county/inyo_county/?s=1793712)