### PR TITLE
fix category for expand/collapse event

### DIFF
--- a/src/components/ExpandableContainer/ExpandableContainer.tsx
+++ b/src/components/ExpandableContainer/ExpandableContainer.tsx
@@ -25,6 +25,7 @@ const ExpandableContainer: React.FC<ExpandableContainerProps> = ({
   tabTextCollapsed,
   tabTextExpanded,
   trackingLabel,
+  trackingCategory,
   children,
 }) => {
   const [collapsed, setCollapsed] = useState(true);
@@ -49,7 +50,7 @@ const ExpandableContainer: React.FC<ExpandableContainerProps> = ({
       </InnerContent>
       <ExpandButton
         onClick={() => setCollapsed(!collapsed)}
-        trackingCategory={EventCategory.NONE} // Change when implementing beyond storybook
+        trackingCategory={trackingCategory}
         trackingLabel={`${collapsed ? 'Expand' : 'Collapse'}: ${trackingLabel}`}
         endIcon={collapsed ? <ExpandMoreIcon /> : <ExpandLessIcon />}
         collapsed={collapsed}


### PR DESCRIPTION
@schamp discovered this bug (see [discussion on Slack](https://covidactnow.slack.com/archives/C01JP05V28G/p1621731934006700)), this just adds the event category to the expand/collapse action.