### PR TITLE
Speed up storybook builds (From ~10s to ~2.5s).

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -6,4 +6,8 @@ module.exports = {
     '@storybook/preset-create-react-app',
     '@storybook/addon-a11y',
   ],
+
+  // This speeds up builds significantly at the cost of doc generation. See:
+  // https://github.com/storybookjs/storybook/issues/12585#issuecomment-701292052
+  typescript: { reactDocgen: 'react-docgen' }
 };


### PR DESCRIPTION
I noticed the build was hanging for a long time on "70% - sealing React Docgen Typescript Plugin" so I did some googling and found https://github.com/storybookjs/storybook/issues/12585#issuecomment-701292052 which has a workaround, though it breaks the "Docs" tab in StoryBook. 😞 