### PR TITLE
Investigate frozen zoom on location input

### DIFF
--- a/src/components/AutocompleteRegions/AutocompleteRegions.style.ts
+++ b/src/components/AutocompleteRegions/AutocompleteRegions.style.ts
@@ -12,7 +12,7 @@ export const StyledTextField = styled(TextField)<{
   .MuiAutocomplete-inputRoot[class*='MuiOutlinedInput-root']
     .MuiAutocomplete-input {
     font-weight: 500;
-    font-size: 16px;
+    font-size: 1rem;
     min-width: ${props => props.$placeholderMinWidth};
   }
 `;

--- a/src/components/AutocompleteRegions/AutocompleteRegions.style.ts
+++ b/src/components/AutocompleteRegions/AutocompleteRegions.style.ts
@@ -12,7 +12,7 @@ export const StyledTextField = styled(TextField)<{
   .MuiAutocomplete-inputRoot[class*='MuiOutlinedInput-root']
     .MuiAutocomplete-input {
     font-weight: 500;
-    font-size: 13px;
+    font-size: 16px;
     min-width: ${props => props.$placeholderMinWidth};
   }
 `;


### PR DESCRIPTION
This PR fixes the issue of the screen freezing after the user adds a new location on the explore chart. This only happens on mobile. Adjusting the font size to be at least 16 px / 1 rem prevents the screen from freezing.

Some forum discussion regarding the issue: https://stackoverflow.com/questions/2989263/disable-auto-zoom-in-input-text-tag-safari-on-iphone