### PR TITLE
Fix box shadow on geolocated cards

### DIFF
--- a/src/common/hooks/useGeolocation.ts
+++ b/src/common/hooks/useGeolocation.ts
@@ -8,7 +8,7 @@
 
 import { singletonHook } from 'react-singleton-hook';
 import { useEffect, useState } from 'react';
-import { IP_API_KEY } from 'common/ip-api';
+// import { IP_API_KEY } from 'common/ip-api';
 
 // move this elsewhere
 export interface GeolocationInfo {
@@ -31,12 +31,12 @@ const useGeolocation = singletonHook(
     useEffect(() => {
       const fetchIpData = () => {
         setIsLoading(true);
-        fetchGeolocationData()
+        mockGeolocationData()
           .then(data => {
             setIpData({
-              zipCode: data.zip,
-              stateCode: data.region,
-              country: data.country,
+              zipCode: '20149',
+              stateCode: 'VA',
+              country: 'United States',
             });
             setIsLoading(false);
           })
@@ -57,18 +57,17 @@ const useGeolocation = singletonHook(
   },
 );
 
-function fetchGeolocationData() {
-  return fetch(
-    `https://pro.ip-api.com/json/?key=${IP_API_KEY}`,
-  ).then(response => response.json());
-}
+// function fetchGeolocationData() {
+//   return fetch(
+//     `https://pro.ip-api.com/json/?key=${IP_API_KEY}`,
+//   ).then(response => response.json());
+// }
 
 // Use this mock to simulate fetchGeolocationData, other data can be obtained from
 // https://ip-api.com/#<IP_ADDRESS> (https://ip-api.com/#8.8.8.8)
-/*
 function mockGeolocationData() {
   // how many seconds to wait before returning fake geolocation data
-  const GEO_WAIT_SECONDS = 30;
+  const GEO_WAIT_SECONDS = 1;
   return new Promise((resolve, reject) => {
     setTimeout(() => {
       resolve({
@@ -95,9 +94,8 @@ function mockGeolocationData() {
         mobile: false,
         proxy: false,
         hosting: true,
-     });
+      });
     }, GEO_WAIT_SECONDS * 1000);
   });
 }
-*/
 export default useGeolocation;

--- a/src/common/hooks/useGeolocation.ts
+++ b/src/common/hooks/useGeolocation.ts
@@ -8,7 +8,7 @@
 
 import { singletonHook } from 'react-singleton-hook';
 import { useEffect, useState } from 'react';
-// import { IP_API_KEY } from 'common/ip-api';
+import { IP_API_KEY } from 'common/ip-api';
 
 // move this elsewhere
 export interface GeolocationInfo {
@@ -31,12 +31,12 @@ const useGeolocation = singletonHook(
     useEffect(() => {
       const fetchIpData = () => {
         setIsLoading(true);
-        mockGeolocationData()
+        fetchGeolocationData()
           .then(data => {
             setIpData({
-              zipCode: '20149',
-              stateCode: 'VA',
-              country: 'United States',
+              zipCode: data.zip,
+              stateCode: data.region,
+              country: data.country,
             });
             setIsLoading(false);
           })
@@ -57,17 +57,18 @@ const useGeolocation = singletonHook(
   },
 );
 
-// function fetchGeolocationData() {
-//   return fetch(
-//     `https://pro.ip-api.com/json/?key=${IP_API_KEY}`,
-//   ).then(response => response.json());
-// }
+function fetchGeolocationData() {
+  return fetch(
+    `https://pro.ip-api.com/json/?key=${IP_API_KEY}`,
+  ).then(response => response.json());
+}
 
 // Use this mock to simulate fetchGeolocationData, other data can be obtained from
 // https://ip-api.com/#<IP_ADDRESS> (https://ip-api.com/#8.8.8.8)
+/*
 function mockGeolocationData() {
   // how many seconds to wait before returning fake geolocation data
-  const GEO_WAIT_SECONDS = 1;
+  const GEO_WAIT_SECONDS = 30;
   return new Promise((resolve, reject) => {
     setTimeout(() => {
       resolve({
@@ -94,8 +95,9 @@ function mockGeolocationData() {
         mobile: false,
         proxy: false,
         hosting: true,
-      });
+     });
     }, GEO_WAIT_SECONDS * 1000);
   });
 }
+*/
 export default useGeolocation;

--- a/src/components/RegionItem/RegionItem.style.tsx
+++ b/src/components/RegionItem/RegionItem.style.tsx
@@ -61,7 +61,10 @@ export const LevelDescription = styled.span`
 export const StyledLink = styled(Link)`
   color: inherit;
   text-decoration: none;
-  margin: 0.4rem;
+
+  @media (min-width: ${materialSMBreakpoint}) {
+    padding: 0.4rem;
+  }
 `;
 
 export const SharedWrapperStyles = css`
@@ -82,8 +85,10 @@ export const Wrapper = styled.div`
   cursor: pointer;
   transition: box-shadow 0.1s ease-in-out;
 
-  :hover {
-    box-shadow: 0 0 6px rgba(0, 0, 0, 0.12);
+  @media (min-width: ${materialSMBreakpoint}) {
+    :hover {
+      box-shadow: 0 0 6px rgba(0, 0, 0, 0.12);
+    }
   }
 `;
 

--- a/src/components/RegionItem/RegionItem.style.tsx
+++ b/src/components/RegionItem/RegionItem.style.tsx
@@ -61,6 +61,7 @@ export const LevelDescription = styled.span`
 export const StyledLink = styled(Link)`
   color: inherit;
   text-decoration: none;
+  margin: 0.4rem;
 `;
 
 export const SharedWrapperStyles = css`
@@ -82,7 +83,7 @@ export const Wrapper = styled.div`
   transition: box-shadow 0.1s ease-in-out;
 
   :hover {
-    box-shadow: 0px 2px 24px rgba(0, 0, 0, 0.12);
+    box-shadow: 0 0 6px rgba(0, 0, 0, 0.12);
   }
 `;
 


### PR DESCRIPTION
This PR fixes the box shadow on geolocated cards on the homepage by ensuring there is enough margin around each card for the shadow to show. Additional notes:
- This PR also aligns box shadow styling to match the search bar.
- Ignore `useGeolocation.ts` for now. This will be reset back to its original version once the PR is approved.