### PR TITLE
Expandable container

### DIFF
--- a/src/components/ExpandableContainer/ExpandableContainer.stories.tsx
+++ b/src/components/ExpandableContainer/ExpandableContainer.stories.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import ExpandableContainer from './ExpandableContainer';
+import { ExpandableSection } from 'components/ExpandableContainer';
+import VulnerabilitiesBlock from 'components/VulnerabilitiesBlock';
+import regions from 'common/regions';
+import { useCcviForFips } from 'common/hooks';
+export default {
+  title: 'Below the fold/Expandable container',
+  component: ExpandableContainer,
+};
+
+export const Example = () => {
+  const region = regions.findByFipsCodeStrict('06');
+  const ccviScores = useCcviForFips(region.fipsCode);
+
+  return (
+    <ExpandableContainer section={ExpandableSection.VULNERABILITIES}>
+      <VulnerabilitiesBlock scores={ccviScores} region={region} />
+    </ExpandableContainer>
+  );
+};

--- a/src/components/ExpandableContainer/ExpandableContainer.style.tsx
+++ b/src/components/ExpandableContainer/ExpandableContainer.style.tsx
@@ -1,0 +1,28 @@
+import styled from 'styled-components';
+import { COLOR_MAP } from 'common/colors';
+import { LargeOutlinedButton } from 'components/ButtonSystem';
+
+export const Container = styled.div``;
+
+export const ExpandButton = styled(LargeOutlinedButton)`
+  width: 100%;
+  border-radius: 0 0 4px 4px;
+  border: 1px solid ${COLOR_MAP.GREY_2};
+  box-shadow: 0 -5px 8px -5px ${COLOR_MAP.GREY_2};
+
+  &:hover {
+    border: 1px solid ${COLOR_MAP.GREY_2};
+  }
+`;
+
+export const InnerContent = styled.div<{
+  collapsedHeight: number;
+  collapsed: boolean;
+}>`
+  height: ${({ collapsed, collapsedHeight }) =>
+    collapsed ? `${collapsedHeight}px` : 'fit-content'};
+  overflow: hidden;
+  border: 1px solid ${COLOR_MAP.GREY_2};
+  border-bottom: none;
+  border-radius: 4px 4px 0 0;
+`;

--- a/src/components/ExpandableContainer/ExpandableContainer.tsx
+++ b/src/components/ExpandableContainer/ExpandableContainer.tsx
@@ -1,0 +1,51 @@
+import React, { useEffect, useState } from 'react';
+import { useLocation } from 'react-router-dom';
+import {
+  Container,
+  ExpandButton,
+  InnerContent,
+} from './ExpandableContainer.style';
+import {
+  ExpandableSection,
+  sectionDetails,
+} from 'components/ExpandableContainer';
+import { EventCategory } from 'components/Analytics';
+import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
+import ExpandLessIcon from '@material-ui/icons/ExpandLess';
+
+const ExpandableContainer: React.FC<{ section: ExpandableSection }> = ({
+  section,
+  children,
+}) => {
+  const [collapsed, setCollapsed] = useState(true);
+  const {
+    collapsedHeight,
+    tabTextCollapsed,
+    tabTextExpanded,
+    trackingLabel,
+  } = sectionDetails[section];
+
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    setCollapsed(true);
+  }, [pathname]);
+
+  return (
+    <Container>
+      <InnerContent collapsedHeight={collapsedHeight} collapsed={collapsed}>
+        {children}
+      </InnerContent>
+      <ExpandButton
+        onClick={() => setCollapsed(!collapsed)}
+        trackingCategory={EventCategory.NONE} // Change when implementing beyond storybook
+        trackingLabel={`Expand location page module: ${trackingLabel}`}
+        endIcon={collapsed ? <ExpandMoreIcon /> : <ExpandLessIcon />}
+      >
+        {collapsed ? tabTextCollapsed : tabTextExpanded}
+      </ExpandButton>
+    </Container>
+  );
+};
+
+export default ExpandableContainer;

--- a/src/components/ExpandableContainer/index.ts
+++ b/src/components/ExpandableContainer/index.ts
@@ -1,0 +1,26 @@
+export enum ExpandableSection {
+  VULNERABILITIES,
+  RECOMMENDATIONS,
+}
+
+interface sectionDetails {
+  collapsedHeight: number;
+  tabTextCollapsed: string;
+  tabTextExpanded: string;
+  trackingLabel: string;
+}
+
+export const sectionDetails: { [key in ExpandableSection]: sectionDetails } = {
+  [ExpandableSection.VULNERABILITIES]: {
+    collapsedHeight: 240,
+    tabTextExpanded: 'Less',
+    tabTextCollapsed: 'More',
+    trackingLabel: 'Vulnerabilities',
+  },
+  [ExpandableSection.RECOMMENDATIONS]: {
+    collapsedHeight: 240,
+    tabTextExpanded: 'Less',
+    tabTextCollapsed: 'More',
+    trackingLabel: 'Recommendations',
+  },
+};


### PR DESCRIPTION
Parent container for recommendations, vulnerabilities, and (eventually) compare/counties. This PR adds the component to storybook with the current vulnerabilities block dropped in as is for now. [Mocks](https://www.figma.com/file/JGqemgZwlG9e5DQbZpdKgy/Redesign?node-id=1370%3A88195)