### PR TITLE
Remove vaccine eligibility component and minor copy tweaks.

### DIFF
--- a/scripts/alert_emails/template.html
+++ b/scripts/alert_emails/template.html
@@ -135,6 +135,7 @@
                                                     <div class="aSK J-J5-Ji aYr"></div>
                                                 </div>
                                             </div>
+                                            <div style="font-size: 13px; color: #828282">Note that risk is reduced for those who are vaccinated.</div>
                                         </div>
                                     </div>
                                 </div>

--- a/src/common/metrics/vaccinations.tsx
+++ b/src/common/metrics/vaccinations.tsx
@@ -76,23 +76,13 @@ function renderStatus(projections: Projections): React.ReactElement {
   const peopleVaccinated = formatInteger(info.peopleVaccinated);
   const percentVaccinated = formatPercent(info.ratioVaccinated, 1);
 
-  let distributedText = <Fragment />;
-  if (info.dosesDistributed && info.ratioDosesAdministered) {
-    distributedText = (
-      <Fragment>
-        {locationName} has administered{' '}
-        {formatPercent(info.ratioDosesAdministered)} of their supply of vaccine
-        doses.
-      </Fragment>
-    );
-  }
-
   return (
     <Fragment>
       In {locationName}, {peopleInitiated} people ({percentInitiated}) have
       received at least one dose and {peopleVaccinated} ({percentVaccinated})
-      are fully vaccinated. {distributedText} Fewer than 0.001% of people who
-      have received a dose experienced a severe adverse reaction.{' '}
+      are fully vaccinated. Anybody who is at least 12 years old is eligible to
+      be vaccinated. Fewer than 0.001% of people who have received a dose
+      experienced a severe adverse reaction.{' '}
       <Link to="/faq#vaccines">See more vaccine resources and FAQs</Link>.
     </Fragment>
   );

--- a/src/components/LocationPage/ChartsHolder.tsx
+++ b/src/components/LocationPage/ChartsHolder.tsx
@@ -22,7 +22,6 @@ import ErrorBoundary from 'components/ErrorBoundary';
 import Explore, { ExploreMetric } from 'components/Explore';
 import Recommendations from './Recommendations';
 import ShareModelBlock from 'components/ShareBlock/ShareModelBlock';
-import VaccinationEligibilityBlock from 'components/VaccinationEligibilityBlock';
 import VulnerabilitiesBlock from 'components/VulnerabilitiesBlock';
 import LocationPageBlock from './LocationPageBlock';
 import { WidthContainer } from './LocationPageBlock.style';
@@ -213,9 +212,6 @@ const ChartsHolder = React.memo(({ region, chartId }: ChartsHolderProps) => {
         />
         <BelowTheFold>
           <WidthContainer>
-            <LocationPageBlock>
-              <VaccinationEligibilityBlock region={region} />
-            </LocationPageBlock>
             <LocationPageBlock>
               <CompareMain
                 stateName={getStateName(region) || region.name} // rename prop


### PR DESCRIPTION
* Remove vaccine eligibility component (per Igor).
* Add copy under vaccine chart that 12+ are eligible (and remove old distributed % text that's no longer relevant).
* Add "Note that risk is reduce for vaccinated indivudals." to risk alert template.

New risk alert email looks like this (see new text under thermometer image):

![image](https://user-images.githubusercontent.com/206364/123344268-5ce68d00-d508-11eb-89e6-f916460e816a.png)
