### PR TITLE
Add 'per 100K' to the chart metric labels

### DIFF
--- a/src/components/Explore/Explore.tsx
+++ b/src/components/Explore/Explore.tsx
@@ -115,7 +115,6 @@ const Explore: React.FunctionComponent<{
     const theme = useTheme();
     const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
     const isMobileXs = useMediaQuery(theme.breakpoints.down('xs'));
-    const metricLabels = getMetricLabels();
 
     const { sharedComponentId } = useParams<{
       sharedComponentId?: string;
@@ -168,6 +167,8 @@ const Explore: React.FunctionComponent<{
       selectedLocations.length > 1 &&
         ORIGINAL_EXPLORE_METRICS.includes(currentMetric),
     );
+
+    const metricLabels = getMetricLabels(normalizeData);
 
     const dateRange = getDateRange(period);
 

--- a/src/components/Explore/Explore.tsx
+++ b/src/components/Explore/Explore.tsx
@@ -162,13 +162,14 @@ const Explore: React.FunctionComponent<{
 
     const [period, setPeriod] = useState<Period>(Period.ALL);
 
+    const multiLocation = selectedLocations.length > 1;
+
     // TODO (chelsi) - does this need to be state?
     const [normalizeData, setNormalizeData] = useState(
-      selectedLocations.length > 1 &&
-        ORIGINAL_EXPLORE_METRICS.includes(currentMetric),
+      multiLocation && ORIGINAL_EXPLORE_METRICS.includes(currentMetric),
     );
 
-    const metricLabels = getMetricLabels(normalizeData);
+    const metricLabels = getMetricLabels(multiLocation);
 
     const dateRange = getDateRange(period);
 

--- a/src/components/Explore/utils.ts
+++ b/src/components/Explore/utils.ts
@@ -95,6 +95,11 @@ export const EXPLORE_METRICS = [
   ExploreMetric.POSITIVITY_RATE,
 ];
 
+// Note that these specifically are counts, not percentages, and can normalized
+// to per 100K when multiple locations are displayed, in which case we manipulate
+// the labels to indicate the 'per 100K'.
+// Therefore, don't add a 'percentage' type metric to this without updating
+// that code accordingly.
 export const ORIGINAL_EXPLORE_METRICS = [
   ExploreMetric.CASES,
   ExploreMetric.DEATHS,
@@ -417,9 +422,14 @@ export function getChartIdByMetric(metric: ExploreMetric) {
 }
 
 export function getMetricLabels(normalizeData: boolean): string[] {
-  const getTitleNormalized = (metric: ExploreMetric) =>
-    getTitle(metric) + ' per 100K';
-  return EXPLORE_METRICS.map(normalizeData ? getTitleNormalized : getTitle);
+  return EXPLORE_METRICS.map((metric: ExploreMetric) => {
+    const title = getTitle(metric);
+    if (normalizeData && ORIGINAL_EXPLORE_METRICS.includes(metric)) {
+      return title + ' per 100K';
+    } else {
+      return title;
+    }
+  });
 }
 
 export function findPointByDate(data: Column[], date: Date): Column | null {

--- a/src/components/Explore/utils.ts
+++ b/src/components/Explore/utils.ts
@@ -421,10 +421,10 @@ export function getChartIdByMetric(metric: ExploreMetric) {
   return exploreMetricData[metric].chartId;
 }
 
-export function getMetricLabels(normalizeData: boolean): string[] {
+export function getMetricLabels(multiLocation: boolean): string[] {
   return EXPLORE_METRICS.map((metric: ExploreMetric) => {
     const title = getTitle(metric);
-    if (normalizeData && ORIGINAL_EXPLORE_METRICS.includes(metric)) {
+    if (multiLocation && ORIGINAL_EXPLORE_METRICS.includes(metric)) {
       return title + ' per 100K';
     } else {
       return title;

--- a/src/components/Explore/utils.ts
+++ b/src/components/Explore/utils.ts
@@ -416,8 +416,10 @@ export function getChartIdByMetric(metric: ExploreMetric) {
   return exploreMetricData[metric].chartId;
 }
 
-export function getMetricLabels() {
-  return EXPLORE_METRICS.map(getTitle);
+export function getMetricLabels(normalizeData: boolean): string[] {
+  const getTitleNormalized = (metric: ExploreMetric) =>
+    getTitle(metric) + ' per 100K';
+  return EXPLORE_METRICS.map(normalizeData ? getTitleNormalized : getTitle);
 }
 
 export function findPointByDate(data: Column[], date: Date): Column | null {


### PR DESCRIPTION
Single series, not normalized:
![image](https://user-images.githubusercontent.com/351548/121763196-e18be100-caee-11eb-8f25-6fdaee0ab6c2.png)
(menu):
![image](https://user-images.githubusercontent.com/351548/121763209-f36d8400-caee-11eb-9814-1e1efbf3175a.png)

Multiple series, normalized:
![image](https://user-images.githubusercontent.com/351548/121763216-07b18100-caef-11eb-996d-f26270fd899e.png)
(menu):
![image](https://user-images.githubusercontent.com/351548/121763219-11d37f80-caef-11eb-9928-b161a6ad0017.png)


This appears to be the only change needed to implement this, but if I'm missing something, please call it out and I'll add it.