### PR TITLE
Reorder about sections

### DIFF
--- a/src/screens/About/About.tsx
+++ b/src/screens/About/About.tsx
@@ -48,16 +48,16 @@ export const sidebarItems: TocItem[] = [
         label: aboutContent.impactHeader,
       },
       {
+        to: '/about#future-projects',
+        label: aboutContent.futureProjectsHeader,
+      },
+      {
         to: '/about#partners',
         label: aboutContent.partnersHeader,
       },
       {
         to: '/about#team',
         label: aboutContent.teamHeader,
-      },
-      {
-        to: '/about#future-projects',
-        label: aboutContent.futureProjectsHeader,
       },
       {
         to: '/about#contact-us',

--- a/src/screens/About/About.tsx
+++ b/src/screens/About/About.tsx
@@ -144,6 +144,12 @@ const About = () => {
             <Button to="/case-studies" cta="View case studies" />
           </ButtonContainer>
         </HashWrapper>
+        <HashWrapper id="future-projects">
+          <AboutHeading2>{aboutContent.futureProjectsHeader}</AboutHeading2>
+          <SectionContent>
+            <MarkdownContent source={aboutContent.futureProjectsContent} />
+          </SectionContent>
+        </HashWrapper>
         <HashWrapper id="partners">
           <AboutHeading2>{aboutContent.partnersHeader}</AboutHeading2>
           <SectionContent>
@@ -185,12 +191,6 @@ const About = () => {
           <SectionContent>
             <MarkdownContent source={aboutContent.teamIntro} />
             <TeamSection />
-          </SectionContent>
-        </HashWrapper>
-        <HashWrapper id="future-projects">
-          <AboutHeading2>{aboutContent.futureProjectsHeader}</AboutHeading2>
-          <SectionContent>
-            <MarkdownContent source={aboutContent.futureProjectsContent} />
           </SectionContent>
         </HashWrapper>
         <AboutHeading2 id="contact-us">


### PR DESCRIPTION
This PR moves the "Our climate work" section higher up on the page, immediately below "Our COVID work" section.