### PR TITLE
Explore feedback items

### DIFF
--- a/src/components/AutocompleteRegions/AutocompleteRegions.style.ts
+++ b/src/components/AutocompleteRegions/AutocompleteRegions.style.ts
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 import TextField from '@material-ui/core/TextField';
+import Paper from '@material-ui/core/Paper';
 
 export const StyledTextField = styled(TextField)<{
   $placeholderMinWidth: string;
@@ -14,4 +15,8 @@ export const StyledTextField = styled(TextField)<{
     font-size: 13px;
     min-width: ${props => props.$placeholderMinWidth};
   }
+`;
+
+export const StyledPaper = styled(Paper)`
+  max-height: 200px;
 `;

--- a/src/components/AutocompleteRegions/AutocompleteRegions.tsx
+++ b/src/components/AutocompleteRegions/AutocompleteRegions.tsx
@@ -4,7 +4,7 @@ import Autocomplete, {
 } from '@material-ui/lab/Autocomplete';
 import { createFilterOptions } from '@material-ui/lab/useAutocomplete';
 import { Region, MetroArea } from 'common/regions';
-import { StyledTextField } from './AutocompleteRegions.style';
+import { StyledTextField, StyledPaper } from './AutocompleteRegions.style';
 /**
  * `createFilterOptions` creates a configuration object that defines how the
  * user input will be matched against the options in the Autocomplete
@@ -59,6 +59,7 @@ const AutocompleteRegions: React.FC<{
   return (
     <Autocomplete
       multiple
+      disablePortal // so the menu always opens downward
       options={regions}
       getOptionLabel={getLocationLabel}
       onChange={onChangeRegions}
@@ -78,6 +79,7 @@ const AutocompleteRegions: React.FC<{
         />
       )}
       {...renderTagsOption}
+      PaperComponent={StyledPaper}
     />
   );
 };

--- a/src/components/Explore/Dropdown/Dropdown.style.tsx
+++ b/src/components/Explore/Dropdown/Dropdown.style.tsx
@@ -37,8 +37,10 @@ export const MainButton = styled(BaseButton)<{
   border-radius: ${({ $open }) => ($open ? '4px 4px 0 0' : '4px')};
   width: 100%;
   position: relative;
+  margin-bottom: 1rem;
 
   @media (min-width: ${materialSMBreakpoint}) {
+    margin-bottom: 0;
     max-width: ${({ $maxWidth }) =>
       Number.isFinite($maxWidth) && `${$maxWidth}px`};
   }

--- a/src/components/Explore/Dropdown/Dropdown.style.tsx
+++ b/src/components/Explore/Dropdown/Dropdown.style.tsx
@@ -5,9 +5,12 @@ import { materialSMBreakpoint } from 'assets/theme/sizes';
 
 export const DropdownWrapper = styled.div<{ $maxWidth: number }>`
   width: 100%;
+  margin-bottom: 1rem;
 
   @media (min-width: ${materialSMBreakpoint}) {
     max-width: ${({ $maxWidth }) => `${$maxWidth}px`};
+    margin-bottom: 0;
+    margin-right: 1rem;
   }
 `;
 
@@ -37,10 +40,8 @@ export const MainButton = styled(BaseButton)<{
   border-radius: ${({ $open }) => ($open ? '4px 4px 0 0' : '4px')};
   width: 100%;
   position: relative;
-  margin-bottom: 1rem;
 
   @media (min-width: ${materialSMBreakpoint}) {
-    margin-bottom: 0;
     max-width: ${({ $maxWidth }) =>
       Number.isFinite($maxWidth) && `${$maxWidth}px`};
   }

--- a/src/components/Explore/Explore.style.ts
+++ b/src/components/Explore/Explore.style.ts
@@ -44,7 +44,6 @@ export const Subtitle = styled.div`
 export const ChartControlsContainer = styled.div`
   margin: ${theme.spacing(2)}px auto;
   display: flex;
-  gap: 1rem;
   flex-direction: column;
 
   @media (min-width: ${materialSMBreakpoint}) {

--- a/src/components/Explore/Explore.style.ts
+++ b/src/components/Explore/Explore.style.ts
@@ -72,6 +72,7 @@ export const NormalizeCheckbox = styled(MuiCheckbox)`
 export const LegendContainer = styled(Box)`
   display: flex;
   flex-wrap: wrap;
+  margin-right: 2rem;
 `;
 
 export const LegendItem = styled(Box)`
@@ -349,7 +350,6 @@ export const DisclaimerBody = styled(Typography)`
 export const FooterContainer = styled.div`
   padding-top: 1rem;
   display: flex;
-  gap: 2rem;
   justify-content: space-between;
   padding-top: 1rem;
 `;

--- a/src/components/Explore/Explore.tsx
+++ b/src/components/Explore/Explore.tsx
@@ -302,7 +302,7 @@ const ExploreCopy: React.FunctionComponent<{
             regions={autocompleteLocations}
             selectedRegions={selectedLocations}
             onChangeSelectedRegions={onChangeSelectedLocations}
-            maxWidth={325}
+            maxWidth={400}
           />
         </Styles.ChartControlsContainer>
         {selectedLocations.length > 0 && hasData && (

--- a/src/components/Explore/Explore.tsx
+++ b/src/components/Explore/Explore.tsx
@@ -39,6 +39,7 @@ import {
   getYFormat,
   getYAxisDecimalPlaces,
   getXTickTimeUnitForPeriod,
+  getMaxYFromDefinition,
 } from './utils';
 import * as Styles from './Explore.style';
 import {
@@ -255,6 +256,7 @@ const ExploreCopy: React.FunctionComponent<{
     const [timeRangeMenuLabel, setTimeRangeMenuLabel] = useState(
       allPeriodLabels[period],
     );
+    const maxYFromDefinition = getMaxYFromDefinition(currentMetric);
 
     const sharedParams = useSharedComponentParams(SharedComponent.Explore);
     useEffect(() => {
@@ -327,6 +329,7 @@ const ExploreCopy: React.FunctionComponent<{
                     yTickFormat={yTickFormat}
                     yTooltipFormat={yTooltipFormat}
                     xTickTimeUnit={getXTickTimeUnitForPeriod(period)}
+                    maxYFromDefinition={maxYFromDefinition}
                   />
                 ) : (
                   <div style={{ height: 400 }} />

--- a/src/components/Explore/ExploreChart.tsx
+++ b/src/components/Explore/ExploreChart.tsx
@@ -22,6 +22,7 @@ const ExploreChart: React.FC<{
   yTickFormat: (val: number) => string;
   yTooltipFormat: (val: number) => string;
   xTickTimeUnit: TimeUnit;
+  maxYFromDefinition: number | null;
 }> = ({
   hasMultipleLocations,
   barOpacity,

--- a/src/components/Explore/LocationSelector.style.ts
+++ b/src/components/Explore/LocationSelector.style.ts
@@ -24,13 +24,13 @@ export const ModalContainer = styled.div`
 export const ModalHeader = styled.div`
   display: flex;
   margin-bottom: 2rem;
-  gap: 1.75rem;
   justify-content: space-between;
 `;
 
 export const ModalTitle = styled.h1`
   ${props => props.theme.fonts.regularBookMidWeight};
   margin: 0;
+  margin-right: 1.75rem;
   font-size: 1.25rem;
 `;
 

--- a/src/components/Explore/LocationSelector.style.ts
+++ b/src/components/Explore/LocationSelector.style.ts
@@ -17,7 +17,7 @@ export const ModalContainer = styled.div`
     width: 100%;
     max-width: 600px;
     border-radius: 4px;
-    margin: 10rem auto auto;
+    margin: auto;
   }
 `;
 

--- a/src/components/Explore/LocationSelector.style.ts
+++ b/src/components/Explore/LocationSelector.style.ts
@@ -15,7 +15,7 @@ export const ModalContainer = styled.div`
   @media (min-width: ${materialSMBreakpoint}) {
     height: unset;
     width: 100%;
-    max-width: 600px;
+    max-width: 580px;
     border-radius: 4px;
     margin: auto;
   }

--- a/src/components/Explore/LocationSelector.tsx
+++ b/src/components/Explore/LocationSelector.tsx
@@ -39,7 +39,7 @@ const LocationSelector: React.FC<{
 
   const closeModal = () => setModalOpen(false);
 
-  const regionNames = selectedRegions.map(getLocationLabel).join(', ');
+  const regionNames = selectedRegions.map(getLocationLabel).join('; ');
 
   const id = uuidv4();
 

--- a/src/components/Explore/MultipleLocationsChart.tsx
+++ b/src/components/Explore/MultipleLocationsChart.tsx
@@ -3,6 +3,7 @@ import isNumber from 'lodash/isNumber';
 import last from 'lodash/last';
 import min from 'lodash/min';
 import sortBy from 'lodash/sortBy';
+import isFinite from 'lodash/isFinite';
 import { Group } from '@vx/group';
 import { scaleUtc, scaleLinear } from '@vx/scale';
 import { useTooltip } from '@vx/tooltip';
@@ -126,6 +127,7 @@ const MultipleLocationsChart: React.FC<{
   yTickFormat: (val: number) => string;
   yTooltipFormat: (val: number) => string;
   xTickTimeUnit: TimeUnit;
+  maxYFromDefinition: number | null;
 }> = ({
   width,
   height,
@@ -141,6 +143,7 @@ const MultipleLocationsChart: React.FC<{
   yTickFormat,
   yTooltipFormat,
   xTickTimeUnit,
+  maxYFromDefinition,
 }) => {
   const seriesList = sortSeriesByLast(unsortedSeriesList).filter(
     series => series.data.length > 0,
@@ -148,7 +151,9 @@ const MultipleLocationsChart: React.FC<{
 
   const [dateFrom, dateTo] = dateRange;
 
-  const maxY = getMaxY(seriesList, dateFrom, dateTo);
+  const maxY = isFinite(maxYFromDefinition)
+    ? maxYFromDefinition
+    : getMaxY(seriesList, dateFrom, dateTo);
 
   const innerWidth = width - marginLeft - marginRight;
   const innerHeight = height - marginTop - marginBottom;

--- a/src/components/Explore/SingleLocationChart.tsx
+++ b/src/components/Explore/SingleLocationChart.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, Fragment } from 'react';
 import isNumber from 'lodash/isNumber';
+import isFinite from 'lodash/isFinite';
 import { Group } from '@vx/group';
 import { scaleUtc, scaleLinear } from '@vx/scale';
 import { useTooltip } from '@vx/tooltip';
@@ -145,6 +146,7 @@ const SingleLocationChart: React.FC<{
   yTickFormat: (val: number) => string;
   yTooltipFormat: (val: number) => string;
   xTickTimeUnit: TimeUnit;
+  maxYFromDefinition: number | null;
 }> = ({
   width,
   height,
@@ -161,10 +163,13 @@ const SingleLocationChart: React.FC<{
   yTickFormat,
   yTooltipFormat,
   xTickTimeUnit,
+  maxYFromDefinition,
 }) => {
   const [dateFrom, dateTo] = dateRange;
 
-  const maxY = getMaxY(seriesList, dateFrom, dateTo);
+  const maxY = isFinite(maxYFromDefinition)
+    ? maxYFromDefinition
+    : getMaxY(seriesList, dateFrom, dateTo);
 
   const numDays = daysBetween(dateFrom, dateTo);
 

--- a/src/components/Explore/utils.ts
+++ b/src/components/Explore/utils.ts
@@ -167,6 +167,7 @@ interface ExploreMetricDescription {
   seriesList: SerieDescription[];
   dataMeasure: DataMeasure;
   yAxisDecimalPlaces: number;
+  maxY?: number;
 }
 
 export const exploreMetricData: {
@@ -236,7 +237,7 @@ export const exploreMetricData: {
     ],
   },
   [ExploreMetric.ICU_HOSPITALIZATIONS]: {
-    title: 'ICU Hospitalizations',
+    title: 'ICU hospitalizations',
     name: 'Current COVID ICU Hospitalizations',
     chartId: 'icu-hospitalizations',
     dataMeasure: DataMeasure.INTEGER,
@@ -257,11 +258,12 @@ export const exploreMetricData: {
     ],
   },
   [ExploreMetric.VACCINATIONS_FIRST_DOSE]: {
-    title: 'Percent Vaccinated (1+ dose)',
-    name: 'Percent Vaccinated (1+ dose)',
+    title: 'Percent vaccinated (1+ dose)',
+    name: 'Percent vaccinated (1+ dose)',
     chartId: 'vaccinations_first_dose',
     dataMeasure: DataMeasure.PERCENT,
     yAxisDecimalPlaces: 0,
+    maxY: 1,
     seriesList: [
       {
         label: 'Percent Vaccinated (1+ dose)',
@@ -272,11 +274,12 @@ export const exploreMetricData: {
     ],
   },
   [ExploreMetric.VACCINATIONS_COMPLETED]: {
-    title: 'Percent Vaccinated (fully)',
-    name: 'Percent Vaccinated (fully)',
+    title: 'Percent vaccinated (fully)',
+    name: 'Percent vaccinated (fully)',
     chartId: 'vaccinations_completed',
     dataMeasure: DataMeasure.PERCENT,
     yAxisDecimalPlaces: 0,
+    maxY: 1,
     seriesList: [
       {
         label: 'Percent Vaccinated (fully)',
@@ -398,6 +401,11 @@ export function getMetricDataMeasure(metric: ExploreMetric) {
 
 export function getYAxisDecimalPlaces(metric: ExploreMetric) {
   return exploreMetricData[metric].yAxisDecimalPlaces;
+}
+
+export function getMaxYFromDefinition(metric: ExploreMetric): number | null {
+  const maxY = exploreMetricData[metric].maxY;
+  return !maxY ? null : maxY;
 }
 
 export function getMetricName(metric: ExploreMetric) {

--- a/src/components/RegionItem/RegionItemSkeleton.tsx
+++ b/src/components/RegionItem/RegionItemSkeleton.tsx
@@ -4,7 +4,6 @@ import {
   Column,
   StyledSkeletonRect,
   CircleIcon,
-  ArrowIcon,
 } from './RegionItem.style';
 import { COLOR_MAP } from 'common/colors';
 
@@ -16,7 +15,6 @@ const RegionItemSkeleton = () => {
         <StyledSkeletonRect width={210} height={14} />
         <StyledSkeletonRect width={75} height={14} />
       </Column>
-      <ArrowIcon />
     </SkeletonWrapper>
   );
 };

--- a/src/screens/HomePage/HomePage.style.tsx
+++ b/src/screens/HomePage/HomePage.style.tsx
@@ -2,6 +2,10 @@ import styled from 'styled-components';
 import { Box } from '@material-ui/core';
 import { Subtitle1 } from 'components/Typography';
 import { mobileBreakpoint, materialSMBreakpoint } from 'assets/theme/sizes';
+import {
+  StyledLink as RegionItemWrappingLink,
+  SkeletonWrapper as RegionItemSkeletonWrapper,
+} from 'components/RegionItem/RegionItem.style';
 
 export const ColumnCentered = styled.div<{ $topBottomSpacing?: boolean }>`
   display: flex;
@@ -23,13 +27,18 @@ export const Section = styled.div`
 export const RegionItemsWrapper = styled.div`
   display: flex;
   flex-direction: row;
-  gap: 0.75rem;
   margin-top: 0.75rem;
   margin-bottom: 2.25rem;
   margin-left: 1rem;
   margin-right: 0;
   flex: 1;
   overflow-x: auto;
+
+  ${RegionItemWrappingLink},${RegionItemSkeletonWrapper} {
+    &:first-of-type{
+      margin-right: .75rem;
+    }
+  }
 
   @media (min-width: ${materialSMBreakpoint}) {
     flex-direction: row;

--- a/src/screens/internal/ShareImage/ExploreChartExportImage.tsx
+++ b/src/screens/internal/ShareImage/ExploreChartExportImage.tsx
@@ -24,6 +24,7 @@ import {
   getMetricDataMeasure,
   getDateRange,
   getYFormat,
+  getMaxYFromDefinition,
 } from 'components/Explore/utils';
 import regions, { Region } from 'common/regions';
 import { TimeUnit } from 'common/utils/time-utils';
@@ -63,6 +64,7 @@ const ExploreChartExportImage = ({
   const dataMeasure = getMetricDataMeasure(currentMetric);
   const yTickFormat = getYFormat(dataMeasure, 0);
   const yTooltipFormat = getYFormat(dataMeasure, 1);
+  const maxYFromDefinition = getMaxYFromDefinition(currentMetric);
 
   const dateRange = getDateRange(Period.ALL);
 
@@ -94,6 +96,7 @@ const ExploreChartExportImage = ({
                 yTickFormat={yTickFormat}
                 yTooltipFormat={yTooltipFormat}
                 xTickTimeUnit={TimeUnit.MONTHS}
+                maxYFromDefinition={maxYFromDefinition}
               />
             )}
           </ParentSize>

--- a/src/screens/internal/ShareImage/ExploreChartImage.tsx
+++ b/src/screens/internal/ShareImage/ExploreChartImage.tsx
@@ -21,6 +21,7 @@ import {
   getMetricDataMeasure,
   getDateRange,
   getYFormat,
+  getMaxYFromDefinition,
 } from 'components/Explore/utils';
 import { Series } from 'components/Explore/interfaces';
 import regions, { Region } from 'common/regions';
@@ -49,6 +50,7 @@ const ExploreChartImage = ({ componentParams }: { componentParams: any }) => {
   const dataMeasure = getMetricDataMeasure(currentMetric);
   const yTickFormat = getYFormat(dataMeasure, 0);
   const yTooltipFormat = getYFormat(dataMeasure, 1);
+  const maxYFromDefinition = getMaxYFromDefinition(currentMetric);
 
   const dateRange = getDateRange(Period.ALL);
 
@@ -85,6 +87,7 @@ const ExploreChartImage = ({ componentParams }: { componentParams: any }) => {
                   yTickFormat={yTickFormat}
                   yTooltipFormat={yTooltipFormat}
                   xTickTimeUnit={TimeUnit.MONTHS}
+                  maxYFromDefinition={maxYFromDefinition}
                 />
               )}
             </ParentSize>


### PR DESCRIPTION
- Sets maxY of percent vaccinated charts to 100%
- Makes location list in button semicolon separated instead of comma separated
- Fixes location selector modal (was opening upward on mobile and going off screen--now always opens downward)
- Misc. style edits
- Replaces uses of `gap` property with margins, as `gap` doesnt seem to work on phones