### PR TITLE
Replace compare table sliders

### DIFF
--- a/src/common/utils/compare.ts
+++ b/src/common/utils/compare.ts
@@ -254,6 +254,28 @@ export const sliderNumberToFilterMap: { [val: number]: GeoScopeFilter } = {
   99: GeoScopeFilter.COUNTRY,
 };
 
+export function labelToFilterMap(val: string): GeoScopeFilter {
+  if (val === 'Nearby') {
+    return GeoScopeFilter.NEARBY;
+  } else if (val === 'USA') {
+    return GeoScopeFilter.COUNTRY;
+  } else return GeoScopeFilter.STATE;
+}
+
+export function scopeToValueMap(
+  locationLevel: GeoScopeFilter,
+  stateId: string | undefined,
+): string {
+  if (locationLevel === GeoScopeFilter.NEARBY) {
+    return 'Nearby';
+  } else if (locationLevel === GeoScopeFilter.COUNTRY) {
+    return 'USA';
+  } else if (stateId) {
+    return stateId;
+  }
+  return '';
+}
+
 export const scopeValueMap = {
   [GeoScopeFilter.NEARBY]: 0,
   [GeoScopeFilter.STATE]: 50,
@@ -267,6 +289,20 @@ export const homepageSliderNumberToFilterMap: {
   0: HomepageLocationScope.COUNTY,
   50: HomepageLocationScope.MSA,
   99: HomepageLocationScope.STATE,
+};
+
+export const homepageLabelToFilterMap: {
+  [val: string]: HomepageLocationScope;
+} = {
+  Counties: HomepageLocationScope.COUNTY,
+  'Metro areas': HomepageLocationScope.MSA,
+  States: HomepageLocationScope.STATE,
+};
+
+export const homepageScopeToValueMap = {
+  [HomepageLocationScope.COUNTY]: 'Counties',
+  [HomepageLocationScope.MSA]: 'Metro areas',
+  [HomepageLocationScope.STATE]: 'States',
 };
 
 export const homepageScopeValueMap = {

--- a/src/common/utils/compare.ts
+++ b/src/common/utils/compare.ts
@@ -254,7 +254,7 @@ export const sliderNumberToFilterMap: { [val: number]: GeoScopeFilter } = {
   99: GeoScopeFilter.COUNTRY,
 };
 
-export function labelToFilterMap(val: string): GeoScopeFilter {
+export function locationPageLabelToFilterMap(val: string): GeoScopeFilter {
   switch (val) {
     case 'Nearby':
       return GeoScopeFilter.NEARBY;
@@ -265,7 +265,7 @@ export function labelToFilterMap(val: string): GeoScopeFilter {
   }
 }
 
-export function scopeToValueMap(
+export function locationPageScopeToValueMap(
   locationLevel: GeoScopeFilter,
   stateId: string | undefined,
 ): string {

--- a/src/common/utils/compare.ts
+++ b/src/common/utils/compare.ts
@@ -255,25 +255,28 @@ export const sliderNumberToFilterMap: { [val: number]: GeoScopeFilter } = {
 };
 
 export function labelToFilterMap(val: string): GeoScopeFilter {
-  if (val === 'Nearby') {
-    return GeoScopeFilter.NEARBY;
-  } else if (val === 'USA') {
-    return GeoScopeFilter.COUNTRY;
-  } else return GeoScopeFilter.STATE;
+  switch (val) {
+    case 'Nearby':
+      return GeoScopeFilter.NEARBY;
+    case 'USA':
+      return GeoScopeFilter.COUNTRY;
+    default:
+      return GeoScopeFilter.STATE;
+  }
 }
 
 export function scopeToValueMap(
   locationLevel: GeoScopeFilter,
   stateId: string | undefined,
 ): string {
-  if (locationLevel === GeoScopeFilter.NEARBY) {
-    return 'Nearby';
-  } else if (locationLevel === GeoScopeFilter.COUNTRY) {
-    return 'USA';
-  } else if (stateId) {
-    return stateId;
+  switch (locationLevel) {
+    case GeoScopeFilter.NEARBY:
+      return 'Nearby';
+    case GeoScopeFilter.COUNTRY:
+      return 'USA';
+    default:
+      return stateId ? stateId : '';
   }
-  return '';
 }
 
 export const scopeValueMap = {

--- a/src/components/Compare/Compare.style.tsx
+++ b/src/components/Compare/Compare.style.tsx
@@ -8,6 +8,7 @@ import { COLORS } from 'common';
 import { COLOR_MAP, LEVEL_COLOR } from 'common/colors';
 import { Level } from 'common/level';
 import { materialSMBreakpoint } from 'assets/theme/sizes';
+import { SectionHeader } from 'components/SharedComponents/SharedComponents.style';
 
 // TODO (Chelsi): consolidate into a theme:
 
@@ -494,7 +495,7 @@ export const HeaderContainer = styled.div`
   display: flex;
   flex-wrap: wrap;
   justify-content: space-between;
-  margin: 0 0 1.5rem 0;
+  margin-bottom: 1.5rem;
   .MuiToggleButtonGroup-root {
     margin-top: 0.5rem;
   }
@@ -510,10 +511,7 @@ export const HeaderContainer = styled.div`
   }
 `;
 
-export const CompareHeader = styled.h2`
-  ${props => props.theme.fonts.regularBookBold};
-  font-size: 1.5rem;
-  letter-spacing: 0;
+export const CompareHeader = styled(SectionHeader)`
   line-height: 1.5;
   margin: 0;
 

--- a/src/components/Compare/Compare.style.tsx
+++ b/src/components/Compare/Compare.style.tsx
@@ -492,11 +492,21 @@ export const StateName = styled.div`
 
 export const HeaderContainer = styled.div`
   display: flex;
+  flex-wrap: wrap;
   justify-content: space-between;
   margin: 0 0 1.5rem 0;
+  .MuiToggleButtonGroup-root {
+    margin-top: 0.5rem;
+  }
 
   @media (min-width: ${materialSMBreakpoint}) {
     justify-content: flex-start;
+  }
+
+  @media (min-width: 375px) {
+    .MuiToggleButtonGroup-root {
+      margin: 0;
+    }
   }
 `;
 

--- a/src/components/Compare/Compare.style.tsx
+++ b/src/components/Compare/Compare.style.tsx
@@ -7,6 +7,7 @@ import { Wrapper as LocationName } from 'components/SharedComponents/StyledRegio
 import { COLORS } from 'common';
 import { COLOR_MAP, LEVEL_COLOR } from 'common/colors';
 import { Level } from 'common/level';
+import { materialSMBreakpoint } from 'assets/theme/sizes';
 
 // TODO (Chelsi): consolidate into a theme:
 
@@ -487,4 +488,26 @@ export const DivForRef = styled.div``;
 export const StateName = styled.div`
   font-size: 0.9rem;
   line-height: 1.2;
+`;
+
+export const HeaderContainer = styled.div`
+  display: flex;
+  justify-content: space-between;
+  margin: 0 0 1.5rem 0;
+
+  @media (min-width: ${materialSMBreakpoint}) {
+    justify-content: flex-start;
+  }
+`;
+
+export const CompareHeader = styled.h2`
+  ${props => props.theme.fonts.regularBookBold};
+  font-size: 1.5rem;
+  letter-spacing: 0;
+  line-height: 1.5;
+  margin: 0;
+
+  @media (min-width: ${materialSMBreakpoint}) {
+    margin: 0 2.5rem 0 0;
+  }
 `;

--- a/src/components/Compare/CompareTable.tsx
+++ b/src/components/Compare/CompareTable.tsx
@@ -4,7 +4,13 @@ import findIndex from 'lodash/findIndex';
 import partition from 'lodash/partition';
 import reverse from 'lodash/reverse';
 import isNumber from 'lodash/isNumber';
-import { Wrapper, Footer, FooterText } from 'components/Compare/Compare.style';
+import {
+  Wrapper,
+  Footer,
+  FooterText,
+  HeaderContainer,
+  CompareHeader,
+} from 'components/Compare/Compare.style';
 import LocationTable from './LocationTable';
 import Filters from 'components/Compare/Filters';
 import {
@@ -29,7 +35,6 @@ import {
 } from './columns';
 import { TextButton } from 'components/ButtonSystem/MainButtons.style';
 import { EventCategory } from 'components/Analytics/utils';
-import { SectionHeader } from 'components/SharedComponents';
 
 function trackShare(label: string) {
   trackCompareEvent(EventAction.SHARE, label);
@@ -209,8 +214,8 @@ const CompareTable = (props: {
   return (
     <Wrapper $isModal={props.isModal} $isHomepage={props.isHomepage}>
       {!props.isModal && (
-        <>
-          <SectionHeader>Compare</SectionHeader>
+        <HeaderContainer>
+          <CompareHeader>Compare</CompareHeader>
           {!disableFilters && (
             <Filters
               isHomepage={props.isHomepage}
@@ -225,7 +230,7 @@ const CompareTable = (props: {
               homepageSliderValue={homepageSliderValue}
             />
           )}
-        </>
+        </HeaderContainer>
       )}
       <LocationTable
         firstColumnHeader={firstColumnHeader}

--- a/src/components/Compare/Filters.style.tsx
+++ b/src/components/Compare/Filters.style.tsx
@@ -21,7 +21,7 @@ export const Container = styled.div<{
 }>`
   display: flex;
   margin: ${({ $isModal }) => $isModal && '1rem auto 0'};
-  padding: ${({ $isModal }) => ($isModal ? '0 0 0 1.75rem' : '0 0 0.75rem')};
+  padding: ${({ $isModal }) => ($isModal ? '0' : '0 0 0.75rem')};
   justify-content: ${({ $isHomepage, $isModal }) =>
     $isHomepage && $isModal && 'center'};
   flex-direction: column;

--- a/src/components/Compare/Filters.style.tsx
+++ b/src/components/Compare/Filters.style.tsx
@@ -20,8 +20,7 @@ export const Container = styled.div<{
   $isHomepage?: boolean;
 }>`
   display: flex;
-  margin: ${({ $isModal }) => $isModal && '1rem auto 0'};
-  padding: ${({ $isModal }) => ($isModal ? '0' : '0 0 0.75rem')};
+  margin: ${({ $isModal }) => $isModal && '0 auto'};
   justify-content: ${({ $isHomepage, $isModal }) =>
     $isHomepage && $isModal && 'center'};
   flex-direction: column;

--- a/src/components/Compare/Filters.tsx
+++ b/src/components/Compare/Filters.tsx
@@ -3,11 +3,11 @@ import {
   GeoScopeFilter,
   trackCompareEvent,
   HomepageLocationScope,
-  labelToFilterMap,
+  locationPageLabelToFilterMap,
   homepageLabelToFilterMap,
   homepageLabelMap,
   homepageScopeToValueMap,
-  scopeToValueMap,
+  locationPageScopeToValueMap,
 } from 'common/utils/compare';
 import { Container } from 'components/Compare/Filters.style';
 import { EventAction } from 'components/Analytics';
@@ -39,11 +39,11 @@ const Filters = (props: {
     event: React.MouseEvent<HTMLElement>,
     value: string,
   ) => {
-    if (props.setGeoScope && value != null) {
-      props.setGeoScope(labelToFilterMap(value));
+    if (value != null) {
+      props.setGeoScope(locationPageLabelToFilterMap(value));
       trackCompareEvent(
         EventAction.SELECT,
-        `GeoScope: ${GeoScopeFilter[labelToFilterMap(value)]}`,
+        `GeoScope: ${GeoScopeFilter[locationPageLabelToFilterMap(value)]}`,
       );
     }
   };
@@ -52,7 +52,7 @@ const Filters = (props: {
     event: React.MouseEvent<HTMLElement>,
     value: string,
   ) => {
-    if (setHomepageScope && value != null) {
+    if (value != null) {
       setHomepageScope(homepageLabelToFilterMap[value]);
       trackCompareEvent(
         EventAction.SELECT,
@@ -75,7 +75,10 @@ const Filters = (props: {
           <CompareLocationTabs
             locationLevels={locationPageFilterLabels}
             onChange={handleLocationPageSelectedOption}
-            selectedOption={scopeToValueMap(props.geoScope, props.stateId)}
+            selectedOption={locationPageScopeToValueMap(
+              props.geoScope,
+              props.stateId,
+            )}
           />
         )}
       </Container>

--- a/src/components/Compare/Filters.tsx
+++ b/src/components/Compare/Filters.tsx
@@ -3,16 +3,15 @@ import {
   GeoScopeFilter,
   trackCompareEvent,
   HomepageLocationScope,
-  sliderNumberToFilterMap,
-  homepageSliderNumberToFilterMap,
+  labelToFilterMap,
+  homepageLabelToFilterMap,
+  homepageLabelMap,
+  homepageScopeToValueMap,
+  scopeToValueMap,
 } from 'common/utils/compare';
-import {
-  Container,
-  SliderContainer,
-  GeoSlider,
-} from 'components/Compare/Filters.style';
+import { Container } from 'components/Compare/Filters.style';
 import { EventAction } from 'components/Analytics';
-import HomepageSlider from './HomepageSlider';
+import CompareLocationTabs from 'components/NewLocationPage/CompareLocationTabs/CompareLocationTabs';
 
 const Filters = (props: {
   isHomepage?: boolean;
@@ -26,57 +25,38 @@ const Filters = (props: {
   setHomepageScope: React.Dispatch<React.SetStateAction<HomepageLocationScope>>;
   homepageSliderValue: HomepageLocationScope;
 }) => {
-  const {
-    sliderValue,
-    homepageScope,
-    setHomepageScope,
-    homepageSliderValue,
-  } = props;
+  const { setHomepageScope } = props;
 
-  const GeoFilterLabels = {
-    [GeoScopeFilter.NEARBY]: 'Nearby',
-    [GeoScopeFilter.STATE]: `${props.stateId}`,
-    [GeoScopeFilter.COUNTRY]: 'USA',
-  };
-
-  // Last value is set to 99 for styling
-  // so that the final mark falls on the slider and not to the right of it
-  const marks = [
-    {
-      value: 0,
-      label: GeoFilterLabels[GeoScopeFilter.NEARBY],
-    },
-    {
-      value: 50,
-      label: GeoFilterLabels[GeoScopeFilter.STATE],
-    },
-    {
-      value: 99,
-      label: GeoFilterLabels[GeoScopeFilter.COUNTRY],
-    },
+  const homepageFilterLabels = [
+    homepageLabelMap[HomepageLocationScope.COUNTY].plural,
+    homepageLabelMap[HomepageLocationScope.MSA].plural,
+    homepageLabelMap[HomepageLocationScope.STATE].plural,
   ];
 
-  const sliderHandleChange = (event: any, value: any) => {
-    if (props.setGeoScope) {
-      props.setGeoScope(sliderNumberToFilterMap[value]);
+  const locationPageFilterLabels = ['Nearby', `${props.stateId}`, 'USA'];
+
+  const handleLocationPageSelectedOption = (
+    event: React.MouseEvent<HTMLElement>,
+    value: string,
+  ) => {
+    if (props.setGeoScope && value != null) {
+      props.setGeoScope(labelToFilterMap(value));
       trackCompareEvent(
         EventAction.SELECT,
-        `GeoScope: ${GeoScopeFilter[sliderNumberToFilterMap[value]]}`,
+        `GeoScope: ${GeoScopeFilter[labelToFilterMap(value)]}`,
       );
     }
   };
 
-  const homepageSliderHandleChange = (
-    event: React.ChangeEvent<{}>,
-    value: any,
+  const handleHomePageSelectedOption = (
+    event: React.MouseEvent<HTMLElement>,
+    value: string,
   ) => {
-    if (setHomepageScope) {
-      setHomepageScope(homepageSliderNumberToFilterMap[value]);
+    if (setHomepageScope && value != null) {
+      setHomepageScope(homepageLabelToFilterMap[value]);
       trackCompareEvent(
         EventAction.SELECT,
-        `GeoScope: ${
-          HomepageLocationScope[homepageSliderNumberToFilterMap[value]]
-        }`,
+        `GeoScope: ${HomepageLocationScope[homepageLabelToFilterMap[value]]}`,
       );
     }
   };
@@ -85,25 +65,18 @@ const Filters = (props: {
     <Fragment>
       <Container $isModal={props.isModal} $isHomepage={props.isHomepage}>
         {props.isHomepage && (
-          <HomepageSlider
-            homepageScope={homepageScope}
-            onChange={homepageSliderHandleChange}
-            homepageSliderValue={homepageSliderValue}
-            $isModal={props.isModal}
+          <CompareLocationTabs
+            locationLevels={homepageFilterLabels}
+            onChange={handleHomePageSelectedOption}
+            selectedOption={homepageScopeToValueMap[props.homepageScope]}
           />
         )}
         {props.isCounty && (
-          <SliderContainer $isModal={props.isModal}>
-            <GeoSlider
-              onChange={sliderHandleChange}
-              value={sliderValue}
-              step={null}
-              marks={marks}
-              track={false}
-              $isModal={props.isModal}
-              geoScope={props.geoScope}
-            />
-          </SliderContainer>
+          <CompareLocationTabs
+            locationLevels={locationPageFilterLabels}
+            onChange={handleLocationPageSelectedOption}
+            selectedOption={scopeToValueMap(props.geoScope, props.stateId)}
+          />
         )}
       </Container>
     </Fragment>

--- a/src/components/NewLocationPage/CompareLocationTabs/CompareLocationTabs.stories.tsx
+++ b/src/components/NewLocationPage/CompareLocationTabs/CompareLocationTabs.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import CompareLocationTabs from './CompareLocationTabs';
 
 export default {
@@ -7,5 +7,20 @@ export default {
 };
 
 export const CompareLocationTabsExample = () => {
-  return <CompareLocationTabs />;
+  const [selectedOption, setSelectedOption] = useState('VT');
+  const handleSelectedOption = (
+    event: React.MouseEvent<HTMLElement>,
+    newSelection: string,
+  ) => {
+    if (newSelection !== null) {
+      setSelectedOption(newSelection);
+    }
+  };
+  return (
+    <CompareLocationTabs
+      locationLevels={['Nearby', 'VT', 'USA']}
+      onChange={handleSelectedOption}
+      selectedOption={selectedOption}
+    />
+  );
 };

--- a/src/components/NewLocationPage/CompareLocationTabs/CompareLocationTabs.style.tsx
+++ b/src/components/NewLocationPage/CompareLocationTabs/CompareLocationTabs.style.tsx
@@ -20,6 +20,7 @@ export const Button = styled(ToggleButton).attrs(props => ({
     color: ${COLOR_MAP.GRAY_BODY_COPY};
     text-transform: none;
     line-height: 1.4;
+    white-space: no-wrap;
   }
   &.Mui-selected {
     ${props => props.theme.fonts.regularBookMidWeight};

--- a/src/components/NewLocationPage/CompareLocationTabs/CompareLocationTabs.style.tsx
+++ b/src/components/NewLocationPage/CompareLocationTabs/CompareLocationTabs.style.tsx
@@ -14,7 +14,7 @@ export const Button = styled(ToggleButton).attrs(props => ({
   disableRipple: true,
 }))`
   ${props => props.theme.fonts.regularBook};
-  padding: 0.75rem;
+  padding: 0.5rem;
   border: none;
   .MuiToggleButton-label {
     color: ${COLOR_MAP.GRAY_BODY_COPY};

--- a/src/components/NewLocationPage/CompareLocationTabs/CompareLocationTabs.style.tsx
+++ b/src/components/NewLocationPage/CompareLocationTabs/CompareLocationTabs.style.tsx
@@ -4,6 +4,7 @@ import ToggleButton from '@material-ui/lab/ToggleButton';
 import ToggleButtonGroup from '@material-ui/lab/ToggleButtonGroup';
 
 export const ButtonGroup = styled(ToggleButtonGroup)`
+  width: fit-content;
   background-color: ${COLOR_MAP.GREY_1};
   border: 1px solid ${COLOR_MAP.GREY_2};
   border-radius: 4px;

--- a/src/components/NewLocationPage/CompareLocationTabs/CompareLocationTabs.tsx
+++ b/src/components/NewLocationPage/CompareLocationTabs/CompareLocationTabs.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { ButtonGroup, Button } from './CompareLocationTabs.style';
 
 const CompareLocationTabs: React.FC<{

--- a/src/components/NewLocationPage/CompareLocationTabs/CompareLocationTabs.tsx
+++ b/src/components/NewLocationPage/CompareLocationTabs/CompareLocationTabs.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { ButtonGroup, Button } from './CompareLocationTabs.style';
 
 const CompareLocationTabs: React.FC<{
-  locationLevels: Array<string>;
+  locationLevels: string[];
   onChange: (
     event: React.MouseEvent<HTMLElement>,
     newSelection: string,

--- a/src/components/NewLocationPage/CompareLocationTabs/CompareLocationTabs.tsx
+++ b/src/components/NewLocationPage/CompareLocationTabs/CompareLocationTabs.tsx
@@ -1,25 +1,19 @@
 import React, { useState } from 'react';
 import { ButtonGroup, Button } from './CompareLocationTabs.style';
 
-const CompareLocationTabs: React.FC = () => {
-  const [selectedOption, setSelectedOption] = useState('VT');
-  const handleSelectedOption = (
+const CompareLocationTabs: React.FC<{
+  locationLevels: Array<string>;
+  onChange: (
     event: React.MouseEvent<HTMLElement>,
     newSelection: string,
-  ) => {
-    if (newSelection !== null) {
-      setSelectedOption(newSelection);
-    }
-  };
+  ) => void;
+  selectedOption: string;
+}> = ({ locationLevels, onChange, selectedOption }) => {
   return (
-    <ButtonGroup
-      value={selectedOption}
-      exclusive
-      onChange={handleSelectedOption}
-    >
-      <Button value={'Nearby'}>Nearby</Button>
-      <Button value={'VT'}>VT</Button>
-      <Button value={'USA'}>USA</Button>
+    <ButtonGroup value={selectedOption} exclusive onChange={onChange}>
+      {locationLevels.map(locationLevel => (
+        <Button value={locationLevel}>{locationLevel}</Button>
+      ))}
     </ButtonGroup>
   );
 };


### PR DESCRIPTION
This PR replaces the compare table sliders with location button group. Some notes:
- Once merged, some cleanup is required to get rid of no longer used slider code.
- Styling to match the appearance to Figma will be completed in a follow-up PR.