### PR TITLE
Explore chart label tweaks.

### DIFF
--- a/src/components/Explore/DateMarker.tsx
+++ b/src/components/Explore/DateMarker.tsx
@@ -15,9 +15,9 @@ const DateMarker: React.FC<{
   seriesList: Series[];
   date: Date;
 }> = ({ left, seriesList, date }) => {
-  const [, seriesSmooth] = seriesList;
-  const pointSmooth = findPointByDate(seriesSmooth.data, date);
-  const dateToCompareTo = pointSmooth ? getColumnDate(pointSmooth) : date;
+  const series = seriesList[0];
+  const point = findPointByDate(series.data, date);
+  const dateToCompareTo = point ? getColumnDate(point) : date;
   const today = new Date();
   today.setHours(0, 0, 0, 0);
   return today < dateToCompareTo ? null : (

--- a/src/components/Explore/MultipleLocationsChart.tsx
+++ b/src/components/Explore/MultipleLocationsChart.tsx
@@ -136,7 +136,6 @@ const MultipleLocationsChart: React.FC<{
   const seriesList = sortSeriesByLast(unsortedSeriesList).filter(
     series => series.data.length > 0,
   );
-
   const dateFrom = new Date('2020-03-01');
   const dateTo = new Date();
   const maxY = getMaxBy<number>(seriesList, getY, 1);


### PR DESCRIPTION
* Have overlapping labels move upwards instead of down.
* Ensure we don't show a label for empty series (was showing up in the upper left at `(0, 0)`).

Fixes: 
* https://trello.com/c/Mgz6dgdr/1242-explore-chart-adjust-label-adjustment-function-to-go-up
* https://trello.com/c/ICgj0iIv/1322-imagepng

**Before:**
![image](https://user-images.githubusercontent.com/206364/117243701-95ad9400-adec-11eb-8b7f-be9b0cd34943.png)

**After:**
![image](https://user-images.githubusercontent.com/206364/117243724-9f36fc00-adec-11eb-99d6-c035a43a2f4d.png)
