### PR TITLE
Fix bolding of location name edge cases

### DIFF
--- a/src/components/NewLocationPage/LocationName/LocationName.stories.tsx
+++ b/src/components/NewLocationPage/LocationName/LocationName.stories.tsx
@@ -22,6 +22,21 @@ export const EastBatonRougeParish = () => {
   return <LocationName region={county} />;
 };
 
+export const DistrictOfColumbia = () => {
+  const county = regions.findByFipsCodeStrict('11001');
+  return <LocationName region={county} />;
+};
+
+export const ValdezCordovaCensusArea = () => {
+  const county = regions.findByFipsCodeStrict('02261');
+  return <LocationName region={county} />;
+};
+
+export const YakutatCityAndBorough = () => {
+  const county = regions.findByFipsCodeStrict('02282');
+  return <LocationName region={county} />;
+};
+
 export const AbileneMetro = () => {
   const metroArea = regions.findByFipsCodeStrict('10180');
   return <LocationName region={metroArea} />;

--- a/src/components/NewLocationPage/LocationName/LocationName.stories.tsx
+++ b/src/components/NewLocationPage/LocationName/LocationName.stories.tsx
@@ -12,6 +12,11 @@ export const NewYork = () => {
   return <LocationName region={state} />;
 };
 
+export const DistrictOfColumbiaState = () => {
+  const state = regions.findByFipsCodeStrict('11');
+  return <LocationName region={state} />;
+};
+
 export const FairFieldCounty = () => {
   const county = regions.findByFipsCodeStrict('09001');
   return <LocationName region={county} />;

--- a/src/components/NewLocationPage/LocationName/LocationName.tsx
+++ b/src/components/NewLocationPage/LocationName/LocationName.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Region, County, MetroArea } from 'common/regions';
-import { isMultiStateMetro, getRegionName } from './utils';
+import { isMultiStateMetro, getSplitRegionName } from './utils';
 import {
   RegionNameContainer,
   RegionNameText,
@@ -31,7 +31,7 @@ const UpdatedDate: React.FC = () => {
 
 function renderStyledRegionName(region: Region) {
   if (region instanceof County) {
-    const [countyName, countySuffix] = getRegionName(region);
+    const [countyName, countySuffix] = getSplitRegionName(region);
     return (
       <>
         <strong>{countyName}</strong>
@@ -40,7 +40,7 @@ function renderStyledRegionName(region: Region) {
       </>
     );
   } else if (region instanceof MetroArea) {
-    const [metroName, metroSuffix] = getRegionName(region);
+    const [metroName, metroSuffix] = getSplitRegionName(region);
     return (
       <>
         {isMultiStateMetro(region) ? (
@@ -58,7 +58,7 @@ function renderStyledRegionName(region: Region) {
       </>
     );
   } else {
-    return <strong>{getRegionName(region)}</strong>;
+    return <strong>{getSplitRegionName(region)}</strong>;
   }
 }
 

--- a/src/components/NewLocationPage/LocationName/LocationName.tsx
+++ b/src/components/NewLocationPage/LocationName/LocationName.tsx
@@ -45,7 +45,8 @@ const LocationName: React.FC<{ region: Region }> = ({ region }) => {
       <RegionNameContainer>
         <RegionNameText>
           <strong>{countyName}</strong>
-          {` ${countySuffix}, ${region.state.stateCode}`}
+          {countySuffix && ` ${countySuffix}`}
+          {`, ${region.state.stateCode}`}
         </RegionNameText>
         <UpdatedDate />
       </RegionNameContainer>
@@ -57,7 +58,8 @@ const LocationName: React.FC<{ region: Region }> = ({ region }) => {
         <RegionNameContainer>
           <RegionNameText>
             <strong>{metroName}</strong>
-            {` ${metroSuffix}, ${region.stateCodes}`}
+            {metroSuffix && ` ${metroSuffix}`}
+            {`, ${region.stateCodes}`}
           </RegionNameText>
           <UpdatedDate />
         </RegionNameContainer>
@@ -67,7 +69,7 @@ const LocationName: React.FC<{ region: Region }> = ({ region }) => {
         <RegionNameContainer>
           <RegionNameText>
             <strong>{`${metroName}, ${region.stateCodes}`}</strong>
-            {` ${metroSuffix}`}
+            {metroSuffix && ` ${metroSuffix}`}
           </RegionNameText>
           <UpdatedDate />
         </RegionNameContainer>

--- a/src/components/NewLocationPage/LocationName/LocationName.tsx
+++ b/src/components/NewLocationPage/LocationName/LocationName.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Region, State, County, MetroArea } from 'common/regions';
+import { Region, County, MetroArea } from 'common/regions';
 import { isMultiStateMetro, getRegionName } from './utils';
 import {
   RegionNameContainer,
@@ -29,55 +29,46 @@ const UpdatedDate: React.FC = () => {
   );
 };
 
-const LocationName: React.FC<{ region: Region }> = ({ region }) => {
-  if (region instanceof State) {
-    return (
-      <RegionNameContainer>
-        <RegionNameText>
-          <strong>{getRegionName(region)}</strong>
-        </RegionNameText>
-        <UpdatedDate />
-      </RegionNameContainer>
-    );
-  } else if (region instanceof County) {
+function renderStyledRegionName(region: Region) {
+  if (region instanceof County) {
     const [countyName, countySuffix] = getRegionName(region);
     return (
-      <RegionNameContainer>
-        <RegionNameText>
-          <strong>{countyName}</strong>
-          {countySuffix && ` ${countySuffix}`}
-          {`, ${region.state.stateCode}`}
-        </RegionNameText>
-        <UpdatedDate />
-      </RegionNameContainer>
+      <>
+        <strong>{countyName}</strong>
+        {countySuffix && ` ${countySuffix}`}
+        {`, ${region.state.stateCode}`}
+      </>
     );
   } else if (region instanceof MetroArea) {
     const [metroName, metroSuffix] = getRegionName(region);
-    if (isMultiStateMetro(region)) {
-      return (
-        <RegionNameContainer>
-          <RegionNameText>
+    return (
+      <>
+        {isMultiStateMetro(region) ? (
+          <>
             <strong>{metroName}</strong>
             {metroSuffix && ` ${metroSuffix}`}
             {`, ${region.stateCodes}`}
-          </RegionNameText>
-          <UpdatedDate />
-        </RegionNameContainer>
-      );
-    } else {
-      return (
-        <RegionNameContainer>
-          <RegionNameText>
+          </>
+        ) : (
+          <>
             <strong>{`${metroName}, ${region.stateCodes}`}</strong>
             {metroSuffix && ` ${metroSuffix}`}
-          </RegionNameText>
-          <UpdatedDate />
-        </RegionNameContainer>
-      );
-    }
+          </>
+        )}
+      </>
+    );
   } else {
-    return null;
+    return <strong>{getRegionName(region)}</strong>;
   }
+}
+
+const LocationName: React.FC<{ region: Region }> = ({ region }) => {
+  return (
+    <RegionNameContainer>
+      <RegionNameText>{renderStyledRegionName(region)}</RegionNameText>
+      <UpdatedDate />
+    </RegionNameContainer>
+  );
 };
 
 export default LocationName;

--- a/src/components/NewLocationPage/LocationName/utils.ts
+++ b/src/components/NewLocationPage/LocationName/utils.ts
@@ -1,26 +1,19 @@
 import { Region, State, County, MetroArea } from 'common/regions';
 
-const regionSuffixes = new Set([
-  'metro',
-  'city',
-  'county',
-  'parish',
-  'area',
-  'borough',
-]);
+const regionSuffixes = ['metro', 'city', 'county', 'parish', 'area', 'borough'];
 
 /**
  * Common indicators of regions with multiple-word suffixes
  * include region names with 'and' and 'census'
  * (e.g. 'City and Borough', 'Census Area').
  */
-const multipleWordSuffixIndicator = new Set(['and', 'census']);
+const multipleWordSuffixIndicator = ['and', 'census'];
 
 export function isMultiStateMetro(region: MetroArea): boolean {
   return region.stateCodes.includes('-');
 }
 
-export function getRegionName(region: Region) {
+export function getSplitRegionName(region: Region) {
   if (region instanceof State) {
     return [region.name];
   } else if (region instanceof County) {
@@ -36,13 +29,13 @@ function splitRegionName(regionName: string) {
   // Don't separate name from suffix for regions with multiple-word suffix.
   // Example: "Valdez-Cordova Census Area", "Yakutat City and Borough"
   if (
-    multipleWordSuffixIndicator.has(
+    multipleWordSuffixIndicator.includes(
       splitRegion[splitRegion.length - 2].toLowerCase(),
     )
   ) {
     suffix = null;
   } else if (
-    regionSuffixes.has(splitRegion[splitRegion.length - 1].toLowerCase())
+    regionSuffixes.includes(splitRegion[splitRegion.length - 1].toLowerCase())
   ) {
     suffix = splitRegion.pop();
   } else suffix = null;

--- a/src/components/NewLocationPage/LocationName/utils.ts
+++ b/src/components/NewLocationPage/LocationName/utils.ts
@@ -18,8 +18,8 @@ const regionSuffixes = [
 
 /**
  * Common indicators of regions with multiple-word suffixes
- * include region names with 'and' and 'census'
- * (e.g. 'City and Borough', 'Census Area').
+ * include region names with 'and' and 'census' as the second-last word of the region name.
+ * Examples: 'Census Area', 'City and Borough'
  */
 const multipleWordSuffixIndicator = ['and', 'census'];
 
@@ -42,18 +42,27 @@ export function getSplitRegionName(region: Region, condensed?: boolean) {
 function splitRegionName(regionName: string) {
   let suffix;
   const splitRegion = regionName.split(' ');
-  // Don't separate name from suffix for regions with multiple-word suffix.
-  // Example: "Valdez-Cordova Census Area", "Yakutat City and Borough"
+  /**
+   * Don't separate name from suffix for regions with multiple-word suffix,
+   * as it is unknown how many words exactly make up a multiple-word suffix.
+   * Example: 'Valdez-Cordova Census Area', 'Yakutat City and Borough'
+   */
   if (
     multipleWordSuffixIndicator.includes(
       splitRegion[splitRegion.length - 2].toLowerCase(),
     )
   ) {
     suffix = null;
+    /**
+     * Separate suffix from the region name if the suffix is a recognizable one-word suffix (most common case).
+     */
   } else if (
     regionSuffixes.includes(splitRegion[splitRegion.length - 1].toLowerCase())
   ) {
     suffix = splitRegion.pop();
+    /**
+     * Cases where it is unknown whether the region name contains a suffix.
+     */
   } else suffix = null;
   const regionNameMain = splitRegion.join(' ');
   return [regionNameMain, suffix];

--- a/src/components/NewLocationPage/LocationName/utils.ts
+++ b/src/components/NewLocationPage/LocationName/utils.ts
@@ -1,5 +1,21 @@
 import { Region, State, County, MetroArea } from 'common/regions';
 
+const regionSuffixes = new Set([
+  'metro',
+  'city',
+  'county',
+  'parish',
+  'area',
+  'borough',
+]);
+
+/**
+ * Common indicators of regions with multiple-word suffixes
+ * include region names with 'and' and 'census'
+ * (e.g. 'City and Borough', 'Census Area').
+ */
+const multipleWordSuffixIndicator = new Set(['and', 'census']);
+
 export function isMultiStateMetro(region: MetroArea): boolean {
   return region.stateCodes.includes('-');
 }
@@ -15,8 +31,21 @@ export function getRegionName(region: Region) {
 }
 
 function splitRegionName(regionName: string) {
+  let suffix;
   const splitRegion = regionName.split(' ');
-  const suffix = splitRegion.pop();
+  // Don't separate name from suffix for regions with multiple-word suffix.
+  // Example: "Valdez-Cordova Census Area", "Yakutat City and Borough"
+  if (
+    multipleWordSuffixIndicator.has(
+      splitRegion[splitRegion.length - 2].toLowerCase(),
+    )
+  ) {
+    suffix = null;
+  } else if (
+    regionSuffixes.has(splitRegion[splitRegion.length - 1].toLowerCase())
+  ) {
+    suffix = splitRegion.pop();
+  } else suffix = null;
   const regionNameMain = splitRegion.join(' ');
   return [regionNameMain, suffix];
 }

--- a/src/components/NewLocationPage/LocationName/utils.ts
+++ b/src/components/NewLocationPage/LocationName/utils.ts
@@ -16,13 +16,6 @@ const regionSuffixes = [
   'bor.',
 ];
 
-/**
- * Common indicators of regions with multiple-word suffixes
- * include region names with 'and' and 'census' as the second-last word of the region name.
- * Examples: 'Census Area', 'City and Borough'
- */
-const multipleWordSuffixIndicator = ['and', 'census'];
-
 export function isMultiStateMetro(region: MetroArea): boolean {
   return region.stateCodes.includes('-');
 }
@@ -39,31 +32,24 @@ export function getSplitRegionName(region: Region, condensed?: boolean) {
   }
 }
 
+/**
+ * We only split the region name into [main, suffix] and apply unique
+ * styles to each if it is a single word suffix (ie. 'County').
+ *
+ * We don't split the region name for regions with multiple-word suffix (ie. 'Census Area', 'City and Borough'),
+ * as it is unknown how many words exactly make up a multiple-word suffix.
+ * In this case, we style the whole region name the same.
+ */
 function splitRegionName(regionName: string) {
-  let suffix;
   const splitRegion = regionName.split(' ');
-  /**
-   * Don't separate name from suffix for regions with multiple-word suffix,
-   * as it is unknown how many words exactly make up a multiple-word suffix.
-   * Example: 'Valdez-Cordova Census Area', 'Yakutat City and Borough'
-   */
   if (
-    multipleWordSuffixIndicator.includes(
-      splitRegion[splitRegion.length - 2].toLowerCase(),
-    )
-  ) {
-    suffix = null;
-    /**
-     * Separate suffix from the region name if the suffix is a recognizable one-word suffix (most common case).
-     */
-  } else if (
     regionSuffixes.includes(splitRegion[splitRegion.length - 1].toLowerCase())
   ) {
-    suffix = splitRegion.pop();
-    /**
-     * Cases where it is unknown whether the region name contains a suffix.
-     */
-  } else suffix = null;
-  const regionNameMain = splitRegion.join(' ');
-  return [regionNameMain, suffix];
+    const suffix = splitRegion.pop();
+    const regionNameMain = splitRegion.join(' ');
+    return [regionNameMain, suffix];
+  } else {
+    const regionNameMain = splitRegion.join(' ');
+    return [regionNameMain];
+  }
 }

--- a/src/components/NewLocationPage/LocationName/utils.ts
+++ b/src/components/NewLocationPage/LocationName/utils.ts
@@ -1,6 +1,20 @@
 import { Region, State, County, MetroArea } from 'common/regions';
 
-const regionSuffixes = ['metro', 'city', 'county', 'parish', 'area', 'borough'];
+const regionSuffixes = [
+  'metro',
+  'city',
+  'municipality',
+  'municipio',
+  'mun.',
+  'county',
+  'co.',
+  'parish',
+  'par.',
+  'area',
+  'c.a.',
+  'borough',
+  'bor.',
+];
 
 /**
  * Common indicators of regions with multiple-word suffixes
@@ -13,11 +27,13 @@ export function isMultiStateMetro(region: MetroArea): boolean {
   return region.stateCodes.includes('-');
 }
 
-export function getSplitRegionName(region: Region) {
+export function getSplitRegionName(region: Region, condensed?: boolean) {
   if (region instanceof State) {
     return [region.name];
   } else if (region instanceof County) {
-    return splitRegionName(region.name);
+    return condensed
+      ? splitRegionName(region.abbreviation)
+      : splitRegionName(region.name);
   } else {
     return splitRegionName(region.shortName);
   }

--- a/src/components/SharedComponents/StyledRegionName/StyledRegionName.tsx
+++ b/src/components/SharedComponents/StyledRegionName/StyledRegionName.tsx
@@ -15,6 +15,17 @@ const StyledRegionName: React.FC<{
 }> = ({ showStateCode, region, condensed, truncateText = false }) => {
   const [regionNameMain, regionSuffix] = getSplitRegionName(region, condensed);
 
+  /**
+   * regionNameMain: Region name seperated from the suffix.
+   *
+   * regionSuffix: Detected suffix derived from the region name. If the region name contains a multiple-word suffix or does not contain a recognizable suffix, this variable is null.
+   *
+   * Examples:
+   *  'Fairfield County' => regionNameMain: 'Fairfield', regionSuffix: 'County'
+   *  'Valdez-Cordova Census Area' => regionNameMain: 'Valdez-Cordova', regionSuffix: null ('Census Area' contains 2 words).
+   *
+   * More info in splitRegionName() in utils.ts.
+   */
   return (
     <Wrapper $truncateText={truncateText}>
       {regionNameMain}

--- a/src/components/SharedComponents/StyledRegionName/StyledRegionName.tsx
+++ b/src/components/SharedComponents/StyledRegionName/StyledRegionName.tsx
@@ -3,7 +3,7 @@
  * Used in Compare table + geolocated region links on the homepage.
  */
 import React, { Fragment } from 'react';
-import { Region, getFormattedStateCode } from 'common/regions';
+import { Region, State, getFormattedStateCode } from 'common/regions';
 import { Suffix, Wrapper } from './StyledRegionName.style';
 import { getSplitRegionName } from 'components/NewLocationPage/LocationName/utils';
 
@@ -35,7 +35,7 @@ const StyledRegionName: React.FC<{
           {regionSuffix !== 'metro' ? ` ${regionSuffix}` : ` ${regionSuffix},`}
         </Suffix>
       )}
-      {!regionSuffix && region.regionType !== 'state' && <Suffix>,</Suffix>}
+      {!regionSuffix && !(region instanceof State) && <Suffix>,</Suffix>}
       {showStateCode && <Fragment>{getFormattedStateCode(region)}</Fragment>}
     </Wrapper>
   );

--- a/src/components/SharedComponents/StyledRegionName/StyledRegionName.tsx
+++ b/src/components/SharedComponents/StyledRegionName/StyledRegionName.tsx
@@ -3,9 +3,9 @@
  * Used in Compare table + geolocated region links on the homepage.
  */
 import React, { Fragment } from 'react';
-import { getRegionNameForRow } from 'common/utils/compare';
 import { Region, getFormattedStateCode } from 'common/regions';
 import { Suffix, Wrapper } from './StyledRegionName.style';
+import { getSplitRegionName } from 'components/NewLocationPage/LocationName/utils';
 
 const StyledRegionName: React.FC<{
   showStateCode: boolean;
@@ -13,11 +13,17 @@ const StyledRegionName: React.FC<{
   condensed?: boolean;
   truncateText?: boolean;
 }> = ({ showStateCode, region, condensed, truncateText = false }) => {
-  const [regionNameMain, regionSuffix] = getRegionNameForRow(region, condensed);
+  const [regionNameMain, regionSuffix] = getSplitRegionName(region, condensed);
 
   return (
     <Wrapper $truncateText={truncateText}>
-      {regionNameMain} {regionSuffix && <Suffix>{regionSuffix}</Suffix>}
+      {regionNameMain}
+      {regionSuffix && (
+        <Suffix>
+          {regionSuffix !== 'metro' ? ` ${regionSuffix}` : ` ${regionSuffix},`}
+        </Suffix>
+      )}
+      {!regionSuffix && region.regionType !== 'state' && <Suffix>,</Suffix>}
       {showStateCode && <Fragment>{getFormattedStateCode(region)}</Fragment>}
     </Wrapper>
   );

--- a/src/components/SharedComponents/StyledRegionName/StyledRegionName.tsx
+++ b/src/components/SharedComponents/StyledRegionName/StyledRegionName.tsx
@@ -18,7 +18,8 @@ const StyledRegionName: React.FC<{
   /**
    * regionNameMain: Region name seperated from the suffix.
    *
-   * regionSuffix: Detected suffix derived from the region name. If the region name contains a multiple-word suffix or does not contain a recognizable suffix, this variable is null.
+   * regionSuffix: Detected suffix derived from the region name.
+   * If the region name contains a multiple-word suffix or does not contain a recognizable suffix, this variable is null.
    *
    * Examples:
    *  'Fairfield County' => regionNameMain: 'Fairfield', regionSuffix: 'County'


### PR DESCRIPTION
This PR addresses issues of location name bolding for the new location page. It implements a check to see whether a region contains a suffix which is likely to be more than one word (e.g. "City and Borough", "Census Area"). If yes, then it will bold the whole name and suffix, for the following reasons:
- There is a high chance the above examples are not the only possible multi-word suffixes out there. Better to bold the whole name and suffix than guess where the name ends and the suffix starts and potentially bold in the wrong place.
- Most multi-word suffixes have the word "and" or "census" as the second last word.

For regions where the last word is not a recognizable suffix (e.g. "District of **Columbia**"), also bold the whole name.

Implementing the above logic after reading "County Variations" in https://en.wikipedia.org/wiki/County_(United_States) 😅  