### PR TITLE
Add "After unsubscribe" page to solicit people to sign up for new project announcements.

### DIFF
--- a/scripts/alert_emails/utils.ts
+++ b/scripts/alert_emails/utils.ts
@@ -90,8 +90,10 @@ function generateAlertEmailContent(
     last_updated: lastUpdated,
     location_url: `${locationURL}?utm_source=risk_alerts&utm_medium=email`,
     subscribe_link: `https://covidactnow.org/alert_signup?utm_campaign=risk_alert_forward_subscribe&utm_source=risk_alerts&utm_medium=email`,
-    unsubscribe_link: `${unsubscribeURL}?email=${encodeURI(emailAddress)}`, // would be nice to know dev/staging/prod
-    feedback_subject_line: encodeURI(
+    unsubscribe_link: `${unsubscribeURL}?email=${encodeURIComponent(
+      emailAddress,
+    )}`, // would be nice to know dev/staging/prod
+    feedback_subject_line: encodeURIComponent(
       `[Alert Feedback] Alert for ${locationName} on ${lastUpdated}`,
     ),
     disclaimer,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -50,6 +50,12 @@ const ShareImage = lazy(() => import('screens/internal/ShareImage/ShareImage'));
 const AlertUnsubscribe = lazy(() =>
   import('screens/AlertUnsubscribe/AlertUnsubscribe'),
 );
+const AfterSubscribe = lazy(() =>
+  import('screens/Subscriptions/AfterSubscribe'),
+);
+const AfterUnsubscribe = lazy(() =>
+  import('screens/Subscriptions/AfterUnsubscribe'),
+);
 
 export default function App() {
   return (
@@ -81,6 +87,16 @@ export default function App() {
                     exact
                     path="/alert_unsubscribe"
                     component={AlertUnsubscribe}
+                  />
+                  <Route
+                    exact
+                    path="/after_subscribe"
+                    component={AfterSubscribe}
+                  />
+                  <Route
+                    exact
+                    path="/after_unsubscribe"
+                    component={AfterUnsubscribe}
                   />
                   <Route exact path="/donate" component={Donate} />
 

--- a/src/cms-content/vaccines/email-alerts.ts
+++ b/src/cms-content/vaccines/email-alerts.ts
@@ -109,7 +109,7 @@ export function getEmailAlertData(
     sourceName: `${region.fullName} Health Department`,
     sourceUrl: eligibilityInfoUrl,
     eligibilityUrl: eligibilityInfoUrl,
-    unsubscribeUrl: `https://covidactnow.org/alert_unsubscribe?email=${encodeURI(
+    unsubscribeUrl: `https://covidactnow.org/alert_unsubscribe?email=${encodeURIComponent(
       emailAddress,
     )}`,
     vaccinationSignupUrl,

--- a/src/screens/AlertUnsubscribe/AlertUnsubscribe.tsx
+++ b/src/screens/AlertUnsubscribe/AlertUnsubscribe.tsx
@@ -11,9 +11,8 @@ import {
 import { EventAction, EventCategory, trackEvent } from 'components/Analytics';
 import AutocompleteRegions from 'components/AutocompleteRegions';
 import regions, { Region } from 'common/regions';
+import { useHistory } from 'react-router-dom';
 
-const unsubscribedCopy =
-  'You are now unsubscribed and will no longer receive alerts.';
 const resubscribedCopy = 'Your COVID alert preferences have been updated.';
 
 async function getAlertsSubscriptions(): Promise<
@@ -26,6 +25,7 @@ async function getAlertsSubscriptions(): Promise<
 const AlertUnsubscribe = () => {
   const params = new URLSearchParams(window.location.search);
   const email = params.get('email') || '';
+  const history = useHistory();
 
   const [selectedLocations, setSelectedLocations] = useState<Region[]>([]);
   const [formSubmittedCopy, setFormSubmittedCopy] = useState('');
@@ -58,7 +58,8 @@ const AlertUnsubscribe = () => {
     trackEvent(EventCategory.ENGAGEMENT, EventAction.ALERTS_UNSUBSCRIBE);
     const subscriptions = await getAlertsSubscriptions();
     await subscriptions.doc(email).delete();
-    setFormSubmittedCopy(unsubscribedCopy);
+
+    history.push(`/after_unsubscribe?email=${encodeURIComponent(email)}`);
   }
 
   function handleSelectChange(selectedLocation: any) {

--- a/src/screens/Subscriptions/AfterSubscribe.tsx
+++ b/src/screens/Subscriptions/AfterSubscribe.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import { Wrapper, Header, BodyCopy } from './Subscriptions.style';
 
 const AfterSubscribe = () => {
@@ -11,7 +12,7 @@ const AfterSubscribe = () => {
           and will hear from us soon.
         </p>
         <p>
-          <a href="/">Click here</a> to return to the site.
+          <Link to="/">Click here</Link> to return to the site.
         </p>
       </BodyCopy>
     </Wrapper>

--- a/src/screens/Subscriptions/AfterSubscribe.tsx
+++ b/src/screens/Subscriptions/AfterSubscribe.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { Wrapper, Header, BodyCopy } from './Subscriptions.style';
+
+const AfterSubscribe = () => {
+  return (
+    <Wrapper>
+      <Header>Thank you</Header>
+      <BodyCopy>
+        <p>
+          Your subscription has been confirmed. You've been added to our list
+          and will hear from us soon.
+        </p>
+        <p>
+          <a href="/">Click here</a> to return to the site.
+        </p>
+      </BodyCopy>
+    </Wrapper>
+  );
+};
+
+export default AfterSubscribe;

--- a/src/screens/Subscriptions/AfterUnsubscribe.tsx
+++ b/src/screens/Subscriptions/AfterUnsubscribe.tsx
@@ -1,0 +1,94 @@
+import React, { createRef } from 'react';
+import { Wrapper, Header, BodyCopy } from './Subscriptions.style';
+import { EventAction, EventCategory } from 'components/Analytics';
+import ExternalLink from 'components/ExternalLink';
+import { LargeFilledButton } from 'components/ButtonSystem';
+
+const AfterUnsubscribe = () => {
+  const params = new URLSearchParams(window.location.search);
+  const email = params.get('email') || '';
+  const formRef = createRef<HTMLFormElement>();
+
+  const formAction = getFormActionLink(email);
+
+  const onSubscribeClick = async () => {
+    if (formRef?.current) {
+      formRef.current.action = await formAction;
+      formRef.current.submit();
+    }
+  };
+
+  return (
+    <Wrapper>
+      <Header>One last thing...</Header>
+      <BodyCopy>
+        <p>
+          Hi there! It looks like you're leaving us. We're sorry to see you go
+          and wanted to thank you for being a subscriber and supporter of Covid
+          Act Now.
+        </p>
+        <p>
+          Our organization will be working on some exciting new projects in the
+          future. Our mission is the same: to help people make informed
+          decisions by focusing on{' '}
+          <ExternalLink href="https://covidactnow.org/about">
+            data, transparency and accessibility
+          </ExternalLink>
+          .
+        </p>
+        <p>
+          If you would like to be alerted about our new ventures, click the
+          button below. And if there are any issues, topics or current events
+          that you think could benefit from the Covid Act Now approach please
+          let us know at{' '}
+          <a href="mailto:info@covidactnow.org">info@covidactnow.org</a>.
+        </p>
+      </BodyCopy>
+      <LargeFilledButton
+        onClick={onSubscribeClick}
+        trackingCategory={EventCategory.ENGAGEMENT}
+        trackingAction={EventAction.SUBSCRIBE}
+        trackingLabel="Future Projects (after-unsubscribe)"
+      >
+        Alert me about future projects
+      </LargeFilledButton>
+
+      <form
+        ref={formRef}
+        className="js-cm-form"
+        id="subForm"
+        method="POST"
+        data-id={CREATESEND_DATA_ID}
+      >
+        <input
+          className="js-cm-email-input qa-input-email"
+          id="fieldEmail"
+          name="cm-jrjjlhr-jrjjlhr"
+          style={{ display: 'none' }}
+          value={email}
+          readOnly
+        />
+      </form>
+    </Wrapper>
+  );
+};
+
+export default AfterUnsubscribe;
+
+const CREATESEND_DATA_ID =
+  '2BE4EF332AA2E32596E38B640E905619870E74723062A0063B893518B3DF0E78D82D32E2B527067C1448DA5B9AB1A453761A10515342B3F0E968D27B0371E31A';
+
+export async function getFormActionLink(emailAddress: string) {
+  let url = new URL('https://createsend.com/t/getsecuresubscribelink');
+  url.searchParams.append('email', encodeURIComponent(emailAddress));
+  url.searchParams.append('data', CREATESEND_DATA_ID);
+
+  const response = await fetch(url.toString(), {
+    method: 'POST',
+    headers: {
+      'Content-type': 'application/x-www-form-urlencoded',
+    },
+  });
+
+  return response.text();
+}

--- a/src/screens/Subscriptions/AfterUnsubscribe.tsx
+++ b/src/screens/Subscriptions/AfterUnsubscribe.tsx
@@ -9,6 +9,8 @@ const AfterUnsubscribe = () => {
   const email = params.get('email') || '';
   const formRef = createRef<HTMLFormElement>();
 
+  // We'll go ahead and prefetch the link so it's ready if/when they click the
+  // subscribe link.
   const formAction = getFormActionLink(email);
 
   const onSubscribeClick = async () => {
@@ -53,6 +55,10 @@ const AfterUnsubscribe = () => {
         Alert me about future projects
       </LargeFilledButton>
 
+      {/*
+          Form originally generated from https://covidactnow.createsend.com/subscribers/signupformbuilder/CF15EB108C36FA37
+          (including the weird IDs, etc.)
+         */}
       <form
         ref={formRef}
         className="js-cm-form"
@@ -64,9 +70,8 @@ const AfterUnsubscribe = () => {
           className="js-cm-email-input qa-input-email"
           id="fieldEmail"
           name="cm-jrjjlhr-jrjjlhr"
-          style={{ display: 'none' }}
+          type="hidden"
           value={email}
-          readOnly
         />
       </form>
     </Wrapper>

--- a/src/screens/Subscriptions/Subscriptions.style.tsx
+++ b/src/screens/Subscriptions/Subscriptions.style.tsx
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 import { Typography, Box } from '@material-ui/core';
+import { materialSMBreakpoint } from 'assets/theme/sizes';
 
 export const Wrapper = styled(Box)`
   max-width: 700px;
@@ -10,7 +11,7 @@ export const Wrapper = styled(Box)`
   flex-direction: column;
   padding: 1.2rem;
 
-  @media (min-width: 600px) {
+  @media (min-width: ${materialSMBreakpoint}) {
     align-items: center;
     margin: 100px auto 125px;
     min-height: 50vh;

--- a/src/screens/Subscriptions/Subscriptions.style.tsx
+++ b/src/screens/Subscriptions/Subscriptions.style.tsx
@@ -1,0 +1,32 @@
+import styled from 'styled-components';
+import { Typography, Box } from '@material-ui/core';
+
+export const Wrapper = styled(Box)`
+  max-width: 700px;
+  width: 100%;
+  margin: 80px auto 100px;
+  display: flex;
+  align-items: flex-start;
+  flex-direction: column;
+  padding: 1.2rem;
+
+  @media (min-width: 600px) {
+    align-items: center;
+    margin: 100px auto 125px;
+    min-height: 50vh;
+  }
+`;
+
+export const Header = styled(Typography)`
+  ${props => props.theme.fonts.regularBookBold};
+  font-size: 2rem;
+  margin-bottom: 2.5rem;
+  line-height: 1.2;
+`;
+
+export const BodyCopy = styled(Typography)`
+  ${props => props.theme.fonts.regularBook};
+  font-size: 1.1rem;
+  margin-bottom: 1.75rem;
+  line-height: 1.4;
+`;


### PR DESCRIPTION
* Add an "after unsubscribe" page that we'll tell Campaign Monitor to use when people unsubscribe from daily download or research rundown.
* Add an "After subscribe" page since the default campaign monitor one has a "click here to return to the site" link that just takes you back to our "after unsubscribe" page instead of the homepage.
* Make the alert unsubscribe button also go to the "after unsubscribe" page.
* Fix a bug (in a couple places) where we weren't properly escaping email addresses in links, leading to e.g. email addresses containing `+` not working properly.
