### PR TITLE
Support multiple comma-separated regions in overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "test.ci": "CHOKIDAR_USEPOLLING=1 cross-env BROWSER=none start-server-and-test start http://localhost:3000 cy.run",
     "cy.open": "cypress open",
     "cy.run": "cypress run",
-    "jest": "TZ=America/Los_Angeles react-scripts test",
+    "jest": "cross-env TZ=America/Los_Angeles react-scripts test",
     "jest.ci": "CI=true yarn jest",
     "lint": "eslint --ext .js,.ts,tsx src --max-warnings=0",
     "lint-fix": "eslint --ext .js,.ts,tsx --fix src",

--- a/public/admin-overrides/config.yml
+++ b/public/admin-overrides/config.yml
@@ -31,9 +31,9 @@ collections:
             fields:
               - name: region
                 label: Region
-                hint: State code (2 letters) or FIPS code (2 or 5 digits)
+                hint: Comma-separated string of state codes (2 letters) and FIPS codes (2 or 5 digits)
                 widget: string
-                pattern: ['^([A-Z][A-Z]|\d{2}|\d{5})$', 'Must be a 2-letter state code or 2 or 5-digit FIPS code']
+                pattern: ['^([A-Z][A-Z]|\d{2}|\d{5})(,([A-Z][A-Z]|\d{2}|\d{5}))*$', 'Must be a 2-letter state code or 2 or 5-digit FIPS code']
               - name: include
                 label: Include
                 widget: select

--- a/src/cms-content/region-overrides/index.ts
+++ b/src/cms-content/region-overrides/index.ts
@@ -1,3 +1,5 @@
+import some from 'lodash/some';
+
 import RegionOverrides from './region-overrides.json';
 import { Markdown } from 'cms-content/utils';
 import { Metric } from 'common/metricEnum';
@@ -21,7 +23,7 @@ const metricIdToMetric: { [metricId: string]: Metric } = {
 interface RegionOverride {
   include: Include;
   metric: string;
-  region: string;
+  region: string; // comma-separated list of state codes and FIPS
   context: string;
   blocked: boolean;
   start_date?: string;
@@ -45,7 +47,7 @@ export function getRegionMetricOverride(
 /** Can be called from a test to validate properties for each override. */
 export function validateOverrides() {
   for (const override of getOverrides()) {
-    getRegionFromOverride(override);
+    getRegionsFromOverride(override);
     getMetricForOverride(override);
   }
 }
@@ -67,28 +69,36 @@ function getOverrides(): RegionOverride[] {
 
 /** Checks if the specified override applies to the specified region. */
 function overrideAppliesToRegion(override: RegionOverride, region: Region) {
-  const overrideRegion = getRegionFromOverride(override);
+  const overrideRegions = getRegionsFromOverride(override);
   const includeSelf =
     override.include === Include.Region ||
     override.include === Include.RegionAndSubregions;
   const includeSubregions =
     override.include === Include.Subregions ||
     override.include === Include.RegionAndSubregions;
-  if (includeSelf && region === overrideRegion) {
+  if (includeSelf && overrideRegions.includes(region)) {
     return true;
   } else if (includeSubregions) {
-    return overrideRegion.contains(region);
+    return some(
+      overrideRegions.map((overrideRegion: Region) =>
+        overrideRegion.contains(region),
+      ),
+    );
   }
   return false;
 }
 
 /** Parses the string "region" out of the specified override and returns it as a Region class. */
-function getRegionFromOverride(override: RegionOverride): Region {
-  if (/^[A-Z][A-Z]$/.test(override.region)) {
-    return regions.findByStateCodeStrict(override.region);
-  } else {
-    return regions.findByFipsCodeStrict(override.region);
-  }
+function getRegionsFromOverride(override: RegionOverride): Region[] {
+  const regionStrings = override.region.split(',');
+  const overrideRegions = regionStrings.map((r: string) => {
+    if (/^[A-Z][A-Z]$/.test(r)) {
+      return regions.findByStateCodeStrict(r);
+    } else {
+      return regions.findByFipsCodeStrict(r);
+    }
+  });
+  return overrideRegions;
 }
 
 function getMetricForOverride(override: RegionOverride): Metric {


### PR DESCRIPTION
Updates CMS schema to allow it, and override processor to handle it.

Does not combine any actual overrides though.