### PR TITLE
Update learn menu and footer copy

### DIFF
--- a/src/assets/theme/megaMenu.ts
+++ b/src/assets/theme/megaMenu.ts
@@ -12,7 +12,7 @@ export interface MenuTheme {
   buttonContentHover: string;
   buttonBorder: string;
   aboutUsContentAlignment: string;
-  aboutUsTextAlignment: string;
+  paragraphAlignment: string;
 }
 
 export const megaMenu: MenuTheme = {
@@ -23,7 +23,7 @@ export const megaMenu: MenuTheme = {
   buttonContentHover: 'white',
   buttonBorder: COLOR_MAP.GREY_2,
   aboutUsContentAlignment: 'flex-start',
-  aboutUsTextAlignment: 'left',
+  paragraphAlignment: 'left',
 };
 
 export const megaMenuFooter: MenuTheme = {
@@ -34,5 +34,5 @@ export const megaMenuFooter: MenuTheme = {
   buttonContentHover: COLOR_MAP.NEW_BLUE.PURPLE,
   buttonBorder: COLOR_MAP.GREY_3,
   aboutUsContentAlignment: 'center',
-  aboutUsTextAlignment: 'center',
+  paragraphAlignment: 'center',
 };

--- a/src/cms-content/footer/footer.json
+++ b/src/cms-content/footer/footer.json
@@ -1,19 +1,6 @@
 {
   "aboutUs": "The Act Now Coalition is an independent 501(c)(3) nonprofit founded by volunteers in March 2020. Covid Act Now is our COVID-focused initiative to help people make informed decisions by providing timely and accurate data about COVID in the U.S.",
-  "learnLinks": [
-    {
-      "cta": "What can you do after you are fully vaccinated?",
-      "url": "/faq#what-can-you-do-after-fully-vaccinated"
-    },
-    {
-      "cta": "Can you transmit COVID after vaccination?",
-      "url": "/faq#can-you-transmit-covid-after-vaccination"
-    },
-    {
-      "url": "faq#can-you-get-covid-after-vaccination",
-      "cta": "Can you get COVID even after being vaccinated?"
-    }
-  ],
+  "learn": "Find simple definitions of COVID-related terms, deep dives into COVID science and treatments, and concise answers to pressing COVID questions.",
   "featuredSections": [
     {
       "cta": "Alerts",

--- a/src/cms-content/footer/index.ts
+++ b/src/cms-content/footer/index.ts
@@ -1,11 +1,5 @@
 import { Markdown } from '../utils';
-import shuffle from 'lodash/shuffle';
 import footer from './footer.json';
-
-export interface LinkItem {
-  url: string;
-  cta: string;
-}
 
 export enum SectionId {
   API = 'API',
@@ -21,17 +15,11 @@ export interface FeaturedItem {
 }
 
 interface MenuContent {
-  learnLinks: LinkItem[];
+  learn: Markdown;
   aboutUs: Markdown;
   featuredSections: FeaturedItem[];
 }
 
-const { learnLinks, aboutUs, featuredSections } = footer;
+const { learn, aboutUs, featuredSections } = footer;
 
-const menuContentWithShuffleLearnLinks = {
-  learnLinks: shuffle(learnLinks),
-  aboutUs,
-  featuredSections,
-};
-
-export const menuContent = menuContentWithShuffleLearnLinks as MenuContent;
+export const menuContent = { learn, aboutUs, featuredSections } as MenuContent;

--- a/src/components/MenuContent/AboutUsSection.tsx
+++ b/src/components/MenuContent/AboutUsSection.tsx
@@ -5,7 +5,7 @@ import {
   Section,
   SectionHeader,
   OutlinedButton,
-  AboutCopy,
+  ParagraphCopy,
   LogoWrapper,
   RowWithSpacing,
 } from './Menu.style';
@@ -30,7 +30,7 @@ const AboutUsSection: React.FC<{
       ) : (
         <SectionHeader>About Us</SectionHeader>
       )}
-      <AboutCopy>{aboutUsCopy}</AboutCopy>
+      <ParagraphCopy>{aboutUsCopy}</ParagraphCopy>
       <RowWithSpacing>
         <OutlinedButton to="/about" onClick={() => onClick('About us')}>
           Learn more about us

--- a/src/components/MenuContent/LearnSection.tsx
+++ b/src/components/MenuContent/LearnSection.tsx
@@ -1,41 +1,21 @@
 import React from 'react';
-import { LinkItem } from 'cms-content/footer';
-import TextAndIconWithSpecialWrapping from 'components/TextAndIconWithSpecialWrapping/TextAndIconWithSpecialWrapping';
 import {
   Section,
-  Column,
   SectionHeader,
-  ArrowIcon,
   OutlinedButton,
-  LearnLink,
+  ParagraphCopy,
 } from './Menu.style';
 
 const LearnSection: React.FC<{
-  learnLinks: LinkItem[];
+  learnCopy: string;
   onClick: (label: string) => void;
-}> = ({ learnLinks, onClick }) => {
+}> = ({ learnCopy, onClick }) => {
   return (
     <Section>
       <SectionHeader>FAQ</SectionHeader>
-      <Column>
-        {learnLinks.map((link: LinkItem) => {
-          const { url, cta } = link;
-          return (
-            <LearnLink
-              key={cta}
-              to={url}
-              onClick={() => onClick(`Learn: ${cta}`)}
-            >
-              <TextAndIconWithSpecialWrapping
-                text={link.cta}
-                icon={<ArrowIcon />}
-              />
-            </LearnLink>
-          );
-        })}
-      </Column>
-      <OutlinedButton to="/faq" onClick={() => onClick('Learn: Vaccine FAQs')}>
-        Vaccine FAQs
+      <ParagraphCopy>{learnCopy}</ParagraphCopy>
+      <OutlinedButton to="/learn" onClick={() => onClick('Learn')}>
+        Learn more
       </OutlinedButton>
     </Section>
   );

--- a/src/components/MenuContent/LearnSection.tsx
+++ b/src/components/MenuContent/LearnSection.tsx
@@ -12,7 +12,7 @@ const LearnSection: React.FC<{
 }> = ({ learnCopy, onClick }) => {
   return (
     <Section>
-      <SectionHeader>FAQ</SectionHeader>
+      <SectionHeader>Learn</SectionHeader>
       <ParagraphCopy>{learnCopy}</ParagraphCopy>
       <OutlinedButton to="/learn" onClick={() => onClick('Learn')}>
         Learn more

--- a/src/components/MenuContent/Menu.style.tsx
+++ b/src/components/MenuContent/Menu.style.tsx
@@ -102,11 +102,11 @@ export const FeaturedDescription = styled.p`
   color: ${props => props.theme.megaMenu.secondaryText};
 `;
 
-export const AboutCopy = styled.p`
+export const ParagraphCopy = styled.p`
   ${BodyCopy};
   color: ${props => props.theme.megaMenu.secondaryText};
   margin-bottom: 2rem;
-  text-align: ${props => props.theme.megaMenu.aboutUsTextAlignment};
+  text-align: ${props => props.theme.megaMenu.paragraphAlignment};
 
   @media (min-width: ${mobileBreakpoint}) {
     text-align: left;
@@ -133,22 +133,6 @@ export const TextLink = styled(Link)`
     ${ArrowIcon} {
       transform: translateX(6px);
       transition: transform 0.06s ease-in-out;
-    }
-  }
-`;
-
-export const LearnLink = styled(TextLink)`
-  &:not(:last-of-type) {
-    margin-bottom: 0.5rem;
-  }
-
-  ${ArrowIcon} {
-    margin-bottom: -4px;
-  }
-
-  @media (min-width: ${mobileBreakpoint}) {
-    &:last-of-type {
-      margin-bottom: 1.75rem;
     }
   }
 `;

--- a/src/components/MenuContent/MenuContent.tsx
+++ b/src/components/MenuContent/MenuContent.tsx
@@ -10,7 +10,7 @@ const MenuContent: React.FC<{
   onClick: (label: string) => void;
   Logo?: ComponentType;
 }> = ({ onClick, Logo }) => {
-  const { learnLinks, aboutUs, featuredSections } = menuContent;
+  const { learn, aboutUs, featuredSections } = menuContent;
 
   const isMobile = useBreakpoint(800);
 
@@ -22,12 +22,12 @@ const MenuContent: React.FC<{
             featuredSections={featuredSections}
             onClick={onClick}
           />
-          <LearnSection learnLinks={learnLinks} onClick={onClick} />
+          <LearnSection learnCopy={learn} onClick={onClick} />
           <AboutUsSection aboutUsCopy={aboutUs} onClick={onClick} Logo={Logo} />
         </>
       ) : (
         <>
-          <LearnSection learnLinks={learnLinks} onClick={onClick} />
+          <LearnSection learnCopy={learn} onClick={onClick} />
           <FeaturedSection
             featuredSections={featuredSections}
             onClick={onClick}


### PR DESCRIPTION
This PR adjusts the content under the FAQ section of the mega-menu/footer. Specifically,
- Replace three shuffled FAQ questions with a paragraph about the learn section.
- Replace the "Vaccine FAQs" button with a "Learn more" button which directs the user to the "Learn" page.
- Clean up no longer needed code.

Note: Added comments throughout the PR for clarity.