### PR TITLE
Some more explore cleanup which prevents it from re-rendering at all on homepage scroll.

### DIFF
--- a/src/common/hooks/index.ts
+++ b/src/common/hooks/index.ts
@@ -16,4 +16,5 @@ export { default as useLocationPageCompareSliderMap } from './useLocationPageCom
 export { default as useHomepageCompareSliderMap } from './useHomepageCompareSliderMap';
 export { default as useLocationSummariesForFips } from './useLocationSummariesForFips';
 export { default as useDynamicVaccineButton } from './useDynamicVaccineButton';
+export { default as useLogChanges } from './useLogChanges';
 export * from './useGeolocatedRegions';

--- a/src/common/hooks/useLogChanges.ts
+++ b/src/common/hooks/useLogChanges.ts
@@ -1,0 +1,34 @@
+import { useEffect, useRef } from 'react';
+
+/**
+ * Diagnostic hook to detect if any entries in the passed object have changed
+ * since the last call. This can be helpful to figure out why components are
+ * re-rendering, hooks are re-running, etc.
+ * Adapted from https://stackoverflow.com/a/51082563
+ *
+ * Example usage:
+ *
+ * const MyComponent = React.memo(props => {
+ *   useLogChanges(props);
+ *   ...
+ *   useLogChanges(hookDep);
+ *   useEffect(() => { ... }, [hookDep])
+ *   ...
+ * });
+ *
+ */
+export default function useLogChanges(props: { [key: string]: unknown }) {
+  const prev = useRef(props);
+  useEffect(() => {
+    const changedProps = Object.entries(props).reduce((ps, [k, v]) => {
+      if (prev.current[k] !== v) {
+        ps[k] = [prev.current[k], v];
+      }
+      return ps;
+    }, {} as { [key: string]: unknown });
+    if (Object.keys(changedProps).length > 0) {
+      console.log('Changed props:', changedProps);
+    }
+    prev.current = props;
+  });
+}

--- a/src/components/NationalText/NationalText.tsx
+++ b/src/components/NationalText/NationalText.tsx
@@ -1,13 +1,12 @@
 import React from 'react';
 import { Paragraph } from 'components/Markdown';
 import { Wrapper } from './NationalText.style';
+import { getNationalText } from './utils';
 
-const NationalText: React.FC<{
-  nationalSummaryText: React.ReactElement;
-}> = ({ nationalSummaryText }) => {
+const NationalText: React.FC = () => {
   return (
     <Wrapper>
-      <Paragraph>{nationalSummaryText}</Paragraph>
+      <Paragraph>{getNationalText()}</Paragraph>
     </Wrapper>
   );
 };

--- a/src/components/NationalText/index.ts
+++ b/src/components/NationalText/index.ts
@@ -1,5 +1,3 @@
 import NationalText from './NationalText';
-import { getNationalText } from './utils';
 
-export { getNationalText };
 export default NationalText;

--- a/src/screens/HomePage/HomePage.tsx
+++ b/src/screens/HomePage/HomePage.tsx
@@ -15,7 +15,6 @@ import Explore, { ExploreMetric } from 'components/Explore';
 import { formatMetatagDate } from 'common/utils';
 import { trackEvent, EventAction, EventCategory } from 'components/Analytics';
 import { getFilterLimit } from 'components/Search';
-import { getNationalText } from 'components/NationalText';
 import HomepageStructuredData from 'screens/HomePage/HomepageStructuredData';
 import { filterGeolocatedRegions } from 'common/regions';
 import { useGeolocatedRegions, useShowPastPosition } from 'common/hooks';
@@ -158,8 +157,7 @@ export default function HomePage() {
                 title="Cases, Deaths and Hospitalizations"
                 initialFipsList={initialFipsListForExplore}
                 defaultMetric={initialMetricForExplore}
-                initialChartIndigenousPopulations={false}
-                nationalSummaryText={getNationalText()}
+                showNationalSummary={true}
               />
             </Section>
             <SectionWrapper>

--- a/src/screens/HomePage/HomePage.tsx
+++ b/src/screens/HomePage/HomePage.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect, useState } from 'react';
+import React, { useRef, useEffect, useState, useMemo } from 'react';
 import Fade from '@material-ui/core/Fade';
 import { useLocation } from 'react-router-dom';
 
@@ -17,7 +17,7 @@ import { trackEvent, EventAction, EventCategory } from 'components/Analytics';
 import { getFilterLimit } from 'components/Search';
 import { getNationalText } from 'components/NationalText';
 import HomepageStructuredData from 'screens/HomePage/HomepageStructuredData';
-import regions, { filterGeolocatedRegions } from 'common/regions';
+import { filterGeolocatedRegions } from 'common/regions';
 import { useGeolocatedRegions, useShowPastPosition } from 'common/hooks';
 import HomePageHeader from 'components/Header/HomePageHeader';
 import {
@@ -31,7 +31,7 @@ import Toggle from './Toggle/Toggle';
 import HorizontalThermometer from 'components/HorizontalThermometer';
 import HomepageItems from 'components/RegionItem/HomepageItems';
 import { useBreakpoint, useFinalAutocompleteLocations } from 'common/hooks';
-import { getLargestMetroFipsForExplore } from 'screens/HomePage/utils';
+import { largestMetroFipsForExplore } from 'screens/HomePage/utils';
 import { DonateButtonHeart } from 'components/DonateButton';
 import GetVaccinatedBanner from 'components/Banner/GetVaccinatedBanner';
 
@@ -49,31 +49,17 @@ export default function HomePage() {
 
   const { userRegions, isLoading } = useGeolocatedRegions();
 
-  const largestMetroFips = getLargestMetroFipsForExplore();
-  const exploreGeoLocations = userRegions
-    ? filterGeolocatedRegions(userRegions).map(region => region.fipsCode)
-    : largestMetroFips;
+  const largestMetroFips = largestMetroFipsForExplore;
+  const exploreGeoLocations = useMemo(
+    () =>
+      userRegions
+        ? filterGeolocatedRegions(userRegions).map(region => region.fipsCode)
+        : largestMetroFips,
+    [largestMetroFips, userRegions],
+  );
 
-  const showRisingHospitalizations =
-    location.hash === '#explore-hospitalizations';
-  const risingHospitalizationStates = [
-    'DE',
-    'FL',
-    'IL',
-    'MD',
-    'MI',
-    'NH',
-    'PA',
-    'PR',
-  ]; // Updated on 21 April 2021 -- this is an illustrative list but not exhaustive
-  const initialFipsListForExplore = showRisingHospitalizations
-    ? risingHospitalizationStates.map(
-        state => regions.findByStateCodeStrict(state).fipsCode,
-      )
-    : exploreGeoLocations;
-  const initialMetricForExplore = showRisingHospitalizations
-    ? ExploreMetric.HOSPITALIZATIONS
-    : ExploreMetric.CASES;
+  const initialFipsListForExplore = exploreGeoLocations;
+  const initialMetricForExplore = ExploreMetric.CASES;
 
   // Location hash is uniquely set from vaccination banner button click
   const compareShowVaccinationsFirst = location.hash === '#compare';

--- a/src/screens/HomePage/utils.ts
+++ b/src/screens/HomePage/utils.ts
@@ -7,9 +7,13 @@ import { RegionDB } from 'common/regions';
  * Gets fips of 5 largest metro areas to set as homepage explore presets.
  * These are precomputed by hand using the function below.
  */
-export function getLargestMetroFipsForExplore() {
-  return ['35620', '31080', '16980', '19100', '26420'];
-}
+export const largestMetroFipsForExplore = [
+  '35620',
+  '31080',
+  '16980',
+  '19100',
+  '26420',
+];
 
 /**
  * Use this function to re-compute the values for the function above, if needed


### PR DESCRIPTION
This builds on #3509 with some non-essential additional cleanup / optimization.

* Remove no-longer-needed `initialChartIndigenousPopulations` prop.
* Change `nationalSummaryText` to a boolean instead of a whole JSX.Element.