### PR TITLE
Switch share image / embeds to vaccination map.

### DIFF
--- a/src/components/HorizontalThermometer/VaccinationsThermometer/VaccinationsThermometer.tsx
+++ b/src/components/HorizontalThermometer/VaccinationsThermometer/VaccinationsThermometer.tsx
@@ -8,29 +8,37 @@ import { COLOR_MAP } from 'common/colors';
 import { v4 as uuidv4 } from 'uuid';
 
 interface Section {
+  // Used in thermometer
   labelTo: string;
+  // Used in SocialLocationPreviewMap legend.
+  labelRange: string;
   color: string;
 }
 
-const thermometerSections: Section[] = [
+export const thermometerSections: Section[] = [
   {
     labelTo: '40%',
+    labelRange: '< 40%',
     color: COLOR_MAP.VACCINATIONS_BLUE[0],
   },
   {
     labelTo: '50%',
+    labelRange: '40 - 50%',
     color: COLOR_MAP.VACCINATIONS_BLUE[1],
   },
   {
     labelTo: '60%',
+    labelRange: '50 - 60%',
     color: COLOR_MAP.VACCINATIONS_BLUE[2],
   },
   {
     labelTo: '70%',
+    labelRange: '60 - 70%',
     color: COLOR_MAP.VACCINATIONS_BLUE[3],
   },
   {
     labelTo: '100%', // Does not render
+    labelRange: '> 70%',
     color: COLOR_MAP.VACCINATIONS_BLUE[4],
   },
 ];

--- a/src/components/ShareBlock/ShareBlock.tsx
+++ b/src/components/ShareBlock/ShareBlock.tsx
@@ -77,6 +77,8 @@ const ShareBlock = ({
     projections && stats ? (
       <SocialLocationPreview projections={projections} stats={stats} />
     ) : (
+      // HACK: We always set isEmbedPreview to true so that we render the states
+      // map (instead of counties) on the homepage, which renders much faster.
       <SocialLocationPreviewMap isEmbedPreview />
     );
 

--- a/src/components/SocialLocationPreview/Legend.style.ts
+++ b/src/components/SocialLocationPreview/Legend.style.ts
@@ -9,6 +9,8 @@ export const LegendContainer = styled.div<{
   flex-wrap: wrap;
   height: ${props => (props.$condensed ? 'unset' : '3.5rem')};
   width: 100%;
+  margin-top: 8px;
+  align-items: center;
 
   @media (min-width: 960px) {
     height: unset;
@@ -27,6 +29,7 @@ export const LegendItemHeader = styled.div`
   font-size: 0.75rem;
   line-height: 1.5;
   color: rgba(0, 0, 0, 0.7);
+  min-width: 70px;
 `;
 
 export const LegendItemContainer = styled.div<{
@@ -41,12 +44,6 @@ export const LegendItemContainer = styled.div<{
     padding: 0;
   `
       : `
-    margin-right: 1rem;
-
-    &:last-child {
-      margin-right: 0;
-    }
-
     @media (min-width: 960px) {
       margin: 0.5rem;
     }
@@ -67,9 +64,12 @@ export const LegendWrapper = styled.div<{
   display: flex;
   flex-direction: column;
   justify-content: center;
-  margin-top: 1rem;
   align-items: ${props => (props.$condensed ? 'flex-start' : 'center')};
   padding: ${props => (props.$condensed ? '0.75rem 0 0' : '0 0.5rem')};
+  margin-top: ${props => (!props.$condensed ? '0.5rem' : 0)};
+  font-weight: bold;
+  font-size: 0.8rem;
+  line-height: 1.1rem;
   ${props =>
     !props.$condensed &&
     css<{

--- a/src/components/SocialLocationPreview/Legend.tsx
+++ b/src/components/SocialLocationPreview/Legend.tsx
@@ -11,6 +11,7 @@ import {
 interface LegendProps {
   children: React.ReactElement[];
   condensed?: boolean;
+  header?: string;
 }
 
 interface LegendItemProps {
@@ -19,9 +20,10 @@ interface LegendItemProps {
   condensed?: boolean;
 }
 
-export function Legend({ children, condensed = false }: LegendProps) {
+export function Legend({ children, condensed = false, header }: LegendProps) {
   return (
     <LegendWrapper $condensed={condensed}>
+      {header}
       <LegendContainer $condensed={condensed}>
         {React.Children.map(children, child =>
           React.cloneElement(child, { condensed: condensed }),

--- a/src/components/SocialLocationPreview/SocialLocationPreviewMap.tsx
+++ b/src/components/SocialLocationPreview/SocialLocationPreviewMap.tsx
@@ -14,7 +14,9 @@ import {
 import { Level } from 'common/level';
 import { LOCATION_SUMMARY_LEVELS } from 'common/metrics/location_summary';
 import USRiskMap from 'components/USMap/USRiskMap';
+import USVaccineMap from 'components/USMap/USVaccineMap';
 import { Legend, LegendItem } from './Legend';
+import { thermometerSections } from 'components/HorizontalThermometer/VaccinationsThermometer/VaccinationsThermometer';
 
 const SocialLocationPreview = (props: {
   border?: Boolean;
@@ -27,6 +29,13 @@ const SocialLocationPreview = (props: {
     lastUpdatedDate !== null ? lastUpdatedDate.toLocaleDateString() : '';
   const { border, Footer, isEmbed, isEmbedPreview } = props;
   const showCountyView = !isEmbed && !isEmbedPreview;
+  // TODO(michael): 2021-06-24: I'm going out on a limb and switching our embeds
+  // over to the vaccine map too, but if anybody complains we could change this
+  // to only show when `!isEmbed` so we don't affect embeds on people's sites.
+  const showVaccineMap = true;
+  const Map = showVaccineMap ? USVaccineMap : USRiskMap;
+  const MapLegend = showVaccineMap ? VaccineMapLegend : RiskMapLegend;
+
   return (
     <Wrapper noShadow={!isEmbedPreview} border={border}>
       <MapHeaderHeader>US COVID Risk &amp; Vaccine Tracker</MapHeaderHeader>
@@ -36,7 +45,7 @@ const SocialLocationPreview = (props: {
       <USMapPreviewHeader border={isEmbedPreview} sideLegend={!isEmbed}>
         <MapWrapper>
           {isEmbed && <MapLegend isEmbed />}
-          <USRiskMap showCounties={showCountyView} />
+          <Map showCounties={showCountyView} />
         </MapWrapper>
         {!isEmbed && (
           <USMapHeaderText>
@@ -58,7 +67,7 @@ const SocialLocationPreview = (props: {
   );
 };
 
-const MapLegend = ({ isEmbed = false }: { isEmbed?: boolean }) => (
+const RiskMapLegend = ({ isEmbed = false }: { isEmbed?: boolean }) => (
   <Legend condensed={!isEmbed}>
     {[
       Level.SUPER_CRITICAL,
@@ -75,6 +84,18 @@ const MapLegend = ({ isEmbed = false }: { isEmbed?: boolean }) => (
             : LOCATION_SUMMARY_LEVELS[level].name
         }
         color={LOCATION_SUMMARY_LEVELS[level].color}
+      />
+    ))}
+  </Legend>
+);
+
+const VaccineMapLegend = ({ isEmbed = false }: { isEmbed?: boolean }) => (
+  <Legend condensed={!isEmbed} header="Pop. with 1+ dose">
+    {thermometerSections.map((section, i) => (
+      <LegendItem
+        key={`legend-${i}`}
+        title={section.labelRange}
+        color={section.color}
       />
     ))}
   </Legend>


### PR DESCRIPTION
I've left the risk map stuff around in case we want to switch back (I'm a bit nervous about switching people's embeds over without them opting-in).  Had to tweak css around a bit to get a legend heading in and looking decent.

Share card on homepage:
![image](https://user-images.githubusercontent.com/206364/123330137-7c72bb00-d4f2-11eb-9fcd-7dc333cd8fc6.png)

Share image:
![image](https://user-images.githubusercontent.com/206364/123330169-898faa00-d4f2-11eb-882e-582329397d01.png)

Embed:
![image](https://user-images.githubusercontent.com/206364/123330202-96140280-d4f2-11eb-9947-76a9e7c8bdde.png)
