### PR TITLE
Show disclaimers for blocked metrics and enable markdown.

### DIFF
--- a/src/components/Charts/MetricChart.tsx
+++ b/src/components/Charts/MetricChart.tsx
@@ -14,7 +14,9 @@ import { VACCINATIONS_COLOR_MAP } from 'common/colors';
 import { EmptyPanel } from 'components/Charts/Charts.style';
 import { getMetricStatusText } from 'common/metric';
 import { ScreenshotReady } from 'components/Screenshot';
+import { MarkdownContent } from 'components/Markdown';
 import { useChartHeightForBreakpoint } from 'common/hooks';
+import { getRegionMetricOverride } from 'cms-content/region-overrides';
 
 // TODO(michael): Rename to `Chart` once we get rid of existing (highcharts) Chart component.
 // TODO(michael): Update ChartsHolder to use this component instead of the individual chart components.
@@ -31,9 +33,20 @@ const MetricChart = React.memo(
   }) => {
     const chartHeight = height ? height : useChartHeightForBreakpoint();
     if (!projections.hasMetric(metric)) {
+      // See if the data has been blocked and there is a disclaimer.
+      const override = getRegionMetricOverride(projections.region, metric);
+      const blockedDisclaimer =
+        override?.blocked && !override.start_date && !override.end_date
+          ? override.disclaimer
+          : undefined;
+
       return (
         <EmptyPanel $height={chartHeight}>
-          <p>{getMetricStatusText(metric, projections)}</p>
+          <p>
+            <MarkdownContent>
+              {blockedDisclaimer || getMetricStatusText(metric, projections)}
+            </MarkdownContent>
+          </p>
           <ScreenshotReady />
         </EmptyPanel>
       );

--- a/src/components/NewLocationPage/ChartFooter/MetricChartFooter.tsx
+++ b/src/components/NewLocationPage/ChartFooter/MetricChartFooter.tsx
@@ -26,6 +26,7 @@ import { getMetricNameExtended, getMetricStatusText } from 'common/metric';
 import { EventCategory } from 'components/Analytics';
 import { makeChartShareQuote } from 'common/utils/makeChartShareQuote';
 import * as urls from 'common/urls';
+import { MarkdownContent } from 'components/Markdown';
 
 const ShareButtonBlock: React.FC<{
   region: Region;
@@ -132,7 +133,9 @@ const MetricChartFooter: React.FC<{
             {'   '}
             <MetricModal {...dialogProps} />
             {overrideDisclaimer && (
-              <OverrideDisclaimer>{overrideDisclaimer}</OverrideDisclaimer>
+              <OverrideDisclaimer>
+                <MarkdownContent>{overrideDisclaimer}</MarkdownContent>
+              </OverrideDisclaimer>
             )}
           </FooterText>
           <ShareButtonBlock {...shareButtonProps} />


### PR DESCRIPTION
Before this change, disclaimers only showed up if the metric wasn't blocked (in the metric footer). We also didn't support markdown (so couldn't embed links) in disclaimers.

**Before:**

![image](https://user-images.githubusercontent.com/206364/142088938-68b87ff5-1aa6-435a-bdc8-ab04745ce55e.png)

**After:**

![image](https://user-images.githubusercontent.com/206364/142089864-4f041eaa-20f2-46ba-96af-86345b7b689b.png)

