### PR TITLE
Simplify / fix VaccineProgressBar sizing.

### DIFF
--- a/src/components/VaccinationsTable/VaccinationsTable.style.tsx
+++ b/src/components/VaccinationsTable/VaccinationsTable.style.tsx
@@ -18,6 +18,7 @@ export const Wrapper = styled.div`
 `;
 
 export const ProgressBarWrapper = styled.div`
+  width: 100px;
   margin-left: 0.5rem;
   display: flex;
 `;

--- a/src/components/VaccinationsTable/VaccinationsTable.tsx
+++ b/src/components/VaccinationsTable/VaccinationsTable.tsx
@@ -44,7 +44,6 @@ const Column: React.FC<{
                   locationName={region.regionName}
                   vaccinationsInitiated={region.vaccinationsInitiated}
                   vaccinationsCompleted={region.vaccinationsCompleted}
-                  width={100}
                 />
               </ProgressBarWrapper>
             </ListItemHalf>

--- a/src/components/VaccineProgressBar/VaccineProgressBar.style.tsx
+++ b/src/components/VaccineProgressBar/VaccineProgressBar.style.tsx
@@ -3,6 +3,8 @@ import { COLOR_MAP } from 'common/colors';
 import { materialSMBreakpoint } from 'assets/theme/sizes';
 
 export const ProgressBarContainer = styled.div`
+  /* Adding display:flex makes sure the ParentSize container is tight to its contents */
+  display: flex;
   width: 100%;
   max-width: 350px;
   margin: auto;
@@ -14,7 +16,6 @@ export const ProgressBarContainer = styled.div`
 `;
 
 export const StyledSvg = styled.svg`
-  width: 100%;
   border: 1px solid ${COLOR_MAP.GREY_2};
   border-radius: 3px;
 `;

--- a/src/components/VaccineProgressBar/VaccineProgressBar.tsx
+++ b/src/components/VaccineProgressBar/VaccineProgressBar.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { ParentSize } from '@vx/responsive';
 import { v4 as uuidv4 } from 'uuid';
 import { ProgressBarContainer, StyledSvg } from './VaccineProgressBar.style';
 import { COLOR_MAP, VACCINATIONS_COLOR_MAP, vaccineColor } from 'common/colors';
@@ -11,19 +10,17 @@ export interface ProgressBarProps {
   locationName: string;
   vaccinationsInitiated: number;
   vaccinationsCompleted: number;
-  width?: number;
 }
 
 function getOffsetPercentage(decimal: number) {
   return formatPercent(decimal, 1);
 }
 
-const VaccineProgressBar: React.FC<ProgressBarProps & { width: number }> = ({
+export const VaccineProgressBar: React.FC<ProgressBarProps> = ({
   oldVersion = false,
   vaccinationsInitiated,
   vaccinationsCompleted,
   locationName,
-  width,
 }) => {
   const height = 18;
   const color = oldVersion
@@ -34,81 +31,66 @@ const VaccineProgressBar: React.FC<ProgressBarProps & { width: number }> = ({
   const hatchPatternId = uuidv4();
 
   return (
-    <StyledSvg
-      width={width}
-      height={height}
-      role="img"
-      aria-labelledby={titleId}
-    >
-      <title id={titleId}>
-        Progress bar showing that in {locationName},{' '}
-        {formatPercent(vaccinationsInitiated)} of the population has received at
-        least 1 dose of a COVID vaccine, and{' '}
-        {formatPercent(vaccinationsCompleted)} of the population has been fully
-        vaccinated.
-      </title>
+    <ProgressBarContainer>
+      <StyledSvg height={height} role="img" aria-labelledby={titleId}>
+        <title id={titleId}>
+          Progress bar showing that in {locationName},{' '}
+          {formatPercent(vaccinationsInitiated)} of the population has received
+          at least 1 dose of a COVID vaccine, and{' '}
+          {formatPercent(vaccinationsCompleted)} of the population has been
+          fully vaccinated.
+        </title>
 
-      <defs>
-        <pattern
-          id={hatchPatternId}
-          width="3"
-          height="1"
-          patternTransform="rotate(45 0 0)"
-          patternUnits="userSpaceOnUse"
-        >
-          <line x1="1" y1="0" x2="1" y2="1" stroke={color} strokeWidth={1.5} />
-        </pattern>
-      </defs>
+        <defs>
+          <pattern
+            id={hatchPatternId}
+            width="3"
+            height="1"
+            patternTransform="rotate(45 0 0)"
+            patternUnits="userSpaceOnUse"
+          >
+            <line
+              x1="1"
+              y1="0"
+              x2="1"
+              y2="1"
+              stroke={color}
+              strokeWidth={1.5}
+            />
+          </pattern>
+        </defs>
 
-      <g>
-        {/* Vaccinations Completed section (solid) */}
-        <rect
-          fill={color}
-          x={0}
-          width={getOffsetPercentage(vaccinationsCompleted)}
-          height={height}
-        />
-        {/* Vaccinations Initiated section (hatched pattern) */}
-        <rect
-          fill={
-            oldVersion
-              ? VACCINATIONS_COLOR_MAP.INITIATED
-              : `url(#${hatchPatternId})`
-          }
-          x={getOffsetPercentage(vaccinationsCompleted)}
-          width={getOffsetPercentage(
-            vaccinationsInitiated - vaccinationsCompleted,
-          )}
-          height={height}
-        />
-        {oldVersion && (
+        <g>
+          {/* Vaccinations Completed section (solid) */}
           <rect
-            fill={COLOR_MAP.GREY_2}
-            x={getOffsetPercentage(vaccinationsInitiated)}
-            width={getOffsetPercentage(1 - vaccinationsInitiated)}
+            fill={color}
+            x={0}
+            width={getOffsetPercentage(vaccinationsCompleted)}
             height={height}
           />
-        )}
-      </g>
-    </StyledSvg>
-  );
-};
-
-const VaccineProgressBarAutosize: React.FC<ProgressBarProps> = props => {
-  return (
-    <ProgressBarContainer>
-      {/* Adding display:flex makes sure the ParentSize container is tight to its contents */}
-      <ParentSize style={{ display: 'flex' }}>
-        {({ width }) => (
-          <VaccineProgressBar
-            {...props}
-            // If no width prop is passed, the progress bar is responsive and uses ParentSize width
-            width={props.width ? props.width : width}
+          {/* Vaccinations Initiated section (hatched pattern) */}
+          <rect
+            fill={
+              oldVersion
+                ? VACCINATIONS_COLOR_MAP.INITIATED
+                : `url(#${hatchPatternId})`
+            }
+            x={getOffsetPercentage(vaccinationsCompleted)}
+            width={getOffsetPercentage(
+              vaccinationsInitiated - vaccinationsCompleted,
+            )}
+            height={height}
           />
-        )}
-      </ParentSize>
+          {oldVersion && (
+            <rect
+              fill={COLOR_MAP.GREY_2}
+              x={getOffsetPercentage(vaccinationsInitiated)}
+              width={getOffsetPercentage(1 - vaccinationsInitiated)}
+              height={height}
+            />
+          )}
+        </g>
+      </StyledSvg>
     </ProgressBarContainer>
   );
 };
-
-export { VaccineProgressBarAutosize as VaccineProgressBar };


### PR DESCRIPTION
I realized that by adding `width: 100%` to the CSS styles of the `svg` element (to fix that flicker problem), it actually negated the `width` property on the svg element itself which means:
1. Passing `width` into VaccineProgressBar wasn't working properly for me when I tried it from the compare table.
2. I think the original reason we had a `width` property was so we could adopt the width of the `ParentSize` wrapper, but with `width: 100%` on the svg element we don't need that wrapper at all, and removing it removes an extra render (the ParentSize was rendering with width 0 first and then with the correct width, which is why we were seeing that flicker in the first place).

So I ended up just removing the `width` property and the `ParentSize` wrapper entirely, and now rely on `width: 100%` in the CSS.  I did have to then specify an explicit width on your ProgressBarWrapper in VaccinationsTable, but other than that everything still works as before, and with less code. So I think this is a win?  Let me know if you have any concerns.  I could be missing something.