### PR TITLE
Search location name format edit

### DIFF
--- a/src/components/SharedComponents/StyledRegionName/StyledRegionName.tsx
+++ b/src/components/SharedComponents/StyledRegionName/StyledRegionName.tsx
@@ -32,7 +32,9 @@ const StyledRegionName: React.FC<{
       {regionNameMain}
       {regionSuffix && (
         <Suffix>
-          {regionSuffix !== 'metro' ? ` ${regionSuffix}` : ` ${regionSuffix},`}
+          {condensed && regionSuffix !== 'metro'
+            ? ` ${regionSuffix}`
+            : ` ${regionSuffix},`}
         </Suffix>
       )}
       {!regionSuffix && !(region instanceof State) && <Suffix>,</Suffix>}


### PR DESCRIPTION
Adds comma between county name and state code in searchbar menu ([explanation in trello](https://trello.com/c/OScl5U0A/1404-update-format-of-location-names-in-search-dropdown-menu-items))

Before: 
![Screen Shot 2021-06-07 at 10 37 30 AM](https://user-images.githubusercontent.com/44076375/121035957-5f14c180-c77c-11eb-8c60-95f59d06416d.png)

After:
![Screen Shot 2021-06-07 at 10 37 53 AM](https://user-images.githubusercontent.com/44076375/121036023-6c31b080-c77c-11eb-8547-d9835610ef95.png)
