### PR TITLE
Homepage style cleanup

### DIFF
--- a/src/components/PartnersSection/PartnersSection.tsx
+++ b/src/components/PartnersSection/PartnersSection.tsx
@@ -1,19 +1,13 @@
 import React from 'react';
 import { PartnerLogoGrid } from 'components/LogoGrid/LogoGrid';
-import {
-  Content,
-  PartnerSection,
-  PartnerHeader,
-} from 'screens/HomePage/HomePage.style';
+import { SectionHeader, SectionWrapper } from 'screens/HomePage/HomePage.style';
 
 function PartnersSection() {
   return (
-    <PartnerSection>
-      <Content>
-        <PartnerHeader>Our Partners</PartnerHeader>
-        <PartnerLogoGrid />
-      </Content>
-    </PartnerSection>
+    <SectionWrapper>
+      <SectionHeader>Our Partners</SectionHeader>
+      <PartnerLogoGrid />
+    </SectionWrapper>
   );
 }
 

--- a/src/screens/HomePage/Announcements/Announcements.style.tsx
+++ b/src/screens/HomePage/Announcements/Announcements.style.tsx
@@ -3,18 +3,8 @@ import { Typography, Box } from '@material-ui/core';
 import { COLOR_MAP } from 'common/colors';
 import { materialSMBreakpoint } from 'assets/theme/sizes';
 
-export const Wrapper = styled(Box)`
-  display: flex;
-  flex-direction: column;
-  max-width: 570px;
-  width: 100%;
-  margin: 0 auto;
-  padding: 0 1rem;
-`;
-
 export const AnnouncementIntro = styled(Typography)`
-  font-family: Roboto;
-  font-weight: 900;
+  ${props => props.theme.fonts.regularBookBold};
   font-size: 24px;
   line-height: 130%;
   margin-bottom: 1rem;
@@ -25,21 +15,16 @@ export const AnnouncementIntro = styled(Typography)`
 `;
 
 export const Date = styled(Typography)`
-  font-family: Source Code Pro;
+  ${props => props.theme.fonts.monospace};
   font-size: 13px;
   line-height: 16px;
-  letter-spacing: 0.01em;
   text-transform: uppercase;
   color: ${COLOR_MAP.GRAY_BODY_COPY};
   margin-bottom: 1rem;
 `;
 
 export const AnnouncementBodyCopy = styled(Typography)`
-  font-family: Roboto;
-  font-size: 1rem;
   line-height: 160%;
-  letter-spacing: 0.01em;
-  margin-bottom: 1.5rem;
   color: ${COLOR_MAP.GRAY_BODY_COPY};
 `;
 
@@ -55,7 +40,6 @@ export const ButtonsContainer = styled(Box)`
 `;
 
 const SharedButtonStyles = css`
-  font-family: Roboto;
   font-size: 1rem;
   line-height: 1.4;
   color: ${COLOR_MAP.BLUE};
@@ -91,4 +75,10 @@ export const ViewAllLink = styled.a`
       margin-left: 0;
     }
   }
+`;
+
+export const Content = styled.div`
+  max-width: 570px;
+  width: 100%;
+  margin: auto;
 `;

--- a/src/screens/HomePage/Announcements/Announcements.tsx
+++ b/src/screens/HomePage/Announcements/Announcements.tsx
@@ -1,38 +1,40 @@
 import React from 'react';
-import { Subtitle1 } from 'components/Typography';
 import {
   AnnouncementIntro,
-  Wrapper,
   Date,
   AnnouncementBodyCopy,
+  Content,
 } from './Announcements.style';
 import ExternalLink from 'components/ExternalLink';
+import { SectionWrapper, SectionHeader } from 'screens/HomePage/HomePage.style';
 
 const Announcements: React.FC = () => {
   return (
-    <Wrapper>
-      <Subtitle1>Announcements</Subtitle1>
-      <AnnouncementIntro>
-        Act Now Coalition and Rewiring America
-      </AnnouncementIntro>
-      <Date>FRIDAY, May 21, 2021</Date>
-      <AnnouncementBodyCopy>
-        We’re excited to announce a new project at Covid Act Now! The Act Now
-        Coalition, the non-profit behind Covid Act Now, is partnering with the
-        non-profit{' '}
-        <ExternalLink href="https://www.rewiringamerica.org">
-          Rewiring America
-        </ExternalLink>{' '}
-        to build accessible data models and share clear, comprehensive
-        information that will support the electrification of American households
-        to slow climate change, save people money and create new American jobs.
-        Read more{' '}
-        <ExternalLink href="https://www.rewiringamerica.org/newsletter/we-had-a-very-big-week-here-at-rewiring-america">
-          here
-        </ExternalLink>
-        .
-      </AnnouncementBodyCopy>
-    </Wrapper>
+    <SectionWrapper>
+      <Content>
+        <SectionHeader>Announcements</SectionHeader>
+        <AnnouncementIntro>
+          Act Now Coalition and Rewiring America
+        </AnnouncementIntro>
+        <Date>FRIDAY, May 21, 2021</Date>
+        <AnnouncementBodyCopy>
+          We’re excited to announce a new project at Covid Act Now! The Act Now
+          Coalition, the non-profit behind Covid Act Now, is partnering with the
+          non-profit{' '}
+          <ExternalLink href="https://www.rewiringamerica.org">
+            Rewiring America
+          </ExternalLink>{' '}
+          to build accessible data models and share clear, comprehensive
+          information that will support the electrification of American
+          households to slow climate change, save people money and create new
+          American jobs. Read more{' '}
+          <ExternalLink href="https://www.rewiringamerica.org/newsletter/we-had-a-very-big-week-here-at-rewiring-america">
+            here
+          </ExternalLink>
+          .
+        </AnnouncementBodyCopy>
+      </Content>
+    </SectionWrapper>
   );
 };
 

--- a/src/screens/HomePage/HomePage.style.tsx
+++ b/src/screens/HomePage/HomePage.style.tsx
@@ -1,6 +1,5 @@
 import styled from 'styled-components';
 import { Box } from '@material-ui/core';
-import palette from 'assets/theme/palette';
 import { Subtitle1 } from 'components/Typography';
 import { mobileBreakpoint, materialSMBreakpoint } from 'assets/theme/sizes';
 
@@ -18,9 +17,6 @@ export const Content = styled.div`
 
 export const Section = styled.div`
   margin: 3.5rem 1rem;
-  @media (min-width: ${mobileBreakpoint}) {
-    margin: 3.5rem 0;
-  }
 `;
 
 // zero right margin so that it's full bleed on mobile when overflowing
@@ -51,24 +47,6 @@ export const SearchBarThermometerWrapper = styled(Box)`
   }
 `;
 
-export const PartnerSection = styled.div`
-  padding: 0 1rem 1rem;
-`;
-
-export const PartnerHeader = styled(Subtitle1)`
-  padding-top: 2.5rem;
-  margin-top: 2.5rem;
-  border-top: 1px solid ${palette.lightGray};
-  text-align: center;
-  margin-bottom: 1rem;
-`;
-
-export const FeaturedHeader = styled(Subtitle1)`
-  margin-top: 4rem;
-  text-align: center;
-  margin-bottom: 1rem;
-`;
-
 export const BannerContainer = styled.div`
   margin: 0 auto;
 
@@ -84,4 +62,15 @@ export const ElectionCountdownContainer = styled.div`
   @media (min-width: ${mobileBreakpoint}) {
     margin-top: 2rem;
   }
+`;
+
+export const SectionWrapper = styled.div`
+  max-width: 1000px;
+  margin: auto 1rem;
+  padding: 2.5rem 0;
+  border-top: 1px solid ${props => props.theme.palette.lightGray};
+`;
+
+export const SectionHeader = styled(Subtitle1)`
+  text-align: center;
 `;

--- a/src/screens/HomePage/HomePage.style.tsx
+++ b/src/screens/HomePage/HomePage.style.tsx
@@ -73,4 +73,5 @@ export const SectionWrapper = styled.div`
 
 export const SectionHeader = styled(Subtitle1)`
   text-align: center;
+  margin-bottom: 1.25rem;
 `;

--- a/src/screens/HomePage/HomePage.tsx
+++ b/src/screens/HomePage/HomePage.tsx
@@ -158,8 +158,8 @@ export default function HomePage() {
               />
             </Section>
             <Announcements />
+            <PartnersSection />
           </Content>
-          <PartnersSection />
           <div ref={shareBlockRef} id="alert_signup">
             <ShareModelBlock />
           </div>


### PR DESCRIPTION
Cleans up some style bugs + inconsistencies on the homepage:
- Explore and compare hit the sides of the screen (/had no padding) on desktop
- No border above announcements section


**Before (no padding around explore/compare, no border above announcements section):**

![Screen Shot 2021-06-01 at 11 55 30 AM](https://user-images.githubusercontent.com/44076375/120354237-4580ff00-c2d0-11eb-94d9-e0d3fdb53ed6.png)


**After (incl. padding, border):**

![Screen Shot 2021-06-01 at 11 56 11 AM](https://user-images.githubusercontent.com/44076375/120354370-5df11980-c2d0-11eb-9b30-8e9a1e0b8b04.png)