### PR TITLE
Unify section spacing

### DIFF
--- a/src/assets/theme/sizes.tsx
+++ b/src/assets/theme/sizes.tsx
@@ -1,12 +1,9 @@
-//TODO (Chelsi): rename these? 600px is generally used as our mobile breakpoint
-
 export const mobileBreakpoint = '800px';
+
 export const materialSMBreakpoint = '600px';
+
 // iPhone 5 screen is 320px wide. This breakpoint is used for iphone5 specific adjustments:
 export const smallPhoneBreakpoint = '321px';
 
-export default {
-  mobileBreakpoint,
-  materialSMBreakpoint,
-  smallPhoneBreakpoint,
-};
+// Breakpoint at which the county map changes to position:fixed on the location page:
+export const countyMapToFixedBreakpoint = '1320px';

--- a/src/components/Compare/Compare.style.tsx
+++ b/src/components/Compare/Compare.style.tsx
@@ -40,17 +40,17 @@ export const Wrapper = styled.div<{
 }>`
   max-width: ${({ $isHomepage }) => ($isHomepage ? '1000px' : '900px')};
   width: 100%;
-  margin: ${({ $isModal }) => ($isModal ? '0 auto' : '0 auto')};
+  margin: 0 auto;
   background: ${({ $isModal }) => $isModal && `${COLOR_MAP.GRAY_BODY_COPY}`};
   max-height: ${({ $isModal }) => $isModal && '100vh'};
 
   @media (min-width: 600px) {
-    margin: ${({ $isModal }) => ($isModal ? '0 auto' : '0 auto')};
+    margin: 0 auto;
     max-height: ${({ $isModal }) => ($isModal ? '80vh' : 'unset')};
   }
 
   @media (min-width: 1060px) {
-    margin: ${({ $isModal }) => ($isModal ? '0 auto' : '0 auto')};
+    margin: 0 auto;
   }
 
   @media (min-width: 1350px) {
@@ -58,7 +58,7 @@ export const Wrapper = styled.div<{
   }
 
   @media (min-width: 1750px) {
-    margin: ${({ $isModal }) => ($isModal ? '0 auto' : '0 auto')};
+    margin: 0 auto;
   }
 
   table {

--- a/src/components/Compare/Compare.style.tsx
+++ b/src/components/Compare/Compare.style.tsx
@@ -45,20 +45,20 @@ export const Wrapper = styled.div<{
   max-height: ${({ $isModal }) => $isModal && '100vh'};
 
   @media (min-width: 600px) {
-    margin: ${({ $isModal }) => ($isModal ? '0 auto' : '3rem auto')};
+    margin: ${({ $isModal }) => ($isModal ? '0 auto' : '0 auto')};
     max-height: ${({ $isModal }) => ($isModal ? '80vh' : 'unset')};
   }
 
   @media (min-width: 1060px) {
-    margin: ${({ $isModal }) => ($isModal ? '0 auto' : '3rem auto 2rem')};
+    margin: ${({ $isModal }) => ($isModal ? '0 auto' : '0 auto')};
   }
 
   @media (min-width: 1350px) {
-    margin: ${({ $isModal }) => ($isModal ? '0 auto' : '3rem 445px 2rem auto')};
+    margin: ${({ $isModal }) => ($isModal ? '0 auto' : '0 445px 0 auto')};
   }
 
   @media (min-width: 1750px) {
-    margin: ${({ $isModal }) => ($isModal ? '0 auto' : '3rem auto 2rem')};
+    margin: ${({ $isModal }) => ($isModal ? '0 auto' : '0 auto')};
   }
 
   table {
@@ -418,7 +418,7 @@ export const Row = styled(TableRow)<{
 
 export const Footer = styled.div`
   display: flex;
-  padding: 1.25rem 1rem;
+  padding: 1.25rem 1rem 0;
   color: ${COLOR_MAP.GRAY_BODY_COPY};
   font-size: 0.875rem;
   justify-content: space-between;
@@ -443,7 +443,7 @@ export const Footer = styled.div`
   }
 
   @media (min-width: 932px) {
-    padding: 1.25rem 0;
+    padding: 1.25rem 0 0;
   }
 `;
 
@@ -473,11 +473,11 @@ export const Header = styled.div<{ isHomepage?: boolean }>`
   font-weight: bold;
   font-size: 1.5rem;
   justify-content: space-between;
-  margin: ${({ isHomepage }) => (isHomepage ? '12px 0 0' : '28px 0 12px')};
+  margin: ${({ isHomepage }) => (isHomepage ? '12px 0 0' : '0 0 12px')};
 
   @media (min-width: 600px) {
     font-size: ${({ isHomepage }) => (isHomepage ? '2rem' : '1.5rem')};
-    margin: ${({ isHomepage }) => (isHomepage ? '0' : '20px 0 12px')};
+    margin: ${({ isHomepage }) => (isHomepage ? '0' : '0 0 12px')};
   }
 `;
 

--- a/src/components/Explore/Explore.style.ts
+++ b/src/components/Explore/Explore.style.ts
@@ -16,7 +16,7 @@ function palette(props: any) {
 }
 
 export const Container = styled.div`
-  margin: ${theme.spacing(4)}px 0;
+  padding-bottom: 1.5rem; // Leaves some space below the 'xx days ago' tooltip
 `;
 
 export const Header = styled.div`

--- a/src/components/Explore/Explore.tsx
+++ b/src/components/Explore/Explore.tsx
@@ -263,8 +263,8 @@ const Explore: React.FunctionComponent<{
 
     return (
       <Styles.Container ref={exploreRef}>
-        <Grid container spacing={1}>
-          <Grid container item sm={9} xs={12} alignContent="center">
+        <Grid container>
+          <Grid container item sm={9} xs={12}>
             <LocationPageSectionHeader>{title}</LocationPageSectionHeader>
           </Grid>
           <Grid item sm xs={12}>

--- a/src/components/LocationPage/ChartBlock.tsx
+++ b/src/components/LocationPage/ChartBlock.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 import {
   LocationPageSectionHeader,
   ChartDescription,
@@ -21,6 +21,7 @@ import { getSourcesForMetric } from 'common/utils/provenance';
 import { Sources } from 'api/schema/RegionSummaryWithTimeseries';
 import { getRegionMetricOverride } from 'cms-content/region-overrides';
 import { MarkdownContent } from 'components/Markdown';
+import LocationPageBlock from './LocationPageBlock';
 
 function ChartBlock(props: {
   chartRef: React.RefObject<HTMLDivElement>;
@@ -48,7 +49,7 @@ function ChartBlock(props: {
   const chartHeight = isMobile ? 280 : 400;
 
   return (
-    <Fragment>
+    <LocationPageBlock>
       <HeaderWrapper>
         <LocationPageSectionHeader ref={props.chartRef}>
           {getMetricNameExtended(metric)}
@@ -86,7 +87,7 @@ function ChartBlock(props: {
           <DisclaimerWrapper>{disclaimerContent}</DisclaimerWrapper>
         </>
       )}
-    </Fragment>
+    </LocationPageBlock>
   );
 }
 

--- a/src/components/LocationPage/ChartBlock.tsx
+++ b/src/components/LocationPage/ChartBlock.tsx
@@ -21,7 +21,6 @@ import { getSourcesForMetric } from 'common/utils/provenance';
 import { Sources } from 'api/schema/RegionSummaryWithTimeseries';
 import { getRegionMetricOverride } from 'cms-content/region-overrides';
 import { MarkdownContent } from 'components/Markdown';
-import LocationPageBlock from './LocationPageBlock';
 
 function ChartBlock(props: {
   chartRef: React.RefObject<HTMLDivElement>;
@@ -49,7 +48,7 @@ function ChartBlock(props: {
   const chartHeight = isMobile ? 280 : 400;
 
   return (
-    <LocationPageBlock>
+    <>
       <HeaderWrapper>
         <LocationPageSectionHeader ref={props.chartRef}>
           {getMetricNameExtended(metric)}
@@ -87,7 +86,7 @@ function ChartBlock(props: {
           <DisclaimerWrapper>{disclaimerContent}</DisclaimerWrapper>
         </>
       )}
-    </LocationPageBlock>
+    </>
   );
 }
 

--- a/src/components/LocationPage/ChartsHolder.style.tsx
+++ b/src/components/LocationPage/ChartsHolder.style.tsx
@@ -19,7 +19,7 @@ export const HeaderWrapperStyles = css`
   display: flex;
   flex-direction: row;
   justify-content: space-between;
-  margin: 3.5rem 0 0.25rem;
+  margin: 0 0 0.25rem;
 
   @media (min-width: ${materialSMBreakpoint}) {
     flex-direction: column;
@@ -84,12 +84,12 @@ export const BetaTag = styled.div`
 
 export const DisclaimerWrapper = styled.div`
   max-width: 600px;
-  padding: 1.5rem 0 0.75rem;
+  padding: 1.5rem 0 0;
   color: ${COLOR_MAP.GRAY_BODY_COPY};
   font-size: 0.875rem;
 
   @media (min-width: ${materialSMBreakpoint}) {
-    padding: 1.5rem 0 2rem;
+    padding: 1.5rem 0 0;
   }
 
   p {

--- a/src/components/LocationPage/ChartsHolder.tsx
+++ b/src/components/LocationPage/ChartsHolder.tsx
@@ -176,20 +176,22 @@ const ChartsHolder = ({ region, chartId }: ChartsHolderProps) => {
         <LocationPageBlock id="vulnerabilities">
           <VulnerabilitiesBlock scores={ccviScores} region={region} />
         </LocationPageBlock>
-        <LocationPageBlock>
-          {!projections ? (
-            <LoadingScreen />
-          ) : (
+        {!projections ? (
+          <LoadingScreen />
+        ) : (
+          <LocationPageBlock>
             <Recommendations
               projections={projections}
               recommendationsRef={recommendationsRef}
             />
-          )}
-          {ALL_METRICS.map(metric => (
-            <ErrorBoundary key={metric}>
-              {!projections ? (
-                <LoadingScreen />
-              ) : (
+          </LocationPageBlock>
+        )}
+        {ALL_METRICS.map(metric => (
+          <ErrorBoundary key={metric}>
+            {!projections ? (
+              <LoadingScreen />
+            ) : (
+              <LocationPageBlock>
                 <ChartBlock
                   metric={metric}
                   projections={projections}
@@ -198,10 +200,10 @@ const ChartsHolder = ({ region, chartId }: ChartsHolderProps) => {
                   region={region}
                   stats={stats}
                 />
-              )}
-            </ErrorBoundary>
-          ))}
-        </LocationPageBlock>
+              </LocationPageBlock>
+            )}
+          </ErrorBoundary>
+        ))}
         <LocationPageBlock ref={exploreChartRef} id="explore-chart">
           <Explore
             initialFipsList={initialFipsList}

--- a/src/components/LocationPage/ChartsHolder.tsx
+++ b/src/components/LocationPage/ChartsHolder.tsx
@@ -210,7 +210,7 @@ const ChartsHolder = ({ region, chartId }: ChartsHolderProps) => {
           />
         </LocationPageBlock>
       </ChartContentWrapper>
-      <div ref={shareBlockRef} id="recommendationsTest">
+      <div ref={shareBlockRef}>
         <ShareModelBlock
           region={region}
           projections={projections}

--- a/src/components/LocationPage/LocationPageBlock.style.ts
+++ b/src/components/LocationPage/LocationPageBlock.style.ts
@@ -10,10 +10,11 @@ export const BlockContainer = styled.div`
 
   @media (min-width: 932px) {
     max-width: 900px;
+    width: 100%;
     margin: 4.25rem auto 0;
   }
 
-  @media (min-width: 1350px) {
+  @media (min-width: 1320px) {
     margin: 4.25rem 445px 0 auto;
   }
 

--- a/src/components/LocationPage/LocationPageBlock.style.ts
+++ b/src/components/LocationPage/LocationPageBlock.style.ts
@@ -15,7 +15,7 @@ export const BlockContainer = styled.div`
     margin: 4.25rem auto 0;
   }
 
-  @media (min-width: ${mapToFixedBreakpoint}) {
+  @media (min-width: ${mapToFixedBreakpoint}px) {
     margin: 4.25rem 445px 0 auto;
   }
 

--- a/src/components/LocationPage/LocationPageBlock.style.ts
+++ b/src/components/LocationPage/LocationPageBlock.style.ts
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 import { materialSMBreakpoint } from 'assets/theme/sizes';
+import { mapToFixedBreakpoint } from 'components/NewLocationPage/CountyMap/CountyMap.style';
 
 export const BlockContainer = styled.div`
   margin: 3rem 1rem 0;
@@ -14,7 +15,7 @@ export const BlockContainer = styled.div`
     margin: 4.25rem auto 0;
   }
 
-  @media (min-width: 1320px) {
+  @media (min-width: ${mapToFixedBreakpoint}) {
     margin: 4.25rem 445px 0 auto;
   }
 

--- a/src/components/LocationPage/LocationPageBlock.style.ts
+++ b/src/components/LocationPage/LocationPageBlock.style.ts
@@ -1,6 +1,8 @@
 import styled from 'styled-components';
-import { materialSMBreakpoint } from 'assets/theme/sizes';
-import { mapToFixedBreakpoint } from 'components/NewLocationPage/CountyMap/CountyMap.style';
+import {
+  materialSMBreakpoint,
+  countyMapToFixedBreakpoint,
+} from 'assets/theme/sizes';
 
 export const BlockContainer = styled.div`
   margin: 3rem 1rem 0;
@@ -15,7 +17,7 @@ export const BlockContainer = styled.div`
     margin: 4.25rem auto 0;
   }
 
-  @media (min-width: ${mapToFixedBreakpoint}px) {
+  @media (min-width: ${countyMapToFixedBreakpoint}) {
     margin: 4.25rem 445px 0 auto;
   }
 

--- a/src/components/LocationPage/LocationPageBlock.style.ts
+++ b/src/components/LocationPage/LocationPageBlock.style.ts
@@ -1,19 +1,24 @@
 import styled from 'styled-components';
+import { materialSMBreakpoint } from 'assets/theme/sizes';
 
 export const BlockContainer = styled.div`
-  margin: 0 1rem;
+  margin: 3rem 1rem 0;
+
+  @media (min-width: ${materialSMBreakpoint}) {
+    margin-top: 4.5rem;
+  }
 
   @media (min-width: 932px) {
     max-width: 900px;
-    margin: 0 auto;
+    margin: 4.25rem auto 0;
   }
 
   @media (min-width: 1350px) {
-    margin: 0 445px 0 auto;
+    margin: 4.25rem 445px 0 auto;
   }
 
   @media (min-width: 1750px) {
-    margin: 0 auto;
+    margin: 4.25rem auto 0;
   }
 
   @media print {

--- a/src/components/NewLocationPage/AboveTheFold/AboveTheFold.style.tsx
+++ b/src/components/NewLocationPage/AboveTheFold/AboveTheFold.style.tsx
@@ -1,8 +1,11 @@
 import styled from 'styled-components';
 import { COLOR_MAP } from 'common/colors';
 import { maxContentWidth } from 'components/NewLocationPage/Shared/Shared.style';
-import { materialSMBreakpoint, mobileBreakpoint } from 'assets/theme/sizes';
-import { mapToFixedBreakpoint } from '../CountyMap';
+import {
+  materialSMBreakpoint,
+  mobileBreakpoint,
+  countyMapToFixedBreakpoint,
+} from 'assets/theme/sizes';
 
 export const MainWrapper = styled.div`
   background-color: ${COLOR_MAP.GREY_0};
@@ -23,7 +26,7 @@ export const HeaderContainer = styled.div`
     align-items: center;
   }
 
-  @media (min-width: ${mapToFixedBreakpoint}px) {
+  @media (min-width: ${countyMapToFixedBreakpoint}) {
     align-items: start;
   }
 `;
@@ -68,7 +71,7 @@ export const GridContainer = styled.div<{ showNote: boolean }>`
       'alerts map'`};
   }
 
-  @media (min-width: ${mapToFixedBreakpoint}px) {
+  @media (min-width: ${countyMapToFixedBreakpoint}) {
     margin: 0 350px 0 auto;
     grid-template-columns: 1fr 1fr;
     grid-template-areas: ${({ showNote }) =>
@@ -107,7 +110,7 @@ export const GridItemMap = styled.div`
   grid-area: map;
   align-self: start;
 
-  @media (min-width: ${mapToFixedBreakpoint}px) {
+  @media (min-width: ${countyMapToFixedBreakpoint}) {
     display: none;
   }
 `;
@@ -120,7 +123,7 @@ export const GridItemNote = styled.div`
 // so there is no extra grid-gap for an empty grid item:
 export const MapOutsideGrid = styled.div`
   display: none;
-  @media (min-width: ${mapToFixedBreakpoint}px) {
+  @media (min-width: ${countyMapToFixedBreakpoint}) {
     display: inherit;
   }
 `;

--- a/src/components/NewLocationPage/CountyMap/CountyMap.style.tsx
+++ b/src/components/NewLocationPage/CountyMap/CountyMap.style.tsx
@@ -7,8 +7,8 @@ export const mapToFixedBreakpoint = 1320;
 
 export const PinnedContainer = css`
   position: fixed;
-  top: 115px; // estimating here, edit
-  right: 40px; //edit when put into context
+  top: 116px; // navBar height (84) + above the fold top padding (2rem)
+  right: 40px;
   box-shadow: 0px 2px 16px rgba(0, 0, 0, 0.08);
   z-index: 901;
 `;

--- a/src/components/NewLocationPage/CountyMap/CountyMap.style.tsx
+++ b/src/components/NewLocationPage/CountyMap/CountyMap.style.tsx
@@ -1,9 +1,11 @@
 import styled, { css } from 'styled-components';
-import { materialSMBreakpoint } from 'assets/theme/sizes';
+import {
+  materialSMBreakpoint,
+  countyMapToFixedBreakpoint,
+} from 'assets/theme/sizes';
 import { FixedAspectRatioContainer } from 'components/FixedAspectRatio/FixedAspectRatio.style';
 
 const desktopMapWidth = 320;
-export const mapToFixedBreakpoint = 1320;
 
 export const PinnedContainer = css`
   position: fixed;
@@ -26,7 +28,7 @@ export const MapContainer = styled.div`
     width: ${desktopMapWidth}px;
   }
 
-  @media (min-width: ${mapToFixedBreakpoint}px) {
+  @media (min-width: ${countyMapToFixedBreakpoint}) {
     ${PinnedContainer};
   }
 `;

--- a/src/components/NewLocationPage/CountyMap/index.ts
+++ b/src/components/NewLocationPage/CountyMap/index.ts
@@ -1,4 +1,1 @@
-import { mapToFixedBreakpoint } from './CountyMap.style';
-
-export { mapToFixedBreakpoint };
 export { default as CountyMap } from './CountyMap';

--- a/src/components/Recommend/Recommend.style.tsx
+++ b/src/components/Recommend/Recommend.style.tsx
@@ -5,32 +5,6 @@ import { LinkButton } from 'components/Button';
 import { materialSMBreakpoint } from 'assets/theme/sizes';
 import { MarkdownContent } from 'components/Markdown';
 
-/*
-TODO (chelsi): these breakpoints and margins are the same as
-the location header and compare. we should centralize them.
-*/
-export const Wrapper = styled.div`
-  max-width: 900px;
-  width: 100%;
-  margin: 1rem auto;
-
-  @media (min-width: ${materialSMBreakpoint}) {
-    margin: 3rem auto;
-  }
-
-  @media (min-width: 1060px) {
-    margin: 3rem auto 2rem;
-  }
-
-  @media (min-width: 1350px) {
-    margin: 3rem 445px 2rem auto;
-  }
-
-  @media (min-width: 1750px) {
-    margin: 3rem auto 2rem;
-  }
-`;
-
 export const Column = styled.div`
   display: flex;
   flex-direction: column;

--- a/src/components/Recommend/Recommend.tsx
+++ b/src/components/Recommend/Recommend.tsx
@@ -3,7 +3,6 @@ import chunk from 'lodash/chunk';
 import ceil from 'lodash/ceil';
 import partition from 'lodash/partition';
 import {
-  Wrapper,
   HeaderCopy,
   Intro,
   RecommendationsContainer,
@@ -125,7 +124,7 @@ const Recommend = (props: {
   const recommendationsColumns = isMobile ? halvedInOrder : partitionedByIndex;
 
   return (
-    <Wrapper ref={recommendationsRef}>
+    <div ref={recommendationsRef}>
       <Header introCopy={introCopy} locationName={locationName} />
       <RecommendationsContainer>
         {recommendationsColumns.map((half, j) => {
@@ -157,7 +156,7 @@ const Recommend = (props: {
         shareQuote={shareQuote}
         feedbackFormUrl={feedbackFormUrl}
       />
-    </Wrapper>
+    </div>
   );
 };
 

--- a/src/components/VaccinationEligibilityBlock/VaccinationEligibilityBlock.style.ts
+++ b/src/components/VaccinationEligibilityBlock/VaccinationEligibilityBlock.style.ts
@@ -5,8 +5,10 @@ import { COLOR_MAP } from 'common/colors';
 export const Container = styled.div``;
 
 export const Section = styled.div`
-  &:not(:last-child) {
-    margin-bottom: 16px;
+  margin-bottom: 1rem;
+
+  &:last-of-type {
+    margin-bottom: 0;
   }
 `;
 

--- a/src/components/VaccinationEligibilityBlock/VaccinationEligibilityBlock.tsx
+++ b/src/components/VaccinationEligibilityBlock/VaccinationEligibilityBlock.tsx
@@ -100,16 +100,16 @@ const VaccinationEligibilityBlock: React.FC<{ region: Region }> = ({
           sourceName={sourceName}
         />
       </Section>
-      <Section>
-        {!allAdultsEligible && (
+      {!allAdultsEligible && (
+        <Section>
           <Source>
             Updated Mondays and Thursdays from:{' '}
             <ExternalLink href={sourceUrl} onClick={trackSourceClick}>
               {sourceName}
             </ExternalLink>
           </Source>
-        )}
-      </Section>
+        </Section>
+      )}
     </Container>
   );
 };

--- a/src/components/VaccinationEligibilityBlock/VaccinationEligibilityBlock.tsx
+++ b/src/components/VaccinationEligibilityBlock/VaccinationEligibilityBlock.tsx
@@ -76,7 +76,7 @@ const VaccinationEligibilityBlock: React.FC<{ region: Region }> = ({
 
   return (
     <Container>
-      <Heading2>Vaccine eligibility</Heading2>
+      <Heading2 style={{ marginTop: 0 }}>Vaccine eligibility</Heading2>
       {allAdultsEligible ? (
         <AllAdultsEligiblePanel />
       ) : (

--- a/src/screens/HomePage/HomePage.style.tsx
+++ b/src/screens/HomePage/HomePage.style.tsx
@@ -27,12 +27,9 @@ export const SectionWrapper = styled.div`
 `;
 
 export const Section = styled.div`
-  margin-bottom: 2.5rem;
-  margin-left: 1rem;
-  margin-right: 1rem;
+  margin: 3.5rem 1rem;
   @media (min-width: ${mobileBreakpoint}) {
-    margin-left: 0;
-    margin-right: 0;
+    margin: 3.5rem 0;
   }
 `;
 

--- a/src/screens/HomePage/HomePage.tsx
+++ b/src/screens/HomePage/HomePage.tsx
@@ -153,8 +153,7 @@ export default function HomePage() {
                 vulnerabilityFirst={compareShowVulnerabilityFirst}
               />
             </Section>
-            <Section ref={exploreSectionRef}>
-              <div id="explore-hospitalizations"></div>
+            <Section ref={exploreSectionRef} id="explore-hospitalizations">
               <Explore
                 title="Cases, Deaths and Hospitalizations"
                 initialFipsList={initialFipsListForExplore}

--- a/src/screens/LocationPage/LocationPage.tsx
+++ b/src/screens/LocationPage/LocationPage.tsx
@@ -19,7 +19,7 @@ function WithSearchInNav({ region }: LocationPageProps) {
   const hasScrolled = useShowPastPosition(850);
 
   return (
-    <div>
+    <>
       <EnsureSharingIdInUrl />
       <AppMetaTags
         canonicalUrl={region.canonicalUrl}
@@ -33,10 +33,8 @@ function WithSearchInNav({ region }: LocationPageProps) {
         hasScrolled={hasScrolled}
         region={region}
       />
-      <div>
-        <ChartsHolder chartId={chartId} region={region} />
-      </div>
-    </div>
+      <ChartsHolder chartId={chartId} region={region} />
+    </>
   );
 }
 


### PR DESCRIPTION
Sections on the location page had inconsistent spacing--this unifies the spacing by removing top/bottom margin from inner elements (headers, footers, inner containers) and places it on the shared `LocationBlock` component. Also cleans up homepage spacing a little bit for compare+explore