### PR TITLE
Fix explore locations bug

### DIFF
--- a/src/components/Explore/Explore.tsx
+++ b/src/components/Explore/Explore.tsx
@@ -242,11 +242,6 @@ const Explore: React.FunctionComponent<{
         const timeoutId = scrollToExplore();
         return () => clearTimeout(timeoutId);
       }
-      setSelectedLocations(initialLocations);
-      setNormalizeData(
-        initialLocations.length > 1 &&
-          ORIGINAL_EXPLORE_METRICS.includes(currentMetric),
-      );
     }, [currentMetric, initialLocations, pathname, scrollToExplore]);
 
     // if the pathname changes (ie. if navigating between location pages via compare or minimap)-

--- a/src/components/Explore/Explore.tsx
+++ b/src/components/Explore/Explore.tsx
@@ -242,7 +242,7 @@ const Explore: React.FunctionComponent<{
         const timeoutId = scrollToExplore();
         return () => clearTimeout(timeoutId);
       }
-    }, [currentMetric, initialLocations, pathname, scrollToExplore]);
+    }, [pathname, scrollToExplore]);
 
     // if the pathname changes (ie. if navigating between location pages via compare or minimap)-
     // resets metric, time period, and locations
@@ -272,13 +272,7 @@ const Explore: React.FunctionComponent<{
         selectedLocations.length > 1 &&
           ORIGINAL_EXPLORE_METRICS.includes(currentMetric),
       );
-    }, [
-      currentMetric,
-      selectedLocations,
-      metricLabels,
-      allPeriodLabels,
-      period,
-    ]);
+    }, [currentMetric, selectedLocations]);
 
     const trackingLabel = hasMultipleLocations
       ? `Multiple Locations`


### PR DESCRIPTION
Location selection currently resets to `initialLocations` whenever a new explore metric is selected. This fixes + cleans up dependencies