### PR TITLE
Scrolling to chart when clicking summary stat

### DIFF
--- a/src/common/utils/makeChartShareQuote.ts
+++ b/src/common/utils/makeChartShareQuote.ts
@@ -1,6 +1,5 @@
 import { Metric } from 'common/metricEnum';
 import { fail, formatDecimal, formatPercent } from 'common/utils';
-import { ExploreMetric } from 'components/Explore';
 
 //TODO(chelsi): move this copy into individual metric files. remove need for hardcoded identifying numers
 export function makeChartShareQuote(
@@ -35,19 +34,4 @@ export function makeChartShareQuote(
     )} daily new cases per 100k population, according to @CovidActNow. See the chart: `;
   }
   return `I'm keeping track of ${displayName}'s vaccination progress and COVID risk level data with @CovidActNow. What does your community look like?`;
-}
-
-export function makeAddedChartShareQuote(
-  displayName: string,
-  metric: ExploreMetric,
-) {
-  if (metric === ExploreMetric.DEATHS) {
-    return `Daily COVID deaths in ${displayName}, according to @CovidActNow. See the chart: `;
-  } else if (metric === ExploreMetric.ICU_HOSPITALIZATIONS) {
-    return `COVID ICU hospitalizations in ${displayName}, according to @CovidActNow. See the chart: `;
-  } else if (metric === ExploreMetric.HOSPITALIZATIONS) {
-    return `COVID hospitalizations in ${displayName}, according to @CovidActNow. See the chart: `;
-  } else {
-    return `I'm keeping track of ${displayName}'s vaccination progress and COVID risk level data with @CovidActNow. What does your community look like?`;
-  }
 }

--- a/src/common/utils/makeChartShareQuote.ts
+++ b/src/common/utils/makeChartShareQuote.ts
@@ -1,8 +1,9 @@
 import { Metric } from 'common/metricEnum';
 import { fail, formatDecimal, formatPercent } from 'common/utils';
+import { ExploreMetric } from 'components/Explore';
 
 //TODO(chelsi): move this copy into individual metric files. remove need for hardcoded identifying numers
-export default function makeChartShareQuote(
+export function makeChartShareQuote(
   displayName: string,
   stats: any = {},
   chartIdentifier: number,
@@ -33,5 +34,20 @@ export default function makeChartShareQuote(
       1,
     )} daily new cases per 100k population, according to @CovidActNow. See the chart: `;
   }
-  return `I'm keeping track of ${displayName}'s COVID data and risk level with @CovidActNow. What does your community look like?`;
+  return `I'm keeping track of ${displayName}'s vaccination progress and COVID risk level data with @CovidActNow. What does your community look like?`;
+}
+
+export function makeAddedChartShareQuote(
+  displayName: string,
+  metric: ExploreMetric,
+) {
+  if (metric === ExploreMetric.DEATHS) {
+    return `Daily COVID deaths in ${displayName}, according to @CovidActNow. See the chart: `;
+  } else if (metric === ExploreMetric.ICU_HOSPITALIZATIONS) {
+    return `COVID ICU hospitalizations in ${displayName}, according to @CovidActNow. See the chart: `;
+  } else if (metric === ExploreMetric.HOSPITALIZATIONS) {
+    return `COVID hospitalizations in ${displayName}, according to @CovidActNow. See the chart: `;
+  } else {
+    return `I'm keeping track of ${displayName}'s vaccination progress and COVID risk level data with @CovidActNow. What does your community look like?`;
+  }
 }

--- a/src/components/Charts/Redesign/Groupings.tsx
+++ b/src/components/Charts/Redesign/Groupings.tsx
@@ -237,6 +237,5 @@ export const getChartGroupFromMetric = (
       find(group.metricList, metric => metric.metric === metricToScrollTo) !==
       undefined,
   );
-  if (!groupWithMetric) return null;
-  return groupWithMetric;
+  return groupWithMetric ?? null;
 };

--- a/src/components/Charts/Redesign/Groupings.tsx
+++ b/src/components/Charts/Redesign/Groupings.tsx
@@ -228,10 +228,14 @@ export function getValueInfo(
 }
 
 // Used for scrolling to correct chart group when clicking summary stat
-export const getChartGroupFromMetric = (metricToScrollTo: Metric): any => {
-  // Fix the any
-  const groupWithMetric = find(CHART_GROUPS, group =>
-    find(group.metricList, metric => metric.metric === metricToScrollTo),
+export const getChartGroupFromMetric = (
+  metricToScrollTo: Metric,
+): ChartGroup | null => {
+  const groupWithMetric = find(
+    CHART_GROUPS,
+    group =>
+      find(group.metricList, metric => metric.metric === metricToScrollTo) !==
+      undefined,
   );
   if (!groupWithMetric) return null;
   return groupWithMetric;

--- a/src/components/Charts/Redesign/Groupings.tsx
+++ b/src/components/Charts/Redesign/Groupings.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import some from 'lodash/some';
+import find from 'lodash/find';
 import { Metric } from 'common/metricEnum';
 import { ExploreMetric } from 'components/Explore';
 import MetricChart from 'components/Charts/MetricChart';
@@ -38,14 +39,21 @@ export interface MetricChartInfo {
   ) => React.ReactElement;
 }
 
+export enum GroupHeader {
+  VACCINATED = '% Vaccinated',
+  CASES = 'Cases',
+  HOSPITALIZATIONS = 'Hospitalizations',
+  DEATHS = 'Deaths',
+}
+
 export interface ChartGroup {
-  groupHeader: string;
+  groupHeader: GroupHeader;
   metricList: MetricChartInfo[];
 }
 
 export const CHART_GROUPS: ChartGroup[] = [
   {
-    groupHeader: '% Vaccinated',
+    groupHeader: GroupHeader.VACCINATED,
     metricList: [
       {
         metric: Metric.VACCINATIONS,
@@ -60,7 +68,7 @@ export const CHART_GROUPS: ChartGroup[] = [
     ],
   },
   {
-    groupHeader: 'Cases',
+    groupHeader: GroupHeader.CASES,
     metricList: [
       {
         metric: Metric.CASE_DENSITY,
@@ -111,7 +119,7 @@ export const CHART_GROUPS: ChartGroup[] = [
     ],
   },
   {
-    groupHeader: 'Hospitalizations',
+    groupHeader: GroupHeader.HOSPITALIZATIONS,
     metricList: [
       {
         metric: Metric.HOSPITAL_USAGE,
@@ -158,16 +166,13 @@ export const CHART_GROUPS: ChartGroup[] = [
     ],
   },
   {
-    groupHeader: 'Deaths',
+    groupHeader: GroupHeader.DEATHS,
     metricList: [
       {
         metric: ExploreMetric.DEATHS,
         metricType: MetricType.EXPLORE_METRIC,
         renderTabLabel: (metricValue, projections) => (
-          <ChartTab
-            metricName="Daily new deaths"
-            metricValueInfo={metricValue}
-          />
+          <ChartTab metricName="Daily deaths" metricValueInfo={metricValue} />
         ),
         renderChart: projections => (
           <SingleLocationParent
@@ -221,3 +226,13 @@ export function getValueInfo(
     }
   }
 }
+
+// Used for scrolling to correct chart group when clicking summary stat
+export const getChartGroupFromMetric = (metricToScrollTo: Metric): any => {
+  // Fix the any
+  const groupWithMetric = find(CHART_GROUPS, group =>
+    find(group.metricList, metric => metric.metric === metricToScrollTo),
+  );
+  if (!groupWithMetric) return null;
+  return groupWithMetric;
+};

--- a/src/components/Charts/Redesign/NewChartBlock.tsx
+++ b/src/components/Charts/Redesign/NewChartBlock.tsx
@@ -29,6 +29,7 @@ const NewChartBlock: React.FC<{
 }> = ({ projections, stats, group, region, groupRef, clickedStatMetric }) => {
   const { metricList, groupHeader } = group;
 
+  // TODO (chelsi) - revisit placement of these state/setState variables
   const [activeTabIndex, setActiveTabIndex] = useState(0);
   const onChangeTab = (newTabIndex: number) => {
     setActiveTabIndex(newTabIndex);

--- a/src/components/Charts/Redesign/NewChartBlock.tsx
+++ b/src/components/Charts/Redesign/NewChartBlock.tsx
@@ -1,4 +1,6 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
+import findIndex from 'lodash/findIndex';
+import isNull from 'lodash/isNull';
 import { Projections } from 'common/models/Projections';
 import { Region } from 'common/regions';
 import { SectionHeader } from 'components/SharedComponents';
@@ -14,6 +16,7 @@ import {
 } from 'components/Charts/Redesign/Groupings';
 import { MetricValues } from 'common/models/Projections';
 import ChartFooter from 'components/NewLocationPage/ChartFooter/ChartFooter';
+import { Metric } from 'common/metricEnum';
 
 const NewChartBlock: React.FC<{
   isMobile: boolean;
@@ -21,7 +24,9 @@ const NewChartBlock: React.FC<{
   stats: MetricValues;
   projections: Projections;
   group: ChartGroup;
-}> = ({ projections, stats, group, region }) => {
+  clickedStatMetric: Metric | null;
+  groupRef: React.RefObject<HTMLDivElement>;
+}> = ({ projections, stats, group, region, groupRef, clickedStatMetric }) => {
   const { metricList, groupHeader } = group;
 
   const [activeTabIndex, setActiveTabIndex] = useState(0);
@@ -29,8 +34,20 @@ const NewChartBlock: React.FC<{
     setActiveTabIndex(newTabIndex);
   };
 
-  const inactiveTabs = metricList.length === 1;
-  const TabsWrapper = inactiveTabs ? InactiveTabWrapper : ChartTabs;
+  // Selects correct tab after clicking summary stat + scrolling to chart block
+  useEffect(() => {
+    if (!isNull(clickedStatMetric)) {
+      const clickedStatMetricIndex = findIndex(
+        metricList,
+        item => item.metric === clickedStatMetric,
+      );
+      if (clickedStatMetricIndex >= 0) {
+        setActiveTabIndex(clickedStatMetricIndex);
+      }
+    }
+  }, [metricList, clickedStatMetric]);
+
+  const TabsWrapper = metricList.length === 1 ? InactiveTabWrapper : ChartTabs;
 
   const { unformattedValue, formattedValue } = getValueInfo(
     stats,
@@ -41,7 +58,7 @@ const NewChartBlock: React.FC<{
 
   return (
     <>
-      <SectionHeader>{groupHeader}</SectionHeader>
+      <SectionHeader ref={groupRef}>{groupHeader}</SectionHeader>
       <TabsWrapper activeTabIndex={activeTabIndex} onChangeTab={onChangeTab}>
         {metricList.map((metricItem: MetricChartInfo, i: number) => {
           const metricValueInfo = getValueInfo(stats, metricItem, projections);

--- a/src/components/Dialogs/utils.tsx
+++ b/src/components/Dialogs/utils.tsx
@@ -59,11 +59,11 @@ export const exploreMetricToFooterContentMap: {
   [key: number]: ExploreMetricModalMapContent;
 } = {
   [ExploreMetric.DEATHS]: {
-    metricName: 'daily new deaths',
+    metricName: 'daily deaths',
     howItsCalculated: 'Our daily deaths number is a seven-day average.',
     metricDefinition: 'This is the number of COVID deaths per day.',
     source: 'The New York Times',
-    statusTextMeasure: 'daily new deaths',
+    statusTextMeasure: 'daily deaths',
   },
   [ExploreMetric.ICU_HOSPITALIZATIONS]: {
     metricName: 'ICU hospitalizations',

--- a/src/components/LocationPage/ChartsHolder.tsx
+++ b/src/components/LocationPage/ChartsHolder.tsx
@@ -99,14 +99,13 @@ const ChartsHolder = React.memo(({ region, chartId }: ChartsHolderProps) => {
     }
   }, [hash]);
 
-  const [scrolledWithRef, setScrolledWithRef] = useState(false);
+  const [scrolledWithUrl, setScrolledWithUrl] = useState(false);
 
   const vaccinationsBlockRef = useRef<HTMLDivElement>(null);
   const casesBlockRef = useRef<HTMLDivElement>(null);
   const hospitalizationsBlockRef = useRef<HTMLDivElement>(null);
   const deathsBlockRed = useRef<HTMLDivElement>(null);
   const chartBlockRefs = useMemo(
-    // Fix the any
     () => ({
       [GroupHeader.VACCINATED]: vaccinationsBlockRef,
       [GroupHeader.CASES]: casesBlockRef,
@@ -121,8 +120,8 @@ const ChartsHolder = React.memo(({ region, chartId }: ChartsHolderProps) => {
       const timeoutId = setTimeout(() => {
         if (chartId in metricRefs) {
           const metricRef = metricRefs[(chartId as unknown) as Metric];
-          if (metricRef.current && !scrolledWithRef) {
-            setScrolledWithRef(true);
+          if (metricRef.current && !scrolledWithUrl) {
+            setScrolledWithUrl(true);
             scrollTo(metricRef.current);
           }
         }
@@ -133,8 +132,8 @@ const ChartsHolder = React.memo(({ region, chartId }: ChartsHolderProps) => {
     const scrollToRecommendations = () => {
       const timeoutId = setTimeout(() => {
         if (isRecommendationsShareUrl) {
-          if (recommendationsRef.current && !scrolledWithRef) {
-            setScrolledWithRef(true);
+          if (recommendationsRef.current && !scrolledWithUrl) {
+            setScrolledWithUrl(true);
             scrollTo(recommendationsRef.current);
           }
         }
@@ -144,13 +143,7 @@ const ChartsHolder = React.memo(({ region, chartId }: ChartsHolderProps) => {
 
     scrollToChart();
     scrollToRecommendations();
-  }, [
-    chartId,
-    metricRefs,
-    isRecommendationsShareUrl,
-    scrolledWithRef,
-    chartBlockRefs,
-  ]);
+  }, [chartId, metricRefs, isRecommendationsShareUrl, scrolledWithUrl]);
 
   const initialFipsList = useMemo(() => [region.fipsCode], [region.fipsCode]);
 
@@ -186,7 +179,6 @@ const ChartsHolder = React.memo(({ region, chartId }: ChartsHolderProps) => {
         ? chartBlockRefs[groupWithMetric.groupHeader]
         : null;
       if (chartBlockRef?.current) {
-        setScrolledWithRef(true);
         scrollTo(chartBlockRef.current);
       }
     },

--- a/src/components/LocationPage/ChartsHolder.tsx
+++ b/src/components/LocationPage/ChartsHolder.tsx
@@ -105,7 +105,7 @@ const ChartsHolder = React.memo(({ region, chartId }: ChartsHolderProps) => {
   const casesBlockRef = useRef<HTMLDivElement>(null);
   const hospitalizationsBlockRef = useRef<HTMLDivElement>(null);
   const deathsBlockRed = useRef<HTMLDivElement>(null);
-  const chartBlockRefs: any = useMemo(
+  const chartBlockRefs = useMemo(
     // Fix the any
     () => ({
       [GroupHeader.VACCINATED]: vaccinationsBlockRef,
@@ -185,7 +185,7 @@ const ChartsHolder = React.memo(({ region, chartId }: ChartsHolderProps) => {
       const chartBlockRef = groupWithMetric
         ? chartBlockRefs[groupWithMetric.groupHeader]
         : null;
-      if (chartBlockRef.current) {
+      if (chartBlockRef?.current) {
         setScrolledWithRef(true);
         scrollTo(chartBlockRef.current);
       }

--- a/src/components/LocationPage/ShareButtons.tsx
+++ b/src/components/LocationPage/ShareButtons.tsx
@@ -1,33 +1,17 @@
 import React, { useState } from 'react';
-import urlJoin from 'url-join';
 import { ClickAwayListener } from '@material-ui/core';
 import SocialButtons from './SocialButtons';
 import { Wrapper } from './ShareButtons.style';
 import ShareButton from 'components/NewLocationPage/ShareButton/ShareButton';
-import makeChartShareQuote from 'common/utils/makeChartShareQuote';
-import * as urls from 'common/urls';
 import { Region } from 'common/regions';
-import type { MetricValues } from 'common/models/Projections';
 import { useEscToClose, useBreakpoint } from 'common/hooks';
 
 const ShareButtons: React.FC<{
+  shareQuote: string;
+  shareUrl: string;
   region: Region;
-  stats: MetricValues;
-  chartIdentifier: number;
   showEmbedButton?: boolean;
-}> = ({ region, stats, chartIdentifier, showEmbedButton }) => {
-  const shareQuote = makeChartShareQuote(
-    region.fullName,
-    stats,
-    chartIdentifier,
-  );
-
-  const shareBaseURL = region.canonicalUrl;
-
-  const shareURL = urls.addSharingId(
-    urlJoin(shareBaseURL, `chart/${chartIdentifier}`),
-  );
-
+}> = ({ shareQuote, shareUrl, region, showEmbedButton }) => {
   const [showSocialButtons, setShowSocialButtons] = useState(false);
 
   const hideSocialButtons = () => setShowSocialButtons(false);
@@ -47,7 +31,7 @@ const ShareButtons: React.FC<{
         {showSocialButtons && (
           <SocialButtons
             iconSize={iconSize}
-            shareURL={shareURL}
+            shareURL={shareUrl}
             shareQuote={shareQuote}
             region={region}
             hideSocialButtons={() => hideSocialButtons()}

--- a/src/components/NewLocationPage/ChartFooter/AddedMetricChartFooter.tsx
+++ b/src/components/NewLocationPage/ChartFooter/AddedMetricChartFooter.tsx
@@ -24,10 +24,14 @@ import { EventCategory } from 'components/Analytics';
 import { ExploreMetric } from 'components/Explore';
 import { getAddedMetricStatusText, DialogProps } from './utils';
 import Legend from 'components/Explore/Legend';
+import { makeAddedChartShareQuote } from 'common/utils/makeChartShareQuote';
 
-const ShareButtonBlock: React.FC<{ region: Region }> = ({ region }) => {
+const ShareButtonBlock: React.FC<{ region: Region; metric: ExploreMetric }> = ({
+  region,
+  metric,
+}) => {
   const shareUrl = region.canonicalUrl;
-  const shareQuote = 'test'; // (Chelsi) - update
+  const shareQuote = makeAddedChartShareQuote(region.fullName, metric);
 
   const props = {
     shareUrl,
@@ -93,6 +97,11 @@ const AddedMetricChartFooter: React.FC<{
 
   const series = getAllSeriesForMetric(metric, projections.primary);
 
+  const shareProps = {
+    region,
+    metric,
+  };
+
   return (
     <Wrapper>
       <DesktopOnly>
@@ -103,7 +112,7 @@ const AddedMetricChartFooter: React.FC<{
             {'   '}
             <MetricModal {...dialogProps} />
           </FooterText>
-          <ShareButtonBlock region={region} />
+          <ShareButtonBlock {...shareProps} />
         </Row>
       </DesktopOnly>
       <MobileOnly>
@@ -111,7 +120,7 @@ const AddedMetricChartFooter: React.FC<{
         <FooterText>{statusText}</FooterText>
         <Row>
           <MetricModal {...dialogProps} />
-          <ShareButtonBlock region={region} />
+          <ShareButtonBlock {...shareProps} />
         </Row>
       </MobileOnly>
     </Wrapper>

--- a/src/components/NewLocationPage/ChartFooter/AddedMetricChartFooter.tsx
+++ b/src/components/NewLocationPage/ChartFooter/AddedMetricChartFooter.tsx
@@ -1,3 +1,5 @@
+/** Chart footer for newly added chart metrics (deaths, hospitalizations, ICU hospitalizations) */
+
 import React from 'react';
 import {
   Row,
@@ -10,39 +12,32 @@ import {
 import {
   DialogMain,
   MetricInfoDialogInner,
-  MetricModalContent,
   getExploreMetricModalContent,
 } from 'components/Dialogs';
 import { getAllSeriesForMetric } from 'components/Explore/utils';
 import { MobileOnly, DesktopOnly } from '../Shared/Shared.style';
 import ShareButtons from 'components/LocationPage/ShareButtons';
 import { Region } from 'common/regions';
-import type { MetricValues, Projections } from 'common/models/Projections';
+import type { Projections } from 'common/models/Projections';
 import { useDialog } from 'common/hooks';
 import { EventCategory } from 'components/Analytics';
 import { ExploreMetric } from 'components/Explore';
-import { getAddedMetricStatusText } from './utils';
+import { getAddedMetricStatusText, DialogProps } from './utils';
 import Legend from 'components/Explore/Legend';
 
-export interface ShareButtonProps {
-  region: Region;
-  stats: MetricValues;
-  chartIdentifier: number;
-  showEmbedButton?: boolean;
-}
+const ShareButtonBlock: React.FC<{ region: Region }> = ({ region }) => {
+  const shareUrl = region.canonicalUrl;
+  const shareQuote = 'test'; // (Chelsi) - update
 
-interface DialogProps {
-  open: boolean;
-  closeDialog: () => void;
-  openDialog: () => void;
-  modalContent: MetricModalContent;
-  modalHeader: string;
-}
+  const props = {
+    shareUrl,
+    shareQuote,
+    region,
+  };
 
-const ShareButtonBlock: React.FC<ShareButtonProps> = shareButtonProps => {
   return (
     <ButtonContainer>
-      <ShareButtons {...shareButtonProps} />
+      <ShareButtons {...props} />
     </ButtonContainer>
   );
 };
@@ -76,17 +71,9 @@ const AddedMetricChartFooter: React.FC<{
   metric: ExploreMetric;
   projections: Projections;
   region: Region;
-  stats: MetricValues;
   formattedValue: string;
-}> = ({ metric, region, stats, formattedValue, projections }) => {
+}> = ({ metric, region, formattedValue, projections }) => {
   const modalContent = getExploreMetricModalContent(region, metric);
-
-  const shareButtonProps = {
-    chartIdentifier: metric,
-    region,
-    stats,
-    showEmbedButton: false,
-  };
 
   const statusText = getAddedMetricStatusText(metric, formattedValue, region);
 
@@ -116,7 +103,7 @@ const AddedMetricChartFooter: React.FC<{
             {'   '}
             <MetricModal {...dialogProps} />
           </FooterText>
-          <ShareButtonBlock {...shareButtonProps} />
+          <ShareButtonBlock region={region} />
         </Row>
       </DesktopOnly>
       <MobileOnly>
@@ -124,7 +111,7 @@ const AddedMetricChartFooter: React.FC<{
         <FooterText>{statusText}</FooterText>
         <Row>
           <MetricModal {...dialogProps} />
-          <ShareButtonBlock {...shareButtonProps} />
+          <ShareButtonBlock region={region} />
         </Row>
       </MobileOnly>
     </Wrapper>

--- a/src/components/NewLocationPage/ChartFooter/AddedMetricChartFooter.tsx
+++ b/src/components/NewLocationPage/ChartFooter/AddedMetricChartFooter.tsx
@@ -28,9 +28,18 @@ import { ExploreMetric } from 'components/Explore';
 import { getAddedMetricStatusText, DialogProps } from './utils';
 import Legend from 'components/Explore/Legend';
 
-const ShareButtonBlock: React.FC<{ region: Region }> = ({ region }) => {
+const ShareButtonBlock: React.FC<{ region: Region; metric: ExploreMetric }> = ({
+  region,
+  metric,
+}) => {
+  const metricToShareQuoteName: { [key: number]: string } = {
+    [ExploreMetric.DEATHS]: 'Daily COVID deaths',
+    [ExploreMetric.ICU_HOSPITALIZATIONS]: 'Current COVID ICU hospitalizations',
+    [ExploreMetric.HOSPITALIZATIONS]: 'Current COVID hospitalizations',
+  };
+
   const shareUrl = region.canonicalUrl;
-  const shareQuote = `Check out Daily COVID deaths, vaccination progress, and other key metrics for ${region.fullName} at @CovidActNow: `;
+  const shareQuote = `${metricToShareQuoteName[metric]}, vaccination progress, and other key metrics for ${region.fullName} at @CovidActNow: `;
 
   const props = {
     shareUrl,
@@ -96,6 +105,7 @@ const AddedMetricChartFooter: React.FC<{
 
   const series = getAllSeriesForMetric(metric, projections.primary);
 
+  const shareProps = { region, metric };
   return (
     <Wrapper>
       <DesktopOnly>
@@ -106,7 +116,7 @@ const AddedMetricChartFooter: React.FC<{
             {'   '}
             <MetricModal {...dialogProps} />
           </FooterText>
-          <ShareButtonBlock region={region} />
+          <ShareButtonBlock {...shareProps} />
         </Row>
       </DesktopOnly>
       <MobileOnly>
@@ -114,7 +124,7 @@ const AddedMetricChartFooter: React.FC<{
         <FooterText>{statusText}</FooterText>
         <Row>
           <MetricModal {...dialogProps} />
-          <ShareButtonBlock region={region} />
+          <ShareButtonBlock {...shareProps} />
         </Row>
       </MobileOnly>
     </Wrapper>

--- a/src/components/NewLocationPage/ChartFooter/AddedMetricChartFooter.tsx
+++ b/src/components/NewLocationPage/ChartFooter/AddedMetricChartFooter.tsx
@@ -1,4 +1,7 @@
-/** Chart footer for newly added chart metrics (deaths, hospitalizations, ICU hospitalizations) */
+/**
+ * Chart footer for newly added chart metrics (deaths, hospitalizations, ICU hospitalizations)
+ * TODO (chelsi) - implement a better naming convention for the files/components/utils that currently use 'Added'
+ */
 
 import React from 'react';
 import {
@@ -24,14 +27,10 @@ import { EventCategory } from 'components/Analytics';
 import { ExploreMetric } from 'components/Explore';
 import { getAddedMetricStatusText, DialogProps } from './utils';
 import Legend from 'components/Explore/Legend';
-import { makeAddedChartShareQuote } from 'common/utils/makeChartShareQuote';
 
-const ShareButtonBlock: React.FC<{ region: Region; metric: ExploreMetric }> = ({
-  region,
-  metric,
-}) => {
+const ShareButtonBlock: React.FC<{ region: Region }> = ({ region }) => {
   const shareUrl = region.canonicalUrl;
-  const shareQuote = makeAddedChartShareQuote(region.fullName, metric);
+  const shareQuote = `Check out Daily COVID deaths, vaccination progress, and other key metrics for ${region.fullName} at @CovidActNow: `;
 
   const props = {
     shareUrl,
@@ -97,11 +96,6 @@ const AddedMetricChartFooter: React.FC<{
 
   const series = getAllSeriesForMetric(metric, projections.primary);
 
-  const shareProps = {
-    region,
-    metric,
-  };
-
   return (
     <Wrapper>
       <DesktopOnly>
@@ -112,7 +106,7 @@ const AddedMetricChartFooter: React.FC<{
             {'   '}
             <MetricModal {...dialogProps} />
           </FooterText>
-          <ShareButtonBlock {...shareProps} />
+          <ShareButtonBlock region={region} />
         </Row>
       </DesktopOnly>
       <MobileOnly>
@@ -120,7 +114,7 @@ const AddedMetricChartFooter: React.FC<{
         <FooterText>{statusText}</FooterText>
         <Row>
           <MetricModal {...dialogProps} />
-          <ShareButtonBlock {...shareProps} />
+          <ShareButtonBlock region={region} />
         </Row>
       </MobileOnly>
     </Wrapper>

--- a/src/components/NewLocationPage/ChartFooter/ChartFooter.tsx
+++ b/src/components/NewLocationPage/ChartFooter/ChartFooter.tsx
@@ -30,7 +30,6 @@ const ChartFooter: React.FC<{
           metric={metric as ExploreMetric}
           projections={projections}
           region={region}
-          stats={stats}
           formattedValue={formattedValue}
         />
       )}

--- a/src/components/NewLocationPage/ChartFooter/MetricChartFooter.tsx
+++ b/src/components/NewLocationPage/ChartFooter/MetricChartFooter.tsx
@@ -24,7 +24,7 @@ import { Metric } from 'common/metricEnum';
 import { getSourcesForMetric } from 'common/utils/provenance';
 import { getMetricNameExtended, getMetricStatusText } from 'common/metric';
 import { EventCategory } from 'components/Analytics';
-import makeChartShareQuote from 'common/utils/makeChartShareQuote';
+import { makeChartShareQuote } from 'common/utils/makeChartShareQuote';
 import * as urls from 'common/urls';
 
 const ShareButtonBlock: React.FC<{

--- a/src/components/NewLocationPage/ChartFooter/MetricChartFooter.tsx
+++ b/src/components/NewLocationPage/ChartFooter/MetricChartFooter.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import urlJoin from 'url-join';
 import {
   Row,
   ButtonContainer,
@@ -11,12 +12,11 @@ import {
 import {
   DialogMain,
   MetricInfoDialogInner,
-  MetricModalContent,
   getMetricModalContent,
 } from 'components/Dialogs';
 import { MobileOnly, DesktopOnly } from '../Shared/Shared.style';
 import ShareButtons from 'components/LocationPage/ShareButtons';
-import { getOverrideDisclaimer } from './utils';
+import { getOverrideDisclaimer, DialogProps } from './utils';
 import { Region } from 'common/regions';
 import type { MetricValues, Projections } from 'common/models/Projections';
 import { useDialog } from 'common/hooks';
@@ -24,26 +24,33 @@ import { Metric } from 'common/metricEnum';
 import { getSourcesForMetric } from 'common/utils/provenance';
 import { getMetricNameExtended, getMetricStatusText } from 'common/metric';
 import { EventCategory } from 'components/Analytics';
+import makeChartShareQuote from 'common/utils/makeChartShareQuote';
+import * as urls from 'common/urls';
 
-export interface ShareButtonProps {
+const ShareButtonBlock: React.FC<{
   region: Region;
   stats: MetricValues;
   chartIdentifier: number;
-  showEmbedButton?: boolean;
-}
+}> = ({ region, chartIdentifier, stats }) => {
+  const shareBaseURL = region.canonicalUrl;
+  const shareUrl = urls.addSharingId(
+    urlJoin(shareBaseURL, `chart/${chartIdentifier}`),
+  );
+  const shareQuote = makeChartShareQuote(
+    region.fullName,
+    stats,
+    chartIdentifier,
+  );
 
-interface DialogProps {
-  open: boolean;
-  closeDialog: () => void;
-  openDialog: () => void;
-  modalContent: MetricModalContent;
-  modalHeader: string;
-}
+  const props = {
+    shareUrl,
+    shareQuote,
+    region,
+  };
 
-const ShareButtonBlock: React.FC<ShareButtonProps> = shareButtonProps => {
   return (
     <ButtonContainer>
-      <ShareButtons {...shareButtonProps} />
+      <ShareButtons {...props} />
     </ButtonContainer>
   );
 };
@@ -98,7 +105,6 @@ const MetricChartFooter: React.FC<{
     chartIdentifier: metric,
     region,
     stats,
-    showEmbedButton: false,
   };
 
   const footerText = getMetricStatusText(metric, projections);

--- a/src/components/NewLocationPage/ChartFooter/utils.ts
+++ b/src/components/NewLocationPage/ChartFooter/utils.ts
@@ -3,7 +3,10 @@ import { County, Region } from 'common/regions';
 import { Sources } from 'api/schema/RegionSummaryWithTimeseries';
 import { getRegionMetricOverride } from 'cms-content/region-overrides';
 import { ExploreMetric } from 'components/Explore';
-import { exploreMetricToFooterContentMap } from 'components/Dialogs';
+import {
+  exploreMetricToFooterContentMap,
+  MetricModalContent,
+} from 'components/Dialogs';
 
 export function getOverrideDisclaimer(
   region: Region,
@@ -35,4 +38,12 @@ export function getAddedMetricStatusText(
   region: Region,
 ) {
   return `Over the last week, ${region.shortName} has averaged ${value} ${exploreMetricToFooterContentMap[metric].statusTextMeasure}.`;
+}
+
+export interface DialogProps {
+  open: boolean;
+  closeDialog: () => void;
+  openDialog: () => void;
+  modalContent: MetricModalContent;
+  modalHeader: string;
 }


### PR DESCRIPTION
i put this in a pr/branch separate of the [feature](https://github.com/covid-projections/covid-projections/pull/3817) because im not sure yet if this is the best solution

also includes some fixing of the share functionality (share quotes working for all charts, page-level share links (rather than chart level), page-level share images for newly added charts (still shares chart image for original key metric charts))