### PR TITLE
Replace chart footer for explore, recommendations, vulnerabilities block

### DIFF
--- a/src/components/Explore/Explore.tsx
+++ b/src/components/Explore/Explore.tsx
@@ -46,6 +46,10 @@ import { EventCategory, EventAction, trackEvent } from 'components/Analytics';
 import regions, { Region, useRegionFromParams } from 'common/regions';
 import NationalText from 'components/NationalText';
 import { SectionHeader } from 'components/SharedComponents';
+import {
+  Footer,
+  ButtonContainer,
+} from 'components/NewLocationPage/ChartFooter/ChartFooter.style';
 
 const MARGIN_SINGLE_LOCATION = 20;
 const MARGIN_STATE_CODE = 60;
@@ -354,8 +358,8 @@ const Explore: React.FunctionComponent<{
             <ScreenshotReady />
           </Styles.EmptyPanel>
         )}
-        <div style={{ paddingTop: '1rem' }}>
-          <Styles.ShareBlock>
+        <Footer>
+          <ButtonContainer>
             <ShareButtonGroup
               disabled={selectedLocations.length === 0 || !hasData}
               imageUrl={() => createSharedComponentId().then(getExportImageUrl)}
@@ -388,8 +392,8 @@ const Explore: React.FunctionComponent<{
                 trackShare(`Twitter: ${trackingLabel}`, numLocations)
               }
             />
-          </Styles.ShareBlock>
-        </div>
+          </ButtonContainer>
+        </Footer>
       </div>
     );
   },

--- a/src/components/LocationPage/ChartBlock.tsx
+++ b/src/components/LocationPage/ChartBlock.tsx
@@ -18,8 +18,12 @@ import { getSourcesForMetric } from 'common/utils/provenance';
 import { Sources } from 'api/schema/RegionSummaryWithTimeseries';
 import { getRegionMetricOverride } from 'cms-content/region-overrides';
 import { MarkdownContent } from 'components/Markdown';
-import LocationPageSectionFooter from 'components/LocationPageSectionFooter/LocationPageSectionFooter';
 import { SectionHeader } from 'components/SharedComponents';
+import {
+  FooterWrapper,
+  Footer,
+  ButtonContainer,
+} from 'components/NewLocationPage/ChartFooter/ChartFooter.style';
 
 function ChartBlock(props: {
   chartRef: React.RefObject<HTMLDivElement>;
@@ -63,15 +67,19 @@ function ChartBlock(props: {
             projections={projections}
             height={chartHeight}
           />
-          <LocationPageSectionFooter>
-            <DisclaimerWrapper>{disclaimerContent}</DisclaimerWrapper>
-            <ShareButtons
-              chartIdentifier={metric}
-              region={region}
-              stats={stats}
-              showEmbedButton={false}
-            />
-          </LocationPageSectionFooter>
+          <FooterWrapper>
+            <Footer>
+              <DisclaimerWrapper>{disclaimerContent}</DisclaimerWrapper>
+              <ButtonContainer>
+                <ShareButtons
+                  chartIdentifier={metric}
+                  region={region}
+                  stats={stats}
+                  showEmbedButton={false}
+                />
+              </ButtonContainer>
+            </Footer>
+          </FooterWrapper>
         </>
       )}
     </>

--- a/src/components/LocationPage/Recommendations.tsx
+++ b/src/components/LocationPage/Recommendations.tsx
@@ -3,8 +3,6 @@ import { mainContent } from 'cms-content/recommendations';
 import Recommend from 'components/Recommend';
 import ExpandableContainer from 'components/ExpandableContainer';
 import ShareButtons from 'components/SharedComponents/ShareButtons';
-import LocationPageSectionFooter from 'components/LocationPageSectionFooter/LocationPageSectionFooter';
-import { DisclaimerWrapper } from 'components/LocationPage/ChartsHolder.style';
 import { EventAction, EventCategory, trackEvent } from 'components/Analytics';
 import ExternalLink from 'components/ExternalLink';
 import { Projections } from 'common/models/Projections';
@@ -12,6 +10,11 @@ import { getRecommendationsShareUrl } from 'common/urls';
 import { getRecommendations, getShareQuote } from 'common/utils/recommend';
 import { Region } from 'common/regions';
 import { SectionHeader } from 'components/SharedComponents';
+import {
+  FooterWrapper,
+  Footer,
+  ButtonContainer,
+} from 'components/NewLocationPage/ChartFooter/ChartFooter.style';
 
 interface RecommendationsProps {
   projections: Projections;
@@ -60,24 +63,26 @@ const Recommendations = ({
           recommendationsRef={recommendationsRef}
         />
       </ExpandableContainer>
-      <LocationPageSectionFooter>
-        <DisclaimerWrapper>
-          Source:{' '}
+      <FooterWrapper>
+        <Footer>
+          Source:&nbsp;
           <ExternalLink
-            style={{ color: 'inherit' }}
             href="https://www.cdc.gov/"
+            style={{ color: 'inherit' }}
             onClick={trackSourceClick}
           >
             CDC
           </ExternalLink>
-        </DisclaimerWrapper>
-        <ShareButtons
-          eventCategory={EventCategory.RECOMMENDATIONS}
-          shareUrl={recommendsShareUrl}
-          shareQuote={recommendsShareQuote}
-          region={region}
-        />
-      </LocationPageSectionFooter>
+          <ButtonContainer>
+            <ShareButtons
+              eventCategory={EventCategory.RECOMMENDATIONS}
+              shareUrl={recommendsShareUrl}
+              shareQuote={recommendsShareQuote}
+              region={region}
+            />
+          </ButtonContainer>
+        </Footer>
+      </FooterWrapper>
     </>
   );
 };

--- a/src/components/NewLocationPage/ChartFooter/ChartFooter.style.tsx
+++ b/src/components/NewLocationPage/ChartFooter/ChartFooter.style.tsx
@@ -3,6 +3,10 @@ import { COLOR_MAP } from 'common/colors';
 import { materialSMBreakpoint } from 'assets/theme/sizes';
 import { TooltipAnchorText } from 'components/InfoTooltip/Tooltip.style';
 
+export const FooterWrapper = styled.div`
+  margin-top: 1.5rem;
+`;
+
 export const Footer = styled.div`
   position: relative;
   display: flex;

--- a/src/components/VulnerabilitiesBlock/VulnerabilitiesBlock.tsx
+++ b/src/components/VulnerabilitiesBlock/VulnerabilitiesBlock.tsx
@@ -6,11 +6,16 @@ import { getShareQuote } from 'common/ccvi/getShareQuote';
 import { RegionCcviItem, getVulnPopulationPercentForFips } from 'common/data';
 import { EventAction, EventCategory, trackEvent } from 'components/Analytics';
 import ShareButtons from '../SharedComponents/ShareButtons';
-import LocationPageSectionFooter from 'components/LocationPageSectionFooter/LocationPageSectionFooter';
 import NewDialog from 'components/NewDialog/NewDialog';
 import { vulnerabilitiesModal } from 'cms-content/modals';
-import { ModalOpenButton } from './VulnerabilitiesBlock.style';
 import { SectionHeader } from 'components/SharedComponents';
+import {
+  FooterWrapper,
+  Footer,
+  ModalButton,
+  AboutText,
+  ButtonContainer,
+} from 'components/NewLocationPage/ChartFooter/ChartFooter.style';
 
 const VulnerabilitiesBlock: React.FC<{
   scores: RegionCcviItem | null;
@@ -62,24 +67,28 @@ const VulnerabilitiesBlock: React.FC<{
           percentPopulationVulnerable={percentPopulationVulnerable}
         />
       </ExpandableContainer>
-      <LocationPageSectionFooter>
-        <ModalOpenButton onClick={modalOpenOnClick}>
-          About this data
-        </ModalOpenButton>
-        <NewDialog
-          open={dialogOpen}
-          closeDialog={closeDialog}
-          header={header}
-          body={body}
-          links={links}
-        />
-        <ShareButtons
-          eventCategory={EventCategory.VULNERABILITIES}
-          shareUrl={shareUrl}
-          shareQuote={shareQuote}
-          region={region}
-        />
-      </LocationPageSectionFooter>
+      <FooterWrapper>
+        <Footer>
+          <ModalButton onClick={modalOpenOnClick}>
+            <AboutText>About this data</AboutText>
+          </ModalButton>
+          <NewDialog
+            open={dialogOpen}
+            closeDialog={closeDialog}
+            header={header}
+            body={body}
+            links={links}
+          />
+          <ButtonContainer>
+            <ShareButtons
+              eventCategory={EventCategory.VULNERABILITIES}
+              shareUrl={shareUrl}
+              shareQuote={shareQuote}
+              region={region}
+            />
+          </ButtonContainer>
+        </Footer>
+      </FooterWrapper>
     </>
   );
 };


### PR DESCRIPTION
The standardized chart footer has been merged. This PR implements the standardized chart footer on the explore chart, recommendations block, and vulnerabilities block. Some important notes:
- The chart footer has not been implemented for the compare table yet, as this footer contain functionalities I'm not confident I should be removing at this point.
- The original plan is to build on to `LocationPageSectionFooter.tsx`. However, some of the styling here has been handled by the individual components of the standardized chart footer. The only exception is the top margin (which I currently just implemented a wrapper (`FooterWrapper` component) around 😬 ).
- Overall, there might be a more optimized approach to standardizing these footers. To prevent double work, I just implemented this PR as a preliminary idea, and we can iterate 😄 .

@chasulin let's sync on this.