### PR TITLE
Add metro areas to zip-based search

### DIFF
--- a/src/common/regions/utils.ts
+++ b/src/common/regions/utils.ts
@@ -153,7 +153,7 @@ function countyIncludesZip(
   return countyToZipMap[county.fipsCode]?.includes(zipCode);
 }
 
-function getCountyRegionFromZipCode(
+export function getCountyRegionFromZipCode(
   zipCode: string,
   countyToZipMap: CountyToZipMap,
 ): Region | undefined {

--- a/src/components/NavBar/NavLocationPage/NavLocationPage.tsx
+++ b/src/components/NavBar/NavLocationPage/NavLocationPage.tsx
@@ -101,7 +101,6 @@ const NavLocationPage: React.FC<{
             <NavBarSearch
               menuOpen={menuOpen}
               WrappingDiv={Fragment}
-              region={region}
               placeholder={
                 hasScrolled ? region.shortName : 'City, county, state, or zip'
               }

--- a/src/components/NavBar/Search/Search.tsx
+++ b/src/components/NavBar/Search/Search.tsx
@@ -5,21 +5,13 @@ import { navSearchbar, navSearchbarLocPage } from 'assets/theme';
 import SearchAutocomplete, { getFilterLimit } from 'components/Search';
 import { Wrapper } from './Search.style';
 import { useFinalAutocompleteLocations } from 'common/hooks';
-import { Region } from 'common/regions';
 
 const Search: React.FC<{
   menuOpen: boolean;
   WrappingDiv?: any /* Chelsi: fix this any */;
-  region?: Region;
   placeholder?: string;
   setMenuOpen: React.Dispatch<React.SetStateAction<boolean>>;
-}> = ({
-  menuOpen,
-  WrappingDiv = Wrapper,
-  region,
-  placeholder,
-  setMenuOpen,
-}) => {
+}> = ({ menuOpen, WrappingDiv = Wrapper, placeholder, setMenuOpen }) => {
   const theme = useContext(ThemeContext);
 
   const { pathname } = useLocation();
@@ -40,7 +32,6 @@ const Search: React.FC<{
           locations={searchLocations}
           filterLimit={getFilterLimit()}
           menuOpen={menuOpen}
-          region={region}
           placeholder={placeholder || 'City, county, state, or zip'}
           setMenuOpen={setMenuOpen}
         />

--- a/src/components/Search/SearchAutocomplete/SearchAutocomplete.tsx
+++ b/src/components/Search/SearchAutocomplete/SearchAutocomplete.tsx
@@ -1,8 +1,10 @@
 import React, { useEffect, useState } from 'react';
+import flatten from 'lodash/flatten';
+import uniq from 'lodash/uniq';
 import { Autocomplete } from '@material-ui/lab';
 import Hidden from '@material-ui/core/Hidden';
 import { createFilterOptions } from '@material-ui/lab/useAutocomplete';
-import { Region, MetroArea } from 'common/regions';
+import { State, County, Region, MetroArea, FipsCode } from 'common/regions';
 import {
   Wrapper,
   StyledTextField,
@@ -29,7 +31,6 @@ const SearchAutocomplete: React.FC<{
   filterLimit: number;
   setHideMapToggle?: any;
   menuOpen: boolean;
-  region?: Region;
   placeholder: string;
   setMenuOpen: React.Dispatch<React.SetStateAction<boolean>>;
 }> = ({
@@ -37,7 +38,6 @@ const SearchAutocomplete: React.FC<{
   filterLimit,
   setHideMapToggle,
   menuOpen,
-  region,
   placeholder,
   setMenuOpen,
 }) => {
@@ -74,15 +74,32 @@ const SearchAutocomplete: React.FC<{
   };
 
   const stringifyOption = (option: Region) => {
-    const zipCodes = countyToZipMap?.[option.fipsCode];
-    if (checkForZipcodeMatch && zipCodes) {
-      return `${zipCodes.join(' ')}`;
-    } else {
+    // given a county fips code, return zip codes
+    const zipsForFips = (fips: FipsCode): string[] => {
+      return countyToZipMap?.[fips] ?? [];
+    };
+
+    if (checkForZipcodeMatch) {
+      // get zipcodes for county, metro, and state objects
+      let zipCodes = null;
       if (option instanceof MetroArea) {
-        return `${option.shortName}, ${(option as MetroArea).stateCodes}`;
-      } else {
-        return option.shortName;
+        zipCodes = uniq(flatten(option.countiesFips.map(zipsForFips)));
+      } else if (option instanceof State) {
+        // going from state -> zips requires mapping all counties for the state
+        // which we don't have and won't be cheap (a list of all zip-codes per state? oof)
+        // so maybe defer this oen for now
+      } else if (option instanceof County) {
+        zipCodes = zipsForFips(option.fipsCode);
       }
+      if (zipCodes) {
+        return `${zipCodes.join(' ')}`;
+      }
+    }
+
+    if (option instanceof MetroArea) {
+      return `${option.shortName}, ${(option as MetroArea).stateCodes}`;
+    } else {
+      return option.shortName;
     }
   };
 

--- a/src/components/Search/SearchAutocomplete/SearchAutocomplete.tsx
+++ b/src/components/Search/SearchAutocomplete/SearchAutocomplete.tsx
@@ -84,12 +84,12 @@ const SearchAutocomplete: React.FC<{
       let zipCodes = null;
       if (option instanceof MetroArea) {
         zipCodes = uniq(flatten(option.countiesFips.map(zipsForFips)));
+      } else if (option instanceof County) {
+        zipCodes = zipsForFips(option.fipsCode);
       } else if (option instanceof State) {
         // going from state -> zips requires mapping all counties for the state
         // which we don't have and won't be cheap (a list of all zip-codes per state? oof)
-        // so maybe defer this oen for now
-      } else if (option instanceof County) {
-        zipCodes = zipsForFips(option.fipsCode);
+        // so maybe defer this one for now
       }
       if (zipCodes) {
         return `${zipCodes.join(' ')}`;


### PR DESCRIPTION
The trello task says "state and metro" but state is a lot harder and I'm not certain it's worth the tradeoff, so this does the first half of it.

Because the items are converted to strings for searching, to make this work for states we'd need to:
 1) get all counties which are part of the given state (which we don't have, so we'd have to scan all counties and filter by state) 
 2) map all counties to zips by trying to look each one up by FIPS
 3) store a string with all zipcodes for counties in a state
 
 This seems like it would be costly, and the value (showing a state by zip) doesn't seem that valuable to me.