### PR TITLE
VaccineTooltip component.

### DIFF
--- a/src/components/USMap/VaccineTooltip/VaccineTooltip.stories.tsx
+++ b/src/components/USMap/VaccineTooltip/VaccineTooltip.stories.tsx
@@ -19,12 +19,12 @@ export const Example = () => {
   return <VaccineTooltip {...props} />;
 };
 
-export const Mobile = () => {
+export const MoreDataLink = () => {
   const props = {
     state: idaho,
     vaccinationsCompleted: 0.29,
     vaccinationsInitiated: 0.35,
-    isMobileVersion: true,
+    addMoreDataLink: true,
   };
 
   return <VaccineTooltip {...props} />;

--- a/src/components/USMap/VaccineTooltip/VaccineTooltip.stories.tsx
+++ b/src/components/USMap/VaccineTooltip/VaccineTooltip.stories.tsx
@@ -1,0 +1,31 @@
+import regions from 'common/regions';
+import React from 'react';
+import VaccineTooltip from './VaccineTooltip';
+
+export default {
+  title: 'Shared Components/USVaccineMap/VaccineTooltip',
+  component: VaccineTooltip,
+};
+
+const idaho = regions.findByStateCodeStrict('ID');
+
+export const Example = () => {
+  const props = {
+    state: idaho,
+    vaccinationsCompleted: 0.29,
+    vaccinationsInitiated: 0.35,
+  };
+
+  return <VaccineTooltip {...props} />;
+};
+
+export const Mobile = () => {
+  const props = {
+    state: idaho,
+    vaccinationsCompleted: 0.29,
+    vaccinationsInitiated: 0.35,
+    isMobileVersion: true,
+  };
+
+  return <VaccineTooltip {...props} />;
+};

--- a/src/components/USMap/VaccineTooltip/VaccineTooltip.style.ts
+++ b/src/components/USMap/VaccineTooltip/VaccineTooltip.style.ts
@@ -1,0 +1,78 @@
+import styled from 'styled-components';
+import ArrowForwardIcon from '@material-ui/icons/ArrowForward';
+import { COLOR_MAP } from 'common/colors';
+import VaccineDot from 'components/VaccineDot/VaccineDot';
+import { LinkButton } from 'components/Button';
+
+export const Container = styled.div`
+  background-color: white;
+  border-radius: 4px;
+  filter: drop-shadow(0px 2px 20px rgba(0, 0, 0, 0.16));
+  width: 240px;
+`;
+
+export const Inner = styled.div`
+  padding: 16px;
+`;
+
+export const LocationName = styled.div<{ $isMobileVersion: boolean }>`
+  ${props => props.theme.fonts.regularBookBold};
+  text-align: ${props => (props.$isMobileVersion ? 'center' : undefined)};
+  color: black;
+  font-size: 16px;
+  line-height: 16px;
+  margin-top: 4px;
+  margin-bottom: 20px;
+`;
+
+export const LocationNameArrowIcon = styled(ArrowForwardIcon)`
+  color: ${COLOR_MAP.GREY_600};
+  font-size: 22px;
+  margin-bottom: -5px;
+  margin-left: 6px;
+`;
+
+export const Row = styled.div`
+  display: flex;
+  margin-top: 3px;
+`;
+
+export const Title = styled.div`
+  ${props => props.theme.fonts.regularBookMidWeight};
+  flex: 100%;
+  font-size: 14px;
+`;
+
+export const Value = styled.div`
+  ${props => props.theme.fonts.monospaceMidWeight};
+  color: ${COLOR_MAP.GREY_4};
+  font-size: 14px;
+  white-space: nowrap;
+`;
+
+export const StyledVaccineDot = styled(VaccineDot)`
+  margin-left: 8px;
+`;
+
+export const ProgressBarWrapper = styled.div`
+  margin-top: 12px;
+  margin-bottom: 2px;
+`;
+
+export const MoreDataLinkContainer = styled.div`
+  padding: 13px;
+  margin-top: -2px;
+  border-top: 1px solid ${COLOR_MAP.GREY_2};
+  text-align: center;
+`;
+
+export const MoreDataLinkButton = styled(LinkButton)`
+  color: ${COLOR_MAP.NEW_BLUE.BASE};
+`;
+
+export const MoreDataArrowIcon = styled(ArrowForwardIcon)`
+  color: ${COLOR_MAP.GREY_4};
+  font-size: 20px;
+  margin-bottom: -3px;
+  margin-left: 6px;
+`;

--- a/src/components/USMap/VaccineTooltip/VaccineTooltip.style.ts
+++ b/src/components/USMap/VaccineTooltip/VaccineTooltip.style.ts
@@ -15,9 +15,9 @@ export const Inner = styled.div`
   padding: 16px;
 `;
 
-export const LocationName = styled.div<{ $isMobileVersion: boolean }>`
+export const LocationName = styled.div<{ $center: boolean }>`
   ${props => props.theme.fonts.regularBookBold};
-  text-align: ${props => (props.$isMobileVersion ? 'center' : undefined)};
+  text-align: ${props => (props.$center ? 'center' : undefined)};
   color: black;
   font-size: 16px;
   line-height: 16px;
@@ -55,8 +55,8 @@ export const StyledVaccineDot = styled(VaccineDot)`
 `;
 
 export const ProgressBarWrapper = styled.div`
-  margin-top: 12px;
-  margin-bottom: 2px;
+  margin-top: 11px;
+  margin-bottom: 1px;
 `;
 
 export const MoreDataLinkContainer = styled.div`

--- a/src/components/USMap/VaccineTooltip/VaccineTooltip.tsx
+++ b/src/components/USMap/VaccineTooltip/VaccineTooltip.tsx
@@ -1,0 +1,101 @@
+import { formatPercent } from 'common/utils';
+import TextAndIconWithSpecialWrapping from 'components/TextAndIconWithSpecialWrapping/TextAndIconWithSpecialWrapping';
+import { DotStyle } from 'components/VaccineDot/VaccineDot';
+import { VaccineProgressBar } from 'components/VaccineProgressBar/VaccineProgressBar';
+import React from 'react';
+import {
+  LocationNameArrowIcon,
+  MoreDataLinkContainer,
+  Container,
+  Inner,
+  LocationName,
+  MoreDataLinkButton,
+  ProgressBarWrapper,
+  Row,
+  StyledVaccineDot,
+  Title,
+  Value,
+  MoreDataArrowIcon,
+} from './VaccineTooltip.style';
+import { State } from 'common/regions';
+import { trackEvent, EventAction, EventCategory } from 'components/Analytics';
+
+export interface VaccineTooltipProps {
+  state: State;
+  vaccinationsInitiated: number;
+  vaccinationsCompleted: number;
+  isMobileVersion?: boolean;
+}
+
+const VaccineTooltip: React.FC<VaccineTooltipProps> = ({
+  state,
+  vaccinationsInitiated,
+  vaccinationsCompleted,
+  isMobileVersion = false,
+}) => {
+  const locationName = state.fullName;
+  return (
+    <Container>
+      <Inner>
+        <LocationName $isMobileVersion={isMobileVersion}>
+          {isMobileVersion ? (
+            locationName
+          ) : (
+            <TextAndIconWithSpecialWrapping
+              text={locationName}
+              icon={<LocationNameArrowIcon />}
+            />
+          )}
+        </LocationName>
+        <Row>
+          <Title>Fully vaccinated</Title>
+          <Value>
+            {formatPercent(vaccinationsCompleted)}
+            <StyledVaccineDot
+              vaccinationsInitiated={vaccinationsInitiated}
+              dotStyle={DotStyle.SOLID}
+            />
+          </Value>
+        </Row>
+        <Row>
+          <Title>1+ dose</Title>
+          <Value>
+            {formatPercent(vaccinationsInitiated)}
+            <StyledVaccineDot
+              vaccinationsInitiated={vaccinationsInitiated}
+              dotStyle={DotStyle.HATCHED}
+            />
+          </Value>
+        </Row>
+        <ProgressBarWrapper>
+          <VaccineProgressBar
+            locationName={locationName}
+            vaccinationsInitiated={vaccinationsInitiated}
+            vaccinationsCompleted={vaccinationsCompleted}
+          />
+        </ProgressBarWrapper>
+      </Inner>
+      {isMobileVersion && (
+        <MoreDataLinkContainer>
+          <MoreDataLinkButton
+            href={state.relativeUrl}
+            aria-label={locationName}
+            onClick={() => {
+              trackMapClick(locationName);
+            }}
+            tabIndex={-1}
+          >
+            More data
+            <MoreDataArrowIcon />
+          </MoreDataLinkButton>
+        </MoreDataLinkContainer>
+      )}
+    </Container>
+  );
+};
+
+function trackMapClick(label: string) {
+  trackEvent(EventCategory.MAP, EventAction.NAVIGATE, label);
+}
+
+export default VaccineTooltip;

--- a/src/components/USMap/VaccineTooltip/VaccineTooltip.tsx
+++ b/src/components/USMap/VaccineTooltip/VaccineTooltip.tsx
@@ -24,21 +24,27 @@ export interface VaccineTooltipProps {
   state: State;
   vaccinationsInitiated: number;
   vaccinationsCompleted: number;
-  isMobileVersion?: boolean;
+  /**
+   * Whether to include "More data" link at the bottom of tooltip.  This is
+   * typically used when the USMap is using `TooltipMode.ACTIVATE_ON_CLICK`
+   * since we then need a link within the Tooltip to actually navigate to
+   * the location page.
+   */
+  addMoreDataLink?: boolean;
 }
 
 const VaccineTooltip: React.FC<VaccineTooltipProps> = ({
   state,
   vaccinationsInitiated,
   vaccinationsCompleted,
-  isMobileVersion = false,
+  addMoreDataLink = false,
 }) => {
   const locationName = state.fullName;
   return (
     <Container>
       <Inner>
-        <LocationName $isMobileVersion={isMobileVersion}>
-          {isMobileVersion ? (
+        <LocationName $center={addMoreDataLink}>
+          {addMoreDataLink ? (
             locationName
           ) : (
             <TextAndIconWithSpecialWrapping
@@ -75,7 +81,7 @@ const VaccineTooltip: React.FC<VaccineTooltipProps> = ({
           />
         </ProgressBarWrapper>
       </Inner>
-      {isMobileVersion && (
+      {addMoreDataLink && (
         <MoreDataLinkContainer>
           <MoreDataLinkButton
             href={state.relativeUrl}
@@ -83,7 +89,6 @@ const VaccineTooltip: React.FC<VaccineTooltipProps> = ({
             onClick={() => {
               trackMapClick(locationName);
             }}
-            tabIndex={-1}
           >
             More data
             <MoreDataArrowIcon />


### PR DESCRIPTION
Adds a VaccineTooltip component for use by the vaccine map. Depends on https://github.com/covid-projections/covid-projections/pull/3851.  Can't be plumbed into the map until https://github.com/covid-projections/covid-projections/pull/3856 lands.  

Desktop version:
![image](https://user-images.githubusercontent.com/206364/122716898-b5bfd800-d21f-11eb-83f5-c281861649b1.png)

Mobile version:
![image](https://user-images.githubusercontent.com/206364/122716927-bfe1d680-d21f-11eb-9c72-653dedc37c87.png)

Demo with map and tooltip integrated: https://covid-projections-git-mikelehen-vaccine-tooltip-covidactnow.vercel.app/?s=1957873