### PR TITLE
Adjust axis ticks

### DIFF
--- a/src/components/Charts/utils.ts
+++ b/src/components/Charts/utils.ts
@@ -190,18 +190,8 @@ export const getXTickFormat = (
   }
 };
 
-/**
- * For mobile, we only show every other month
- */
-function getMobileDateTicks(tickValues: Date[]): Date[] {
-  return tickValues.filter((value: Date, i: number) => i % 2 === 0);
-}
-
 export function getFinalTicks(isMobile: boolean, ticks: Date[]): Date[] {
-  if (isMobile) {
-    return getMobileDateTicks(ticks);
-  }
-  return ticks;
+  return ticks.filter((value: Date, i: number) => i % (isMobile ? 3 : 2) === 0);
 }
 
 export function getTimeAxisTicks(

--- a/src/components/Explore/utils.ts
+++ b/src/components/Explore/utils.ts
@@ -156,25 +156,19 @@ export const formatDecimalAxis = (num: number, places = 2): string => {
   /**
    * If value is between 100k and 1m, display in abbreviated form.
    * Examples
-   * - 100,000 => 100k
-   * - 1,000,000 => 1.0m
-   * - 1,100,000 => 1.1m
+   * - 100,000 => 100K
+   * - 1,000,000 => 1M
+   * - 1,100,000 => 1.1M
    */
-  if (num > 99999) {
-    return num > 999999
-      ? `${(num / 1000000).toLocaleString(undefined, {
-          minimumFractionDigits: 1,
-          maximumFractionDigits: 1,
-        })}m`
-      : `${(num / 1000).toLocaleString(undefined, {
-          minimumFractionDigits: 0,
-          maximumFractionDigits: 0,
-        })}k`;
+  if (num >= 100_000) {
+    //@ts-ignore
+    return new Intl.NumberFormat('en', { notation: 'compact' }).format(num);
+  } else {
+    return num.toLocaleString(undefined, {
+      minimumFractionDigits: places,
+      maximumFractionDigits: places,
+    });
   }
-  return num.toLocaleString(undefined, {
-    minimumFractionDigits: places,
-    maximumFractionDigits: places,
-  });
 };
 
 export const getYFormat = (dataMeasure: DataMeasure, places: number) => {

--- a/src/components/Explore/utils.ts
+++ b/src/components/Explore/utils.ts
@@ -149,12 +149,39 @@ function getDatasetIdByMetric(metric: ExploreMetric): DatasetId {
   }
 }
 
+export const formatDecimalAxis = (num: number, places = 2): string => {
+  if (num === null) {
+    return '-';
+  }
+  /**
+   * If value is between 100k and 1m, display in abbreviated form.
+   * Examples
+   * - 100,000 => 100k
+   * - 1,000,000 => 1.0m
+   * - 1,100,000 => 1.1m
+   */
+  if (num > 99999) {
+    return num > 999999
+      ? `${(num / 1000000).toLocaleString(undefined, {
+          minimumFractionDigits: 1,
+          maximumFractionDigits: 1,
+        })}m`
+      : `${(num / 1000).toLocaleString(undefined, {
+          minimumFractionDigits: 0,
+          maximumFractionDigits: 0,
+        })}k`;
+  }
+  return num.toLocaleString(undefined, {
+    minimumFractionDigits: places,
+    maximumFractionDigits: places,
+  });
+};
+
 export const getYFormat = (dataMeasure: DataMeasure, places: number) => {
   const yFormat = (value: number) =>
     dataMeasure === DataMeasure.PERCENT
       ? formatPercent(value, places)
-      : formatDecimal(value, places);
-
+      : formatDecimalAxis(value, places);
   return yFormat;
 };
 


### PR DESCRIPTION
- Adjust x axis so the labels don't squish together.
- Adjust y axis so each label isn't too long.

Before:
![image](https://user-images.githubusercontent.com/46338131/148300359-c53690f0-3dd3-4c46-baac-ceb0601ebb32.png)

After:
![image](https://user-images.githubusercontent.com/46338131/148300478-17946c4d-0cb1-45c6-9b39-b48312fb886f.png)
