### PR TITLE
Remove unused renderDisclaimer() method per TODO.

### DIFF
--- a/src/common/metrics/case_density.tsx
+++ b/src/common/metrics/case_density.tsx
@@ -1,5 +1,4 @@
 import React, { Fragment } from 'react';
-import { Sources } from 'api/schema/RegionSummaryWithTimeseries';
 import { COLOR_MAP } from 'common/colors';
 import { Level, LevelInfoMap } from 'common/level';
 import { Projections } from 'common/models/Projections';
@@ -7,19 +6,12 @@ import { formatDecimal, formatInteger } from 'common/utils';
 import Thermometer from 'components/Thermometer';
 import { MetricDefinition } from './interfaces';
 import { Metric } from 'common/metricEnum';
-import {
-  InfoTooltip,
-  TextTooltip,
-  renderTooltipContent,
-} from 'components/InfoTooltip';
+import { InfoTooltip, renderTooltipContent } from 'components/InfoTooltip';
 import { metricToTooltipMap } from 'cms-content/tooltips';
-import { Region } from 'common/regions';
-import { getDataSourceTooltipContent } from 'common/utils/provenance';
 import { trackOpenTooltip } from 'components/InfoTooltip';
 
 export const CaseIncidenceMetric: MetricDefinition = {
   renderStatus,
-  renderDisclaimer,
   renderThermometer,
   renderInfoTooltip,
   metricName: 'Daily new cases',
@@ -102,39 +94,6 @@ function renderStatus(projections: Projections): React.ReactElement {
       Over the last week, {locationName} has averaged {newCasesPerDayText} new
       confirmed cases per day (<b>{formatDecimal(currentCaseDensity, 1)}</b> for
       every 100,000 residents).
-    </Fragment>
-  );
-}
-
-function renderDisclaimer(
-  region: Region,
-  provenance?: Sources,
-): React.ReactElement {
-  const { body } = metricToTooltipMap[Metric.CASE_DENSITY].metricCalculation;
-
-  return (
-    <Fragment>
-      {'Learn more about '}
-      <TextTooltip
-        title={getDataSourceTooltipContent(
-          Metric.CASE_DENSITY,
-          region,
-          provenance,
-        )}
-        mainCopy={'where our data comes from'}
-        trackOpenTooltip={() =>
-          trackOpenTooltip(`Learn more: ${Metric.CASE_DENSITY}`)
-        }
-      />
-      {' and '}
-      <TextTooltip
-        title={renderTooltipContent(body)}
-        mainCopy={'how we calculate our metrics'}
-        trackOpenTooltip={() =>
-          trackOpenTooltip(`How we calculate: ${Metric.CASE_DENSITY}`)
-        }
-      />
-      .
     </Fragment>
   );
 }

--- a/src/common/metrics/case_growth.tsx
+++ b/src/common/metrics/case_growth.tsx
@@ -1,5 +1,4 @@
 import React, { Fragment } from 'react';
-import { Sources } from 'api/schema/RegionSummaryWithTimeseries';
 import { COLOR_MAP } from 'common/colors';
 import { Level, LevelInfoMap } from 'common/level';
 import { getLevel } from 'common/metric';
@@ -9,21 +8,14 @@ import { formatDecimal } from 'common/utils';
 import { Projections } from 'common/models/Projections';
 import { MetricDefinition } from './interfaces';
 import Thermometer from 'components/Thermometer';
-import {
-  InfoTooltip,
-  TextTooltip,
-  renderTooltipContent,
-} from 'components/InfoTooltip';
+import { InfoTooltip, renderTooltipContent } from 'components/InfoTooltip';
 import { metricToTooltipMap } from 'cms-content/tooltips';
-import { Region } from 'common/regions';
-import { getDataSourceTooltipContent } from 'common/utils/provenance';
 import { trackOpenTooltip } from 'components/InfoTooltip';
 
 const METRIC_NAME = 'Infection rate';
 
 export const CaseGrowthMetric: MetricDefinition = {
   renderStatus,
-  renderDisclaimer,
   renderThermometer,
   renderInfoTooltip,
   metricName: METRIC_NAME,
@@ -120,41 +112,6 @@ function renderStatus(projections: Projections): React.ReactElement {
     <Fragment>
       On average, each person in {locationName} with COVID is infecting{' '}
       {formatDecimal(rt)} other people. {epidemiologyReasoning}
-    </Fragment>
-  );
-}
-
-function renderDisclaimer(
-  region: Region,
-  provenance?: Sources,
-): React.ReactElement {
-  const { body } = metricToTooltipMap[
-    Metric.CASE_GROWTH_RATE
-  ].metricCalculation;
-
-  return (
-    <Fragment>
-      {'Learn more about '}
-      <TextTooltip
-        title={getDataSourceTooltipContent(
-          Metric.CASE_GROWTH_RATE,
-          region,
-          provenance,
-        )}
-        mainCopy={'where our data comes from'}
-        trackOpenTooltip={() =>
-          trackOpenTooltip(`Learn more: ${Metric.CASE_GROWTH_RATE}`)
-        }
-      />
-      {' and '}
-      <TextTooltip
-        title={renderTooltipContent(body)}
-        mainCopy={'how we calculate our metrics'}
-        trackOpenTooltip={() =>
-          trackOpenTooltip(`How we calculate: ${Metric.CASE_GROWTH_RATE}`)
-        }
-      />
-      .
     </Fragment>
   );
 }

--- a/src/common/metrics/hospitalizations.tsx
+++ b/src/common/metrics/hospitalizations.tsx
@@ -1,5 +1,4 @@
 import React, { Fragment } from 'react';
-import { Sources } from 'api/schema/RegionSummaryWithTimeseries';
 import { COLOR_MAP } from 'common/colors';
 import { Level, LevelInfoMap } from 'common/level';
 import { levelText } from 'common/utils/chart';
@@ -9,21 +8,14 @@ import { formatPercent, formatInteger, assert } from 'common/utils';
 import { Projections } from 'common/models/Projections';
 import { MetricDefinition } from './interfaces';
 import Thermometer from 'components/Thermometer';
-import {
-  InfoTooltip,
-  TextTooltip,
-  renderTooltipContent,
-} from 'components/InfoTooltip';
+import { InfoTooltip, renderTooltipContent } from 'components/InfoTooltip';
 import { metricToTooltipMap } from 'cms-content/tooltips';
-import { Region } from 'common/regions';
-import { getDataSourceTooltipContent } from 'common/utils/provenance';
 import { trackOpenTooltip } from 'components/InfoTooltip';
 
 const METRIC_NAME = 'ICU capacity used';
 
 export const ICUCapacityUsed: MetricDefinition = {
   renderStatus,
-  renderDisclaimer,
   renderThermometer,
   renderInfoTooltip,
   metricName: METRIC_NAME,
@@ -150,39 +142,6 @@ function renderStatus(projections: Projections): React.ReactElement {
       {locationName} has reported having {totalICUBeds} staffed adult ICU beds.{' '}
       {patientBreakdown} Overall, {totalICUPatients} out of {totalICUBeds} (
       {icuCapacityUsed}) are filled. {textLevel}.
-    </Fragment>
-  );
-}
-
-function renderDisclaimer(
-  region: Region,
-  provenance?: Sources,
-): React.ReactElement {
-  const { body } = metricToTooltipMap[Metric.HOSPITAL_USAGE].metricCalculation;
-
-  return (
-    <Fragment>
-      {'Learn more about '}
-      <TextTooltip
-        title={getDataSourceTooltipContent(
-          Metric.HOSPITAL_USAGE,
-          region,
-          provenance,
-        )}
-        mainCopy={'where our data comes from'}
-        trackOpenTooltip={() =>
-          trackOpenTooltip(`Learn more: ${Metric.HOSPITAL_USAGE}`)
-        }
-      />
-      {' and '}
-      <TextTooltip
-        title={renderTooltipContent(body)}
-        mainCopy={'how we calculate our metrics'}
-        trackOpenTooltip={() =>
-          trackOpenTooltip(`How we calculate: ${Metric.HOSPITAL_USAGE}`)
-        }
-      />
-      .
     </Fragment>
   );
 }

--- a/src/common/metrics/interfaces.ts
+++ b/src/common/metrics/interfaces.ts
@@ -1,16 +1,8 @@
 import React from 'react';
-import { Sources } from 'api/schema/RegionSummaryWithTimeseries';
 import { Projections } from 'common/models/Projections';
-import { Region } from 'common/regions';
 
 export interface MetricDefinition {
   renderStatus: (projections: Projections) => React.ReactElement;
-
-  // TODO (Chelsi) - delete renderDislcaimer altogether when new metric footers/modals are shipped
-  renderDisclaimer: (
-    region: Region,
-    provenance?: Sources,
-  ) => React.ReactElement;
 
   metricName: string;
   extendedMetricName: string;

--- a/src/common/metrics/positive_rate.tsx
+++ b/src/common/metrics/positive_rate.tsx
@@ -1,5 +1,4 @@
 import React, { Fragment } from 'react';
-import { Sources } from 'api/schema/RegionSummaryWithTimeseries';
 import { COLOR_MAP } from 'common/colors';
 import { Level, LevelInfoMap } from 'common/level';
 import { levelText } from 'common/utils/chart';
@@ -9,21 +8,14 @@ import { formatPercent } from 'common/utils';
 import { Projections } from 'common/models/Projections';
 import { MetricDefinition } from './interfaces';
 import Thermometer from 'components/Thermometer';
-import {
-  InfoTooltip,
-  TextTooltip,
-  renderTooltipContent,
-} from 'components/InfoTooltip';
+import { InfoTooltip, renderTooltipContent } from 'components/InfoTooltip';
 import { metricToTooltipMap } from 'cms-content/tooltips';
-import { Region } from 'common/regions';
-import { getDataSourceTooltipContent } from 'common/utils/provenance';
 import { trackOpenTooltip } from 'components/InfoTooltip';
 
 const METRIC_NAME = 'Positive test rate';
 
 export const PositiveTestRateMetric: MetricDefinition = {
   renderStatus,
-  renderDisclaimer,
   renderThermometer,
   renderInfoTooltip,
   metricName: METRIC_NAME,
@@ -141,39 +133,6 @@ function renderStatus(projections: Projections) {
     <Fragment>
       A {lowSizableLarge} percentage ({percentage}) of COVID tests were
       positive, {testingBroadlyText}.
-    </Fragment>
-  );
-}
-
-function renderDisclaimer(
-  region: Region,
-  provenance?: Sources,
-): React.ReactElement {
-  const { body } = metricToTooltipMap[Metric.POSITIVE_TESTS].metricCalculation;
-
-  return (
-    <Fragment>
-      {'Learn more about '}
-      <TextTooltip
-        title={getDataSourceTooltipContent(
-          Metric.POSITIVE_TESTS,
-          region,
-          provenance,
-        )}
-        mainCopy={'where our data comes from'}
-        trackOpenTooltip={() =>
-          trackOpenTooltip(`Learn more: ${Metric.POSITIVE_TESTS}`)
-        }
-      />
-      {' and '}
-      <TextTooltip
-        title={renderTooltipContent(body)}
-        mainCopy={'how we calculate our metrics'}
-        trackOpenTooltip={() =>
-          trackOpenTooltip(`How we calculate: ${Metric.POSITIVE_TESTS}`)
-        }
-      />
-      .
     </Fragment>
   );
 }

--- a/src/common/metrics/vaccinations.tsx
+++ b/src/common/metrics/vaccinations.tsx
@@ -1,19 +1,12 @@
 import React, { Fragment } from 'react';
-import { Sources } from 'api/schema/RegionSummaryWithTimeseries';
 import { COLOR_MAP } from 'common/colors';
 import { Level, LevelInfo, LevelInfoMap } from 'common/level';
 import { formatPercent, formatInteger } from 'common/utils';
 import { Projections } from 'common/models/Projections';
 import { MetricDefinition } from './interfaces';
 import { Metric } from 'common/metricEnum';
-import {
-  InfoTooltip,
-  TextTooltip,
-  renderTooltipContent,
-} from 'components/InfoTooltip';
+import { InfoTooltip, renderTooltipContent } from 'components/InfoTooltip';
 import { metricToTooltipMap } from 'cms-content/tooltips';
-import { Region, State } from 'common/regions';
-import { getDataSourceTooltipContent } from 'common/utils/provenance';
 import { trackOpenTooltip } from 'components/InfoTooltip';
 import { Link } from 'react-router-dom';
 
@@ -21,7 +14,6 @@ const METRIC_NAME = 'Vaccinated';
 
 export const VaccinationsMetric: MetricDefinition = {
   renderStatus,
-  renderDisclaimer,
   renderThermometer,
   renderInfoTooltip,
   metricName: METRIC_NAME,
@@ -84,51 +76,6 @@ function renderStatus(projections: Projections): React.ReactElement {
       be vaccinated. Fewer than 0.001% of people who have received a dose
       experienced a severe adverse reaction.{' '}
       <Link to="/faq#vaccines">See more vaccine resources and FAQs</Link>.
-    </Fragment>
-  );
-}
-
-function renderDisclaimer(
-  region: Region,
-  provenance?: Sources,
-): React.ReactElement {
-  const { body } = metricToTooltipMap[Metric.VACCINATIONS].metricCalculation;
-
-  /**
-   * We don't have a fallback source for non-state vaccinations.
-   * If the page is not a state page or if there is no vaccinations provenance in the API,
-   * we don't render the first half of the disclaimer ("where our data comes from").
-   */
-  return (
-    <Fragment>
-      {'Learn more about '}
-      {region instanceof State ||
-      (provenance && provenance[0].name && provenance[0].url) ? (
-        <>
-          <TextTooltip
-            title={getDataSourceTooltipContent(
-              Metric.VACCINATIONS,
-              region,
-              provenance,
-            )}
-            mainCopy={'where our data comes from'}
-            trackOpenTooltip={() =>
-              trackOpenTooltip(`Learn more: ${Metric.VACCINATIONS}`)
-            }
-          />
-          {' and '}
-        </>
-      ) : (
-        ''
-      )}
-      <TextTooltip
-        title={renderTooltipContent(body)}
-        mainCopy={'how we calculate our metrics'}
-        trackOpenTooltip={() =>
-          trackOpenTooltip(`How we calculate: ${Metric.VACCINATIONS}`)
-        }
-      />
-      .
     </Fragment>
   );
 }


### PR DESCRIPTION
There was a TODO to delete renderDisclaimer() in src/common/metrics/interfaces.ts and indeed it is not used.  So deleting it to avoid confusion.