### PR TITLE
Update Vaccination Color Thresholds

### DIFF
--- a/src/common/colors.ts
+++ b/src/common/colors.ts
@@ -118,6 +118,12 @@ export function vaccineColorFromLocationSummary(
 }
 
 export function vaccineColor(val: number): string {
+  // Round to the nearest .01 before calculating color to make it match the
+  // rounding we do in the map / compare table.
+  // TODO(michael): Ideally we'd use roundMetricValue() from metric.tsx but that
+  // causes a circular dependency. :-(
+  val = Number(val.toFixed(2));
+
   const colors = COLOR_MAP.VACCINATIONS_BLUE;
   if (val < 0.5) {
     return colors[0];

--- a/src/common/colors.ts
+++ b/src/common/colors.ts
@@ -119,13 +119,13 @@ export function vaccineColorFromLocationSummary(
 
 export function vaccineColor(val: number): string {
   const colors = COLOR_MAP.VACCINATIONS_BLUE;
-  if (val < 0.4) {
+  if (val < 0.5) {
     return colors[0];
-  } else if (val < 0.5) {
-    return colors[1];
   } else if (val < 0.6) {
-    return colors[2];
+    return colors[1];
   } else if (val < 0.7) {
+    return colors[2];
+  } else if (val < 0.8) {
     return colors[3];
   } else {
     return colors[4];

--- a/src/components/HorizontalThermometer/VaccinationsThermometer/VaccinationsThermometer.tsx
+++ b/src/components/HorizontalThermometer/VaccinationsThermometer/VaccinationsThermometer.tsx
@@ -17,28 +17,28 @@ interface Section {
 
 export const thermometerSections: Section[] = [
   {
-    labelTo: '40%',
-    labelRange: '< 40%',
-    color: COLOR_MAP.VACCINATIONS_BLUE[0],
-  },
-  {
     labelTo: '50%',
-    labelRange: '40 - 50%',
-    color: COLOR_MAP.VACCINATIONS_BLUE[1],
+    labelRange: '< 50%',
+    color: COLOR_MAP.VACCINATIONS_BLUE[0],
   },
   {
     labelTo: '60%',
     labelRange: '50 - 60%',
-    color: COLOR_MAP.VACCINATIONS_BLUE[2],
+    color: COLOR_MAP.VACCINATIONS_BLUE[1],
   },
   {
     labelTo: '70%',
     labelRange: '60 - 70%',
+    color: COLOR_MAP.VACCINATIONS_BLUE[2],
+  },
+  {
+    labelTo: '80%',
+    labelRange: '70 - 80%',
     color: COLOR_MAP.VACCINATIONS_BLUE[3],
   },
   {
     labelTo: '100%', // Does not render
-    labelRange: '> 70%',
+    labelRange: '> 80%',
     color: COLOR_MAP.VACCINATIONS_BLUE[4],
   },
 ];


### PR DESCRIPTION
We are updating the vaccination color thresholds now that more states (and Puerto Rico) are open 80%.

As part of that update, we are standardizing how we round/truncate percentages to make them the same.