### PR TITLE
Create chart tabs

### DIFF
--- a/src/components/NewLocationPage/ChartTabs/ChartTab.stories.tsx
+++ b/src/components/NewLocationPage/ChartTabs/ChartTab.stories.tsx
@@ -13,3 +13,15 @@ export const CaseDensityTab = () => {
 export const ChartGrowthRateTab = () => {
   return <ChartTab metric={Metric.CASE_GROWTH_RATE} value={0.25} />;
 };
+
+export const HospitalUsageTab = () => {
+  return <ChartTab metric={Metric.HOSPITAL_USAGE} value={0.5} />;
+};
+
+export const PositiveTestTab = () => {
+  return <ChartTab metric={Metric.POSITIVE_TESTS} value={0.75} />;
+};
+
+export const VaccinationTab = () => {
+  return <ChartTab metric={Metric.VACCINATIONS} value={1} />;
+};

--- a/src/components/NewLocationPage/ChartTabs/ChartTab.stories.tsx
+++ b/src/components/NewLocationPage/ChartTabs/ChartTab.stories.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import ChartTab from './ChartTab';
+import { Metric } from 'common/metricEnum';
+
+export default {
+  title: 'Location page redesign/Chart Tabs',
+};
+
+export const CaseDensityTab = () => {
+  return <ChartTab metric={Metric.CASE_DENSITY} value={25} />;
+};
+
+export const ChartGrowthRateTab = () => {
+  return <ChartTab metric={Metric.CASE_GROWTH_RATE} value={0.25} />;
+};

--- a/src/components/NewLocationPage/ChartTabs/ChartTab.stories.tsx
+++ b/src/components/NewLocationPage/ChartTabs/ChartTab.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ChartTab from './ChartTab';
 import { Metric } from 'common/metricEnum';
+import { TabsContainer } from './ChartTab.style';
 
 export default {
   title: 'Location page redesign/Chart Tabs',
@@ -24,4 +25,14 @@ export const PositiveTestTab = () => {
 
 export const VaccinationTab = () => {
   return <ChartTab metric={Metric.VACCINATIONS} value={1} />;
+};
+
+export const MultipleTabs = () => {
+  return (
+    <TabsContainer>
+      <ChartTab metric={Metric.CASE_DENSITY} value={25} />
+      <ChartTab metric={Metric.CASE_GROWTH_RATE} value={0.25} />
+      <ChartTab metric={Metric.HOSPITAL_USAGE} value={0.5} />
+    </TabsContainer>
+  );
 };

--- a/src/components/NewLocationPage/ChartTabs/ChartTab.stories.tsx
+++ b/src/components/NewLocationPage/ChartTabs/ChartTab.stories.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
+import React, { useState } from 'react';
 import ChartTab from './ChartTab';
+import ChartTabs from './ChartTabs';
 import { Metric } from 'common/metricEnum';
-import { TabsContainer } from './ChartTab.style';
 
 export default {
   title: 'Location page redesign/Chart Tabs',
@@ -28,11 +28,20 @@ export const VaccinationTab = () => {
 };
 
 export const MultipleTabs = () => {
+  const tabsContent = [
+    { metric: Metric.CASE_DENSITY, value: 25 },
+    { metric: Metric.CASE_GROWTH_RATE, value: 0.25 },
+    { metric: Metric.HOSPITAL_USAGE, value: 0.5 },
+  ];
+  const onChangeTab = (newMetric: number) => {
+    setCurrentTabIndex(newMetric);
+  };
+  const [currentTabIndex, setCurrentTabIndex] = useState(0);
   return (
-    <TabsContainer>
-      <ChartTab metric={Metric.CASE_DENSITY} value={25} />
-      <ChartTab metric={Metric.CASE_GROWTH_RATE} value={0.25} />
-      <ChartTab metric={Metric.HOSPITAL_USAGE} value={0.5} />
-    </TabsContainer>
+    <ChartTabs
+      activeTabIndex={currentTabIndex}
+      tabsContent={tabsContent}
+      onChangeTab={onChangeTab}
+    />
   );
 };

--- a/src/components/NewLocationPage/ChartTabs/ChartTab.style.tsx
+++ b/src/components/NewLocationPage/ChartTabs/ChartTab.style.tsx
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 import { COLOR_MAP } from 'common/colors';
+import { materialSMBreakpoint } from 'assets/theme/sizes';
 
 export const TabsContainer = styled.div`
   display: flex;
@@ -9,12 +10,14 @@ export const TabsContainer = styled.div`
 export const Tab = styled.div`
   display: flex;
   flex-direction: column;
-  max-width: 8rem;
+  max-width: 10.5rem;
 `;
 
 // TODO: Figure out transforming color to black on hover or click?
 export const TabTitle = styled.div`
   text-transform: uppercase;
+  font-size: 0.8rem;
+  line-height: 1;
   color: ${COLOR_MAP.GREY_4};
   margin-bottom: 0.5rem;
 `;
@@ -26,6 +29,12 @@ export const TabContent = styled.div`
 `;
 
 export const MetricSubLabel = styled.div`
+  font-size: 0.8rem;
   text-transform: uppercase;
   color: ${COLOR_MAP.GREY_4};
+
+  @media (min-width: ${materialSMBreakpoint}) {
+    color: ${COLOR_MAP.GREY_3};
+    padding: 0.5rem 0 0 0.5rem;
+  }
 `;

--- a/src/components/NewLocationPage/ChartTabs/ChartTab.style.tsx
+++ b/src/components/NewLocationPage/ChartTabs/ChartTab.style.tsx
@@ -21,6 +21,7 @@ export const Tab = styled(MuiTab)`
   text-align: left;
   padding: 6px 0;
   margin-right: 1.5rem;
+  opacity: 1;
   .MuiTab-wrapper {
     align-items: start;
   }

--- a/src/components/NewLocationPage/ChartTabs/ChartTab.style.tsx
+++ b/src/components/NewLocationPage/ChartTabs/ChartTab.style.tsx
@@ -1,0 +1,31 @@
+import styled from 'styled-components';
+import { COLOR_MAP } from 'common/colors';
+
+export const TabsContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+`;
+
+export const Tab = styled.div`
+  display: flex;
+  flex-direction: column;
+  max-width: 8rem;
+`;
+
+// TODO: Figure out transforming color to black on hover or click?
+export const TabTitle = styled.div`
+  text-transform: uppercase;
+  color: ${COLOR_MAP.GREY_4};
+  margin-bottom: 0.5rem;
+`;
+
+export const TabContent = styled.div`
+  display: flex;
+  flex-direction: row;
+  margin-bottom: 1rem;
+`;
+
+export const MetricSubLabel = styled.div`
+  text-transform: uppercase;
+  color: ${COLOR_MAP.GREY_4};
+`;

--- a/src/components/NewLocationPage/ChartTabs/ChartTab.style.tsx
+++ b/src/components/NewLocationPage/ChartTabs/ChartTab.style.tsx
@@ -11,9 +11,14 @@ export const Tab = styled.div`
   display: flex;
   flex-direction: column;
   max-width: 10.5rem;
+
+  &:hover {
+    color: ${COLOR_MAP.BLACK};
+    font-weight: 500;
+    border-bottom: 3px solid ${COLOR_MAP.BLACK};
+  }
 `;
 
-// TODO: Figure out transforming color to black on hover or click?
 export const TabTitle = styled.div`
   text-transform: uppercase;
   font-size: 0.8rem;

--- a/src/components/NewLocationPage/ChartTabs/ChartTab.style.tsx
+++ b/src/components/NewLocationPage/ChartTabs/ChartTab.style.tsx
@@ -5,8 +5,14 @@ import MuiTab from '@material-ui/core/Tab';
 import MuiTabs from '@material-ui/core/Tabs';
 
 export const Tabs = styled(MuiTabs)`
+  .MuiTabs-flexContainer {
+    align-items: flex-end;
+  }
   .MuiTabs-indicator {
     background-color: ${COLOR_MAP.BLACK};
+  }
+  .MuiTab-root {
+    min-width: fit-content;
   }
 `;
 
@@ -15,6 +21,9 @@ export const Tab = styled(MuiTab)`
   text-align: left;
   padding: 6px 0;
   margin-right: 1.5rem;
+  .MuiTab-wrapper {
+    align-items: start;
+  }
   &.Mui-selected {
     font-weight: 500;
   }
@@ -27,8 +36,7 @@ export const TabsContainer = styled.div`
 export const TabContainer = styled.div`
   display: flex;
   flex-direction: column;
-  min-width: 4rem;
-  max-width: 10.5rem;
+  width: fit-content;
   justify-content: space-between;
 `;
 

--- a/src/components/NewLocationPage/ChartTabs/ChartTab.style.tsx
+++ b/src/components/NewLocationPage/ChartTabs/ChartTab.style.tsx
@@ -1,25 +1,36 @@
 import styled from 'styled-components';
 import { COLOR_MAP } from 'common/colors';
 import { materialSMBreakpoint } from 'assets/theme/sizes';
+import MuiTab from '@material-ui/core/Tab';
+import MuiTabs from '@material-ui/core/Tabs';
+
+export const Tabs = styled(MuiTabs)`
+  .MuiTabs-indicator {
+    background-color: ${COLOR_MAP.BLACK};
+  }
+`;
+
+export const Tab = styled(MuiTab)`
+  line-height: 1;
+  text-align: left;
+  padding: 6px 0;
+  margin-right: 1.5rem;
+  &.Mui-selected {
+    font-weight: 500;
+  }
+`;
 
 export const TabsContainer = styled.div`
   display: flex;
 `;
 
-export const Tab = styled.div`
-  display: flex;
+export const TabContainer = styled.div`
+  align-itmes: start;
+  display: inline-flex;
   flex-direction: column;
   min-width: 4rem;
   max-width: 10.5rem;
-  margin-right: 1.5rem;
   justify-content: space-between;
-
-  &:hover,
-  &:focus {
-    color: ${COLOR_MAP.BLACK};
-    font-weight: 500;
-    border-bottom: 3px solid ${COLOR_MAP.BLACK};
-  }
 `;
 
 export const TabTitle = styled.div`
@@ -32,7 +43,7 @@ export const TabTitle = styled.div`
 
 export const TabContent = styled.div`
   display: flex;
-  margin-bottom: 1rem;
+  margin-bottom: 0.5rem;
 `;
 
 export const MetricSubLabel = styled.div`

--- a/src/components/NewLocationPage/ChartTabs/ChartTab.style.tsx
+++ b/src/components/NewLocationPage/ChartTabs/ChartTab.style.tsx
@@ -4,15 +4,18 @@ import { materialSMBreakpoint } from 'assets/theme/sizes';
 
 export const TabsContainer = styled.div`
   display: flex;
-  flex-direction: row;
 `;
 
 export const Tab = styled.div`
   display: flex;
   flex-direction: column;
+  min-width: 4rem;
   max-width: 10.5rem;
+  margin-right: 1.5rem;
+  justify-content: space-between;
 
-  &:hover {
+  &:hover,
+  &:focus {
     color: ${COLOR_MAP.BLACK};
     font-weight: 500;
     border-bottom: 3px solid ${COLOR_MAP.BLACK};
@@ -29,7 +32,6 @@ export const TabTitle = styled.div`
 
 export const TabContent = styled.div`
   display: flex;
-  flex-direction: row;
   margin-bottom: 1rem;
 `;
 
@@ -37,6 +39,7 @@ export const MetricSubLabel = styled.div`
   font-size: 0.8rem;
   text-transform: uppercase;
   color: ${COLOR_MAP.GREY_4};
+  line-height: 1;
 
   @media (min-width: ${materialSMBreakpoint}) {
     color: ${COLOR_MAP.GREY_3};

--- a/src/components/NewLocationPage/ChartTabs/ChartTab.style.tsx
+++ b/src/components/NewLocationPage/ChartTabs/ChartTab.style.tsx
@@ -25,8 +25,7 @@ export const TabsContainer = styled.div`
 `;
 
 export const TabContainer = styled.div`
-  align-itmes: start;
-  display: inline-flex;
+  display: flex;
   flex-direction: column;
   min-width: 4rem;
   max-width: 10.5rem;

--- a/src/components/NewLocationPage/ChartTabs/ChartTab.tsx
+++ b/src/components/NewLocationPage/ChartTabs/ChartTab.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { formatValue, getLevelInfo } from 'common/metric';
+import { Metric } from 'common/metricEnum';
+import { useBreakpoint } from 'common/hooks';
+import {
+  TabsContainer,
+  Tab,
+  TabTitle,
+  TabContent,
+  MetricSubLabel,
+} from './ChartTab.style';
+import { CircleIcon } from '../Shared/Shared.style';
+import { Value } from '../SummaryStat/SummaryStat.style';
+import { getMetricNameForStat, metricSubLabelText } from '../SummaryStat/utils';
+
+const ChartTab: React.FC<{ metric: Metric; value: number | null }> = ({
+  metric,
+  value,
+}) => {
+  const isMobile = useBreakpoint(600);
+  const metricName = getMetricNameForStat(metric);
+  const hasSubLabel = metric in metricSubLabelText;
+  const levelInfo = getLevelInfo(metric, value);
+  const formattedValue = formatValue(metric, value, /*nullValueCopy=*/ '-');
+
+  return (
+    <TabsContainer>
+      <Tab>
+        <TabTitle>
+          {metricName}
+          {isMobile && hasSubLabel && (
+            <MetricSubLabel>
+              {metricSubLabelText[metric].join(' ')}
+            </MetricSubLabel>
+          )}
+        </TabTitle>
+        <TabContent>
+          <CircleIcon $iconColor={levelInfo.color} />
+          <Value>{formattedValue}</Value>
+          {!isMobile && hasSubLabel && (
+            <MetricSubLabel>
+              {metricSubLabelText[metric].join(' ')}
+            </MetricSubLabel>
+          )}
+        </TabContent>
+      </Tab>
+    </TabsContainer>
+  );
+};
+
+export default ChartTab;

--- a/src/components/NewLocationPage/ChartTabs/ChartTab.tsx
+++ b/src/components/NewLocationPage/ChartTabs/ChartTab.tsx
@@ -2,7 +2,12 @@ import React from 'react';
 import { formatValue, getLevelInfo } from 'common/metric';
 import { Metric } from 'common/metricEnum';
 import { useBreakpoint } from 'common/hooks';
-import { Tab, TabTitle, TabContent, MetricSubLabel } from './ChartTab.style';
+import {
+  TabContainer,
+  TabTitle,
+  TabContent,
+  MetricSubLabel,
+} from './ChartTab.style';
 import { CircleIcon } from '../Shared/Shared.style';
 import { Value } from '../SummaryStat/SummaryStat.style';
 import { getMetricNameForStat, metricSubLabelText } from '../SummaryStat/utils';
@@ -18,7 +23,7 @@ const ChartTab: React.FC<{ metric: Metric; value: number | null }> = ({
   const formattedValue = formatValue(metric, value, /*nullValueCopy=*/ '-');
 
   return (
-    <Tab>
+    <TabContainer>
       <TabTitle>
         {metricName}
         {isMobile && hasSubLabel && (
@@ -36,7 +41,7 @@ const ChartTab: React.FC<{ metric: Metric; value: number | null }> = ({
           </MetricSubLabel>
         )}
       </TabContent>
-    </Tab>
+    </TabContainer>
   );
 };
 

--- a/src/components/NewLocationPage/ChartTabs/ChartTab.tsx
+++ b/src/components/NewLocationPage/ChartTabs/ChartTab.tsx
@@ -2,13 +2,7 @@ import React from 'react';
 import { formatValue, getLevelInfo } from 'common/metric';
 import { Metric } from 'common/metricEnum';
 import { useBreakpoint } from 'common/hooks';
-import {
-  TabsContainer,
-  Tab,
-  TabTitle,
-  TabContent,
-  MetricSubLabel,
-} from './ChartTab.style';
+import { Tab, TabTitle, TabContent, MetricSubLabel } from './ChartTab.style';
 import { CircleIcon } from '../Shared/Shared.style';
 import { Value } from '../SummaryStat/SummaryStat.style';
 import { getMetricNameForStat, metricSubLabelText } from '../SummaryStat/utils';
@@ -24,27 +18,25 @@ const ChartTab: React.FC<{ metric: Metric; value: number | null }> = ({
   const formattedValue = formatValue(metric, value, /*nullValueCopy=*/ '-');
 
   return (
-    <TabsContainer>
-      <Tab>
-        <TabTitle>
-          {metricName}
-          {isMobile && hasSubLabel && (
-            <MetricSubLabel>
-              {metricSubLabelText[metric].join(' ')}
-            </MetricSubLabel>
-          )}
-        </TabTitle>
-        <TabContent>
-          <CircleIcon $iconColor={levelInfo.color} />
-          <Value>{formattedValue}</Value>
-          {!isMobile && hasSubLabel && (
-            <MetricSubLabel>
-              {metricSubLabelText[metric].join(' ')}
-            </MetricSubLabel>
-          )}
-        </TabContent>
-      </Tab>
-    </TabsContainer>
+    <Tab>
+      <TabTitle>
+        {metricName}
+        {isMobile && hasSubLabel && (
+          <MetricSubLabel>
+            {metricSubLabelText[metric].join(' ')}
+          </MetricSubLabel>
+        )}
+      </TabTitle>
+      <TabContent>
+        <CircleIcon $iconColor={levelInfo.color} />
+        <Value>{formattedValue}</Value>
+        {!isMobile && hasSubLabel && (
+          <MetricSubLabel>
+            {metricSubLabelText[metric].join(' ')}
+          </MetricSubLabel>
+        )}
+      </TabContent>
+    </Tab>
   );
 };
 

--- a/src/components/NewLocationPage/ChartTabs/ChartTabs.tsx
+++ b/src/components/NewLocationPage/ChartTabs/ChartTabs.tsx
@@ -1,0 +1,39 @@
+import React, { FunctionComponent } from 'react';
+import { Tab, Tabs } from './ChartTab.style';
+import ChartTab from './ChartTab';
+import { Metric } from 'common/metricEnum';
+
+export interface TabContent {
+  metric: Metric;
+  value: number;
+}
+
+const ChartTabs: FunctionComponent<{
+  activeTabIndex: number;
+  tabsContent: TabContent[];
+  onChangeTab: (newTabIndex: number) => void;
+}> = ({ activeTabIndex, tabsContent, onChangeTab }) => {
+  return (
+    <Tabs
+      value={activeTabIndex}
+      onChange={(event, tabIndex) => onChangeTab(tabIndex)}
+      aria-label="Metrics Tabs"
+      variant="scrollable"
+    >
+      {tabsContent.map((tab: TabContent, i: number) => {
+        return (
+          <Tab
+            key={`tab-${i}`}
+            disableRipple
+            disableFocusRipple
+            label={<ChartTab metric={tab.metric} value={tab.value} />}
+            id={`tab-id-${i}`}
+            aria-controls={`tab-id-${i}`}
+          />
+        );
+      })}
+    </Tabs>
+  );
+};
+
+export default ChartTabs;


### PR DESCRIPTION
This PR creates standardized chart tabs. Some curious notes below:
- Some metric names don't seem to match what's on Figma 🤔 (e.g. vaccination metrics). This PR currently uses the same logic as `SummaryStat` to get the metric name and metric sub-label. If it's necessary that the metric names must match what's on Figma exactly, we may need to build in additional logic?
- This PR assumes both click and hover behaviour will trigger the metric name to be bolded and the bottom border to appear.