### PR TITLE
Fix labels in vaccine chart share images.

### DIFF
--- a/src/components/Charts/Charts.style.ts
+++ b/src/components/Charts/Charts.style.ts
@@ -191,7 +191,7 @@ export const LegendLabel = styled.span`
 // Vaccination Label
 export const VaccinationLabel = styled.g`
   rect {
-    fill: white;
+    fill: ${props => palette(props).background};
   }
   text {
     ${props => props.theme.fonts.regularBook};


### PR DESCRIPTION
Use the theme background color for chart labels in vaccination chart.

Before:
![image](https://user-images.githubusercontent.com/206364/121274277-0417c300-c87f-11eb-8d59-8c3e1c38a3bb.png)

After:
![image](https://user-images.githubusercontent.com/206364/121274259-fcf0b500-c87e-11eb-88ea-1dd37c5efd4f.png)
