### PR TITLE
Location page scroll bug

### DIFF
--- a/src/components/LocationPage/ChartsHolder.tsx
+++ b/src/components/LocationPage/ChartsHolder.tsx
@@ -78,12 +78,15 @@ const ChartsHolder = ({ region, chartId }: ChartsHolderProps) => {
     }
   }, [hash]);
 
+  const [scrolledWithRef, setScrolledWithRef] = useState(false);
+
   useEffect(() => {
     const scrollToChart = () => {
       const timeoutId = setTimeout(() => {
         if (chartId in metricRefs) {
           const metricRef = metricRefs[(chartId as unknown) as Metric];
-          if (metricRef.current) {
+          if (metricRef.current && !scrolledWithRef) {
+            setScrolledWithRef(true);
             scrollTo(metricRef.current);
           }
         }
@@ -94,7 +97,8 @@ const ChartsHolder = ({ region, chartId }: ChartsHolderProps) => {
     const scrollToRecommendations = () => {
       const timeoutId = setTimeout(() => {
         if (isRecommendationsShareUrl) {
-          if (recommendationsRef.current) {
+          if (recommendationsRef.current && !scrolledWithRef) {
+            setScrolledWithRef(true);
             scrollTo(recommendationsRef.current);
           }
         }
@@ -104,7 +108,7 @@ const ChartsHolder = ({ region, chartId }: ChartsHolderProps) => {
 
     scrollToChart();
     scrollToRecommendations();
-  }, [chartId, metricRefs, isRecommendationsShareUrl]);
+  }, [chartId, metricRefs, isRecommendationsShareUrl, scrolledWithRef]);
 
   const initialFipsList = useMemo(() => [region.fipsCode], [region.fipsCode]);
 

--- a/src/screens/HomePage/HomePage.tsx
+++ b/src/screens/HomePage/HomePage.tsx
@@ -1,7 +1,6 @@
 import React, { useRef, useEffect, useState, useMemo } from 'react';
 import Fade from '@material-ui/core/Fade';
 import { useLocation } from 'react-router-dom';
-
 import Map from 'components/Map/Map';
 import { NavBarSearch } from 'components/NavBar';
 import { NavAllOtherPages } from 'components/NavBar';


### PR DESCRIPTION
Chart/recommendations share URLs keep scrolling you back to the shared element. i.e. https://covidactnow.org/us/massachusetts-ma/chart/5 keeps jumping back to the daily new cases chart when you scroll away from it. This fix works, but there might be a better way?