### PR TITLE
Change compare table title on location page

### DIFF
--- a/src/components/Compare/CompareTable.tsx
+++ b/src/components/Compare/CompareTable.tsx
@@ -265,7 +265,9 @@ const CompareTable = (props: {
     <Wrapper $isModal={props.isModal} $isHomepage={props.isHomepage}>
       {!props.isModal && (
         <HeaderContainer $isHomepage={props.isHomepage}>
-          <CompareHeader $isHomepage={props.isHomepage}>Compare</CompareHeader>
+          <CompareHeader $isHomepage={props.isHomepage}>
+            {props.isHomepage ? 'Compare' : 'Counties'}
+          </CompareHeader>
           {!disableFilters && (
             <Filters
               isHomepage={props.isHomepage}

--- a/src/components/Compare/CompareTable.tsx
+++ b/src/components/Compare/CompareTable.tsx
@@ -266,7 +266,7 @@ const CompareTable = (props: {
       {!props.isModal && (
         <HeaderContainer $isHomepage={props.isHomepage}>
           <CompareHeader $isHomepage={props.isHomepage}>
-            {props.isHomepage ? 'Compare' : 'Counties'}
+            {props.region ? 'Counties' : 'Compare'}
           </CompareHeader>
           {!disableFilters && (
             <Filters


### PR DESCRIPTION
Tiny change to update the compare table title to "Counties" on the location page.