### PR TITLE
send the path parameter to Amplitude

### DIFF
--- a/src/components/Analytics/amplitude.ts
+++ b/src/components/Analytics/amplitude.ts
@@ -25,8 +25,9 @@ export async function initializeAmplitude() {
 
 export function amplitudeLogEvent(eventType: string, properties: any) {
   getAmplitude().then(amplitude => {
+    const { pathname: path } = window.location;
     if (amplitude) {
-      amplitude.getInstance().logEvent(eventType, properties);
+      amplitude.getInstance().logEvent(eventType, { ...properties, path });
     }
   });
 }


### PR DESCRIPTION
[Trello](https://trello.com/c/gvTbTzxB/1291-add-current-path-to-all-amplitude-events-as-a-property) - Adds the pathname to the Amplitude events

### Example

```
{
 "eventCategory": "Explore",
 "eventAction": "Select",
 "eventLabel": "Adding Location",
 "eventValue": 2,
 "path": "/us/wyoming-wy/"
}
```