### PR TITLE
Add option to search by fips

### DIFF
--- a/src/components/Search/SearchAutocomplete/SearchAutocomplete.tsx
+++ b/src/components/Search/SearchAutocomplete/SearchAutocomplete.tsx
@@ -44,6 +44,7 @@ const SearchAutocomplete: React.FC<{
   const [input, setInput] = useState('');
   /* We only check for a zipcode match when the input is all numbers and has a length of 5: */
   const [checkForZipcodeMatch, setCheckForZipcodeMatch] = useState(false);
+  const [checkForFipsMatch, setCheckForFipsMatch] = useState(false);
   const [noOptionsCopy, setNoOptionsCopy] = useState('No location found');
   const [isOpen, setIsOpen] = useState(false);
   const { result: countyToZipMap } = useCountyToZipMap();
@@ -63,8 +64,13 @@ const SearchAutocomplete: React.FC<{
     if (isStringOfDigits) {
       setNoOptionsCopy('Enter a valid 5-digit zip code');
       setCheckForZipcodeMatch(value.length === 5);
+      setCheckForFipsMatch(false);
+    } else if (value.startsWith('fips:')) {
+      setCheckForZipcodeMatch(false);
+      setCheckForFipsMatch(true);
     } else {
       setCheckForZipcodeMatch(false);
+      setCheckForFipsMatch(false);
       if (value.length) {
         setNoOptionsCopy(
           `No locations named ${value} found. You can also try searching by zip code.`,
@@ -79,6 +85,10 @@ const SearchAutocomplete: React.FC<{
       return countyToZipMap?.[fips] ?? [];
     };
 
+    // Search by fips matches patterns of "fips:<fips code>"
+    if (checkForFipsMatch) {
+      return `fips:${option.fipsCode}`;
+    }
     if (checkForZipcodeMatch) {
       // get zipcodes for county, metro, and state objects
       let zipCodes = null;


### PR DESCRIPTION
I've wanted this feature for a long time and am finding it helpful for quick reference when debugging outlier detection values.

Adds a sneaky check in search autocomplete to trigger matching by fips
![image](https://user-images.githubusercontent.com/1422280/130835767-b3c174ef-5f38-4be8-8410-c65361dca40f.png)
