### PR TITLE
Increase vaccination chart tooltip width

### DIFF
--- a/src/components/Charts/ChartVaccinations.tsx
+++ b/src/components/Charts/ChartVaccinations.tsx
@@ -71,7 +71,7 @@ const VaccinesTooltip: React.FC<{
 
   return pointInitiated ? (
     <Tooltip
-      width={'160px'}
+      width={'170px'}
       top={top(pointInitiated)}
       left={left(pointCompleted ? pointCompleted : pointInitiated)}
       title={formatTooltipColumnDate(pointInitiated)}


### PR DESCRIPTION
Tiny change to ensure "Fully vaccinated" doesn't wrap on the vaccination chart tooltip.