### PR TITLE
Fix frozen location dropdown

### DIFF
--- a/src/components/Search/Homepage/HomepageSearchAutocomplete.tsx
+++ b/src/components/Search/Homepage/HomepageSearchAutocomplete.tsx
@@ -81,6 +81,7 @@ const HomepageSearchAutocomplete: React.FC<{
       EventAction.NAVIGATE,
       `Selected: ${value.fullName} (${input})`,
     );
+    setIsOpen(false);
     window.location.href = value.relativeUrl;
   };
 


### PR DESCRIPTION
This PR ensures the location dropdown closes when the user selects a location to navigate to.