### PR TITLE
Get location summaries synchronously from the main bundle if possible.

### DIFF
--- a/src/common/hooks/useLocationSummariesForFips.tsx
+++ b/src/common/hooks/useLocationSummariesForFips.tsx
@@ -1,16 +1,6 @@
-import { useEffect, useState } from 'react';
-import { LocationSummary, useSummaries } from 'common/location_summaries';
+import { useSummaries } from 'common/location_summaries';
 
 export default function useLocationSummariesForFips(fips: string) {
-  const [locationSummaryForFips, setLocationSummaryForFips] = useState<
-    LocationSummary
-  >();
   const summaries = useSummaries();
-
-  useEffect(() => {
-    if (summaries) {
-      setLocationSummaryForFips(summaries[fips]);
-    }
-  }, [summaries, fips]);
-  return locationSummaryForFips;
+  return summaries?.[fips] || null;
 }


### PR DESCRIPTION
Fixes https://trello.com/c/Mu3twLii/1306-fix-issue-where-the-screen-flashes-our-bottom-banner-when-navigating-to-location-pages-from-homepage

Because we had a hook calling a hook, setting a state variable, I think we had at least 2 or 3 async roundtrips before the location page header could render, which was probably enough time for some other work to get queued onto the JS event loop, bogging things down enough that there was ~1/2 second of time where the footer rendered but not the location page header... at least for me. 🤷 