### PR TITLE
Restore CTAs in vulnerability block

### DIFF
--- a/src/components/VulnerabilitiesBlock/VulnerabilitiesBlockInner.tsx
+++ b/src/components/VulnerabilitiesBlock/VulnerabilitiesBlockInner.tsx
@@ -16,6 +16,7 @@ import { RegionCcviItem } from 'common/data';
 import { getSurgoUrlByRegion } from 'common/ccvi/index';
 import { EventCategory } from 'components/Analytics';
 import { TextButton } from 'components/ButtonSystem';
+import OpenInNewIcon from '@material-ui/icons/OpenInNew';
 
 const VulnerabilitiesBlockInner: React.FC<{
   scores: RegionCcviItem;
@@ -56,6 +57,7 @@ const VulnerabilitiesBlockInner: React.FC<{
               href={surgoUrl}
               trackingCategory={EventCategory.VULNERABILITIES}
               trackingLabel={'Surgo link'}
+              endIcon={<OpenInNewIcon />}
             >
               {surgoUrlCta}
             </TextButton>

--- a/src/components/VulnerabilitiesBlock/VulnerabilitiesBlockInner.tsx
+++ b/src/components/VulnerabilitiesBlock/VulnerabilitiesBlockInner.tsx
@@ -14,7 +14,7 @@ import { getCcviLevelNameFromScore } from 'common/ccvi';
 import { Region, County } from 'common/regions';
 import { RegionCcviItem } from 'common/data';
 import { getSurgoUrlByRegion } from 'common/ccvi/index';
-import { EventAction, EventCategory, trackEvent } from 'components/Analytics';
+import { EventCategory } from 'components/Analytics';
 import { TextButton } from 'components/ButtonSystem';
 
 const VulnerabilitiesBlockInner: React.FC<{
@@ -54,13 +54,8 @@ const VulnerabilitiesBlockInner: React.FC<{
           <SummaryText>
             <TextButton
               href={surgoUrl}
-              onClick={() =>
-                trackEvent(
-                  EventCategory.VULNERABILITIES,
-                  EventAction.CLICK_LINK,
-                  'Surgo link',
-                )
-              }
+              trackingCategory={EventCategory.VULNERABILITIES}
+              trackingLabel={'Surgo link'}
             >
               {surgoUrlCta}
             </TextButton>

--- a/src/components/VulnerabilitiesBlock/VulnerabilitiesBlockInner.tsx
+++ b/src/components/VulnerabilitiesBlock/VulnerabilitiesBlockInner.tsx
@@ -11,8 +11,12 @@ import {
 import CcviThermometer from './CcviThermometer/CcviThermometer';
 import { renderRegionDescription } from 'common/ccvi/renderRegionDescription';
 import { getCcviLevelNameFromScore } from 'common/ccvi';
-import { Region } from 'common/regions';
+import { Region, County } from 'common/regions';
 import { RegionCcviItem } from 'common/data';
+import { getSurgoUrlByRegion } from 'common/ccvi/index';
+import ExternalLink from 'components/ExternalLink';
+import { EventAction, EventCategory, trackEvent } from 'components/Analytics';
+import { COLOR_MAP } from 'common/colors';
 
 const VulnerabilitiesBlockInner: React.FC<{
   scores: RegionCcviItem;
@@ -30,6 +34,10 @@ const VulnerabilitiesBlockInner: React.FC<{
   const communityVulnerabilityQuote =
     'Communities with higher vulnerability have pre-existing economic, social, and physical conditions that may make it hard to respond to and recover from a COVID outbreak.';
 
+  const surgoUrl = getSurgoUrlByRegion(region);
+  const surgoUrlCta =
+    region instanceof County ? 'View by neighborhood' : 'View by county';
+
   return (
     <Content>
       <FirstColumn>
@@ -43,6 +51,23 @@ const VulnerabilitiesBlockInner: React.FC<{
           {region.shortName} {regionDescription}
         </SummaryText>
         <SummaryText>{communityVulnerabilityQuote}</SummaryText>
+        {surgoUrl && (
+          <SummaryText>
+            <ExternalLink
+              href={surgoUrl}
+              onClick={() =>
+                trackEvent(
+                  EventCategory.VULNERABILITIES,
+                  EventAction.CLICK_LINK,
+                  'Surgo link',
+                )
+              }
+              style={{ color: COLOR_MAP.NEW_BLUE.BASE }}
+            >
+              {surgoUrlCta}
+            </ExternalLink>
+          </SummaryText>
+        )}
       </FirstColumn>
       <SecondColumn>
         <TextSmall>WHAT MAKES THIS AREA VULNERABLE</TextSmall>

--- a/src/components/VulnerabilitiesBlock/VulnerabilitiesBlockInner.tsx
+++ b/src/components/VulnerabilitiesBlock/VulnerabilitiesBlockInner.tsx
@@ -14,9 +14,8 @@ import { getCcviLevelNameFromScore } from 'common/ccvi';
 import { Region, County } from 'common/regions';
 import { RegionCcviItem } from 'common/data';
 import { getSurgoUrlByRegion } from 'common/ccvi/index';
-import ExternalLink from 'components/ExternalLink';
 import { EventAction, EventCategory, trackEvent } from 'components/Analytics';
-import { COLOR_MAP } from 'common/colors';
+import { TextButton } from 'components/ButtonSystem';
 
 const VulnerabilitiesBlockInner: React.FC<{
   scores: RegionCcviItem;
@@ -53,7 +52,7 @@ const VulnerabilitiesBlockInner: React.FC<{
         <SummaryText>{communityVulnerabilityQuote}</SummaryText>
         {surgoUrl && (
           <SummaryText>
-            <ExternalLink
+            <TextButton
               href={surgoUrl}
               onClick={() =>
                 trackEvent(
@@ -62,10 +61,9 @@ const VulnerabilitiesBlockInner: React.FC<{
                   'Surgo link',
                 )
               }
-              style={{ color: COLOR_MAP.NEW_BLUE.BASE }}
             >
               {surgoUrlCta}
-            </ExternalLink>
+            </TextButton>
           </SummaryText>
         )}
       </FirstColumn>


### PR DESCRIPTION
This PR restores CTAs in the vulnerability block on state and county location pages.