### PR TITLE
Ensure location URL doesn't get added to history stack twice

### DIFF
--- a/src/components/Compare/CompareTableRow.tsx
+++ b/src/components/Compare/CompareTableRow.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { useHistory } from 'react-router-dom';
 import isNumber from 'lodash/isNumber';
 import FiberManualRecordIcon from '@material-ui/icons/FiberManualRecord';
 import {
@@ -43,8 +42,6 @@ const CompareTableRow = (props: {
     showStateCode,
   } = props;
 
-  const history = useHistory();
-
   const fipsCode = location.region.fipsCode;
 
   const region = regions.findByFipsCode(fipsCode);
@@ -57,7 +54,7 @@ const CompareTableRow = (props: {
   const populationRoundTo = isHomepage ? 3 : 2;
 
   const navigate = () => {
-    history.push(locationLink);
+    window.location.href = locationLink;
   };
 
   return (


### PR DESCRIPTION
This PR fixes the issue of the browser back button needing to be clicked twice to navigate back to the homepage (after the user clicks on a location on the compare table).