### PR TITLE
Fix circle icon alignment

### DIFF
--- a/src/components/RegionItem/RegionItem.style.tsx
+++ b/src/components/RegionItem/RegionItem.style.tsx
@@ -10,7 +10,8 @@ const regionItemWidth = '296px';
 
 export const CircleIcon = styled(FiberManualRecordIcon)<{ $iconColor: string }>`
   color: ${({ $iconColor }) => $iconColor};
-  font-size: 1rem;
+  font-size: 0.8rem;
+  display: flex;
 `;
 
 export const CopyContainer = styled.div`


### PR DESCRIPTION
Homepage region items' circle icon looks a bit off. This fixes

Before-

![Screen Shot 2021-06-21 at 6 43 41 PM](https://user-images.githubusercontent.com/44076375/122836640-9cbb3380-d2c0-11eb-95d4-2f5b38555cf4.png)

After- 

![Screen Shot 2021-06-21 at 6 43 34 PM](https://user-images.githubusercontent.com/44076375/122836656-a6449b80-d2c0-11eb-9ce7-14a6d37696e8.png)