### PR TITLE
Mega menu bug

### DIFF
--- a/src/components/NavBar/NavAllOtherPages/NavAllOtherPages.tsx
+++ b/src/components/NavBar/NavAllOtherPages/NavAllOtherPages.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { ClickAwayListener } from '@material-ui/core';
+// import { ClickAwayListener } from '@material-ui/core';
 import Logo from 'assets/images/logo';
 import MegaMenu from 'components/NavBar/MegaMenu/MegaMenu';
 import * as Style from 'components/NavBar/NavBar.style';
@@ -76,16 +76,16 @@ const NavAllOtherPages: React.FC<{
         <Style.Spacer />
         <>
           {renderSecondaryElement()}
-          <ClickAwayListener onClickAway={closeMenu}>
-            <Style.IconButton
-              onClick={onClickHamburger}
-              edge="end"
-              onMouseEnter={onHoverHamburger}
-            >
-              <Style.MenuLabel>Menu</Style.MenuLabel>
-              {menuOpen ? <Style.CloseIcon /> : <Style.MenuIcon />}
-            </Style.IconButton>
-          </ClickAwayListener>
+          {/* <ClickAwayListener onClickAway={closeMenu}> */}
+          <Style.IconButton
+            onClick={onClickHamburger}
+            edge="end"
+            onMouseEnter={onHoverHamburger}
+          >
+            <Style.MenuLabel>Menu</Style.MenuLabel>
+            {menuOpen ? <Style.CloseIcon /> : <Style.MenuIcon />}
+          </Style.IconButton>
+          {/* </ClickAwayListener> */}
         </>
         <MegaMenu {...menuProps} />
       </Style.Toolbar>

--- a/src/components/NavBar/NavAllOtherPages/NavAllOtherPages.tsx
+++ b/src/components/NavBar/NavAllOtherPages/NavAllOtherPages.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-// import { ClickAwayListener } from '@material-ui/core';
 import Logo from 'assets/images/logo';
 import MegaMenu from 'components/NavBar/MegaMenu/MegaMenu';
 import * as Style from 'components/NavBar/NavBar.style';
@@ -76,7 +75,6 @@ const NavAllOtherPages: React.FC<{
         <Style.Spacer />
         <>
           {renderSecondaryElement()}
-          {/* <ClickAwayListener onClickAway={closeMenu}> */}
           <Style.IconButton
             onClick={onClickHamburger}
             edge="end"
@@ -85,7 +83,6 @@ const NavAllOtherPages: React.FC<{
             <Style.MenuLabel>Menu</Style.MenuLabel>
             {menuOpen ? <Style.CloseIcon /> : <Style.MenuIcon />}
           </Style.IconButton>
-          {/* </ClickAwayListener> */}
         </>
         <MegaMenu {...menuProps} />
       </Style.Toolbar>

--- a/src/components/NavBar/NavLocationPage/NavLocationPage.tsx
+++ b/src/components/NavBar/NavLocationPage/NavLocationPage.tsx
@@ -4,7 +4,7 @@
  */
 import React, { Fragment } from 'react';
 import { Link } from 'react-router-dom';
-import { ClickAwayListener } from '@material-ui/core';
+// import { ClickAwayListener } from '@material-ui/core';
 import ArrowBack from '@material-ui/icons/ArrowBack';
 import Logo from 'assets/images/logo';
 import MegaMenu from 'components/NavBar/MegaMenu/MegaMenu';
@@ -112,16 +112,16 @@ const NavLocationPage: React.FC<{
             {renderSecondaryElement()}
           </Style.GridItemSecondaryEl>
           <Style.GridItemMenuIcon>
-            <ClickAwayListener onClickAway={closeMenu}>
-              <Style.IconButton
-                onClick={onClickHamburger}
-                edge="end"
-                onMouseEnter={onHoverHamburger}
-              >
-                <Style.MenuLabel>Menu</Style.MenuLabel>
-                {menuOpen ? <Style.CloseIcon /> : <Style.MenuIcon />}
-              </Style.IconButton>
-            </ClickAwayListener>
+            {/* <ClickAwayListener onClickAway={closeMenu}> */}
+            <Style.IconButton
+              onClick={onClickHamburger}
+              edge="end"
+              onMouseEnter={onHoverHamburger}
+            >
+              <Style.MenuLabel>Menu</Style.MenuLabel>
+              {menuOpen ? <Style.CloseIcon /> : <Style.MenuIcon />}
+            </Style.IconButton>
+            {/* </ClickAwayListener> */}
           </Style.GridItemMenuIcon>
         </Style.GridContainer>
         <MegaMenu {...menuProps} />

--- a/src/components/NavBar/NavLocationPage/NavLocationPage.tsx
+++ b/src/components/NavBar/NavLocationPage/NavLocationPage.tsx
@@ -4,7 +4,6 @@
  */
 import React, { Fragment } from 'react';
 import { Link } from 'react-router-dom';
-// import { ClickAwayListener } from '@material-ui/core';
 import ArrowBack from '@material-ui/icons/ArrowBack';
 import Logo from 'assets/images/logo';
 import MegaMenu from 'components/NavBar/MegaMenu/MegaMenu';
@@ -106,13 +105,13 @@ const NavLocationPage: React.FC<{
               placeholder={
                 hasScrolled ? region.shortName : 'City, county, state, or zip'
               }
+              setMenuOpen={setMenuOpen}
             />
           </Style.GridItemSearch>
           <Style.GridItemSecondaryEl>
             {renderSecondaryElement()}
           </Style.GridItemSecondaryEl>
           <Style.GridItemMenuIcon>
-            {/* <ClickAwayListener onClickAway={closeMenu}> */}
             <Style.IconButton
               onClick={onClickHamburger}
               edge="end"
@@ -121,7 +120,6 @@ const NavLocationPage: React.FC<{
               <Style.MenuLabel>Menu</Style.MenuLabel>
               {menuOpen ? <Style.CloseIcon /> : <Style.MenuIcon />}
             </Style.IconButton>
-            {/* </ClickAwayListener> */}
           </Style.GridItemMenuIcon>
         </Style.GridContainer>
         <MegaMenu {...menuProps} />

--- a/src/components/NavBar/Search/Search.tsx
+++ b/src/components/NavBar/Search/Search.tsx
@@ -12,7 +12,14 @@ const Search: React.FC<{
   WrappingDiv?: any /* Chelsi: fix this any */;
   region?: Region;
   placeholder?: string;
-}> = ({ menuOpen, WrappingDiv = Wrapper, region, placeholder }) => {
+  setMenuOpen: React.Dispatch<React.SetStateAction<boolean>>;
+}> = ({
+  menuOpen,
+  WrappingDiv = Wrapper,
+  region,
+  placeholder,
+  setMenuOpen,
+}) => {
   const theme = useContext(ThemeContext);
 
   const { pathname } = useLocation();
@@ -35,6 +42,7 @@ const Search: React.FC<{
           menuOpen={menuOpen}
           region={region}
           placeholder={placeholder || 'City, county, state, or zip'}
+          setMenuOpen={setMenuOpen}
         />
       </WrappingDiv>
     </ThemeProvider>

--- a/src/components/PageContent/PageContent.tsx
+++ b/src/components/PageContent/PageContent.tsx
@@ -24,7 +24,9 @@ const PageContent: React.FC<{ sidebarItems: TocItem[] }> = ({
   return (
     <Fragment>
       <NavAllOtherPages
-        renderSearch={() => <NavBarSearch menuOpen={menuOpen} />}
+        renderSearch={() => (
+          <NavBarSearch menuOpen={menuOpen} setMenuOpen={setMenuOpen} />
+        )}
         renderSecondaryElement={() => <DesktopOnlyDonateButton />}
         menuOpen={menuOpen}
         setMenuOpen={setMenuOpen}

--- a/src/components/Search/SearchAutocomplete/SearchAutocomplete.stories.tsx
+++ b/src/components/Search/SearchAutocomplete/SearchAutocomplete.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import SearchAutocomplete from './SearchAutocomplete';
 import { getFilterLimit } from 'components/Search';
 import {
@@ -20,11 +20,13 @@ export const Home = () => {
   };
   const geolocatedRegions = getGeolocatedRegions(geolocation, countyToZipMap);
   const locations = getFinalAutocompleteLocations(geolocatedRegions);
+  const [menuOpen, setMenuOpen] = useState(false);
   return (
     <SearchAutocomplete
       locations={locations}
       filterLimit={getFilterLimit()}
-      menuOpen={false}
+      menuOpen={menuOpen}
+      setMenuOpen={setMenuOpen}
       placeholder="City, county, state, or zip"
     />
   );

--- a/src/components/Search/SearchAutocomplete/SearchAutocomplete.tsx
+++ b/src/components/Search/SearchAutocomplete/SearchAutocomplete.tsx
@@ -31,6 +31,7 @@ const SearchAutocomplete: React.FC<{
   menuOpen: boolean;
   region?: Region;
   placeholder: string;
+  setMenuOpen: React.Dispatch<React.SetStateAction<boolean>>;
 }> = ({
   locations,
   filterLimit,
@@ -38,6 +39,7 @@ const SearchAutocomplete: React.FC<{
   menuOpen,
   region,
   placeholder,
+  setMenuOpen,
 }) => {
   const [input, setInput] = useState('');
   /* We only check for a zipcode match when the input is all numbers and has a length of 5: */
@@ -153,6 +155,7 @@ const SearchAutocomplete: React.FC<{
               EventAction.FOCUS,
               'Search Focused',
             );
+            setMenuOpen(false); // Makes sure mega menu is closed when clicking into the search bar
             setIsOpen(true);
             if (setHideMapToggle) {
               setHideMapToggle(true);

--- a/src/screens/Donate/Donate.tsx
+++ b/src/screens/Donate/Donate.tsx
@@ -43,7 +43,9 @@ const Donate: React.FC = () => {
   return (
     <>
       <NavAllOtherPages
-        renderSearch={() => <NavBarSearch menuOpen={menuOpen} />}
+        renderSearch={() => (
+          <NavBarSearch menuOpen={menuOpen} setMenuOpen={setMenuOpen} />
+        )}
         renderSecondaryElement={() => <DesktopOnlyDonateButton />}
         menuOpen={menuOpen}
         setMenuOpen={setMenuOpen}

--- a/src/screens/HomePage/HomePage.tsx
+++ b/src/screens/HomePage/HomePage.tsx
@@ -91,7 +91,11 @@ export default function HomePage() {
   const showDonateButton = !isMobileNavBar || (isMobileNavBar && !hasScrolled);
 
   const renderNavBarSearch = () => (
-    <>{hasScrolled && <NavBarSearch menuOpen={menuOpen} />}</>
+    <>
+      {hasScrolled && (
+        <NavBarSearch menuOpen={menuOpen} setMenuOpen={setMenuOpen} />
+      )}
+    </>
   );
 
   const renderDonateButton = () => (
@@ -132,6 +136,7 @@ export default function HomePage() {
                 filterLimit={getFilterLimit()}
                 menuOpen={menuOpen}
                 placeholder="City, county, state, or zip"
+                setMenuOpen={setMenuOpen}
               />
               <HomepageItems isLoading={isLoading} userRegions={userRegions} />
               <Toggle


### PR DESCRIPTION
`ClickAwayListener` was breaking the mega menu and causing it to close on mobile when attempting to click a link (and overall, on prod, if you click anywhere within the mega menu that isn't a link, the menu closes). This removes `ClickAwayListener` altogether, which was originally implemented to make sure that the mega menu and search bar were never open at the same time. Instead, we now call `setMenuOpen(false)` when clicking into the search bar.