### PR TITLE
Hide explore legend if no data

### DIFF
--- a/src/components/Explore/Legend.tsx
+++ b/src/components/Explore/Legend.tsx
@@ -1,9 +1,16 @@
 import React from 'react';
+import some from 'lodash/some';
 import { Series } from './interfaces';
 import * as Styles from './Explore.style';
 import { LegendMarker } from './SeriesChart';
 
 const Legend: React.FC<{ seriesList: Series[] }> = ({ seriesList }) => {
+  const hasData = some(seriesList, ({ data }) => data.length > 0);
+
+  if (!hasData) {
+    return null;
+  }
+
   return (
     <Styles.LegendContainer>
       {seriesList.map(({ type, label }, i) => (


### PR DESCRIPTION
We are currently rendering the legend even if theres no data/no chart -- this fixes