### PR TITLE
Change learn heading to educational resources

### DIFF
--- a/src/components/MenuContent/LearnSection.tsx
+++ b/src/components/MenuContent/LearnSection.tsx
@@ -12,7 +12,7 @@ const LearnSection: React.FC<{
 }> = ({ learnCopy, onClick }) => {
   return (
     <Section>
-      <SectionHeader>Learn</SectionHeader>
+      <SectionHeader>Educational Resources</SectionHeader>
       <ParagraphCopy>{learnCopy}</ParagraphCopy>
       <OutlinedButton to="/learn" onClick={() => onClick('Learn')}>
         Learn more


### PR DESCRIPTION
This PR changes the heading of the Learn section in the mega-menu/footer from "Learn" to "Educational Resources".