### PR TITLE
Mobile mega menu fix

### DIFF
--- a/src/components/NavBar/MegaMenu/MegaMenu.tsx
+++ b/src/components/NavBar/MegaMenu/MegaMenu.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import Fade from '@material-ui/core/Fade';
 import { StyledMegaMenu } from './MegaMenu.style';
 import MenuContent from 'components/MenuContent';
 import { trackEvent, EventCategory, EventAction } from 'components/Analytics';
@@ -20,11 +21,11 @@ const MegaMenu: React.FC<{
   return (
     <>
       {isMobile && open && <LockBodyScroll />}
-      {open && (
+      <Fade in={open} timeout={0}>
         <StyledMegaMenu role="navigation" onMouseLeave={onMouseLeave}>
           <MenuContent onClick={onClick} />
         </StyledMegaMenu>
-      )}
+      </Fade>
     </>
   );
 };


### PR DESCRIPTION
The mobile mega menu is currently broken (links are not redirecting anywhere and menu is closing when clicking any of them). For some reason, adding the recently removed `Fade` wrapper back in fixes this bug. Pushing as a quick fix and going to investigate more