### PR TITLE
Display -- instead of 0% in map tooltip

### DIFF
--- a/src/components/USMap/VaccineTooltip/VaccineTooltip.tsx
+++ b/src/components/USMap/VaccineTooltip/VaccineTooltip.tsx
@@ -33,6 +33,10 @@ export interface VaccineTooltipProps {
   addMoreDataLink?: boolean;
 }
 
+function hasVaccineData(vaccineData: number): boolean {
+  return vaccineData > 0;
+}
+
 const VaccineTooltip: React.FC<VaccineTooltipProps> = ({
   state,
   vaccinationsInitiated,
@@ -56,20 +60,21 @@ const VaccineTooltip: React.FC<VaccineTooltipProps> = ({
         <Row>
           <Title>1+ dose</Title>
           <Value>
-            {vaccinationsInitiated === 0
-              ? '--'
-              : formatPercent(vaccinationsInitiated)}
+            {hasVaccineData(vaccinationsInitiated)
+              ? formatPercent(vaccinationsInitiated)
+              : '--'}
           </Value>
         </Row>
         <Row>
           <Title>Fully vaccinated</Title>
           <Value>
-            {vaccinationsCompleted === 0
-              ? '--'
-              : formatPercent(vaccinationsCompleted)}
+            {hasVaccineData(vaccinationsCompleted)
+              ? formatPercent(vaccinationsCompleted)
+              : '--'}
           </Value>
         </Row>
-        {vaccinationsInitiated !== 0 && vaccinationsCompleted !== 0 ? (
+        {hasVaccineData(vaccinationsInitiated) &&
+        hasVaccineData(vaccinationsCompleted) ? (
           <ProgressBarWrapper>
             <VaccineProgressBar
               locationName={locationName}
@@ -78,12 +83,7 @@ const VaccineTooltip: React.FC<VaccineTooltipProps> = ({
             />
           </ProgressBarWrapper>
         ) : (
-          <Box
-            display="flex"
-            justifyContent="center"
-            mt={2}
-            color={COLOR_MAP.GRAY.DARK}
-          >
+          <Box display="flex" mt={2} color={COLOR_MAP.GRAY.DARK}>
             No vaccination data available
           </Box>
         )}

--- a/src/components/USMap/VaccineTooltip/VaccineTooltip.tsx
+++ b/src/components/USMap/VaccineTooltip/VaccineTooltip.tsx
@@ -17,6 +17,8 @@ import {
 import { State } from 'common/regions';
 import { trackEvent, EventAction, EventCategory } from 'components/Analytics';
 import { TextButton } from 'components/ButtonSystem';
+import Box from '@material-ui/core/Box';
+import { COLOR_MAP } from 'common/colors';
 
 export interface VaccineTooltipProps {
   state: State;
@@ -67,13 +69,24 @@ const VaccineTooltip: React.FC<VaccineTooltipProps> = ({
               : formatPercent(vaccinationsCompleted)}
           </Value>
         </Row>
-        <ProgressBarWrapper>
-          <VaccineProgressBar
-            locationName={locationName}
-            vaccinationsInitiated={vaccinationsInitiated}
-            vaccinationsCompleted={vaccinationsCompleted}
-          />
-        </ProgressBarWrapper>
+        {vaccinationsInitiated !== 0 && vaccinationsCompleted !== 0 ? (
+          <ProgressBarWrapper>
+            <VaccineProgressBar
+              locationName={locationName}
+              vaccinationsInitiated={vaccinationsInitiated}
+              vaccinationsCompleted={vaccinationsCompleted}
+            />
+          </ProgressBarWrapper>
+        ) : (
+          <Box
+            display="flex"
+            justifyContent="center"
+            mt={2}
+            color={COLOR_MAP.GRAY.DARK}
+          >
+            No vaccination data available
+          </Box>
+        )}
       </Inner>
       {addMoreDataLink && (
         <MoreDataLinkContainer>

--- a/src/components/USMap/VaccineTooltip/VaccineTooltip.tsx
+++ b/src/components/USMap/VaccineTooltip/VaccineTooltip.tsx
@@ -37,6 +37,10 @@ function hasVaccineData(vaccineData: number): boolean {
   return vaccineData > 0;
 }
 
+function getRenderedValue(vaccineData: number): string {
+  return hasVaccineData(vaccineData) ? formatPercent(vaccineData) : '--';
+}
+
 const VaccineTooltip: React.FC<VaccineTooltipProps> = ({
   state,
   vaccinationsInitiated,
@@ -59,19 +63,11 @@ const VaccineTooltip: React.FC<VaccineTooltipProps> = ({
         </LocationName>
         <Row>
           <Title>1+ dose</Title>
-          <Value>
-            {hasVaccineData(vaccinationsInitiated)
-              ? formatPercent(vaccinationsInitiated)
-              : '--'}
-          </Value>
+          <Value>{getRenderedValue(vaccinationsInitiated)}</Value>
         </Row>
         <Row>
           <Title>Fully vaccinated</Title>
-          <Value>
-            {hasVaccineData(vaccinationsCompleted)
-              ? formatPercent(vaccinationsCompleted)
-              : '--'}
-          </Value>
+          <Value>{getRenderedValue(vaccinationsCompleted)}</Value>
         </Row>
         {hasVaccineData(vaccinationsInitiated) &&
         hasVaccineData(vaccinationsCompleted) ? (

--- a/src/components/USMap/VaccineTooltip/VaccineTooltip.tsx
+++ b/src/components/USMap/VaccineTooltip/VaccineTooltip.tsx
@@ -53,11 +53,19 @@ const VaccineTooltip: React.FC<VaccineTooltipProps> = ({
         </LocationName>
         <Row>
           <Title>1+ dose</Title>
-          <Value>{formatPercent(vaccinationsInitiated)}</Value>
+          <Value>
+            {vaccinationsInitiated === 0
+              ? '--'
+              : formatPercent(vaccinationsInitiated)}
+          </Value>
         </Row>
         <Row>
           <Title>Fully vaccinated</Title>
-          <Value>{formatPercent(vaccinationsCompleted)}</Value>
+          <Value>
+            {vaccinationsCompleted === 0
+              ? '--'
+              : formatPercent(vaccinationsCompleted)}
+          </Value>
         </Row>
         <ProgressBarWrapper>
           <VaccineProgressBar

--- a/src/components/VaccineProgressBar/VaccineProgressBar.tsx
+++ b/src/components/VaccineProgressBar/VaccineProgressBar.tsx
@@ -81,6 +81,14 @@ const VaccineProgressBar: React.FC<ProgressBarProps & { width: number }> = ({
           )}
           height={height}
         />
+        {(vaccinationsCompleted === 0 || vaccinationsInitiated === 0) && (
+          <rect
+            fill={COLOR_MAP.GRAY.LIGHT}
+            x={0}
+            width={width}
+            height={height}
+          />
+        )}
         {oldVersion && (
           <rect
             fill={COLOR_MAP.GREY_2}

--- a/src/components/VaccineProgressBar/VaccineProgressBar.tsx
+++ b/src/components/VaccineProgressBar/VaccineProgressBar.tsx
@@ -81,14 +81,6 @@ const VaccineProgressBar: React.FC<ProgressBarProps & { width: number }> = ({
           )}
           height={height}
         />
-        {(vaccinationsCompleted === 0 || vaccinationsInitiated === 0) && (
-          <rect
-            fill={COLOR_MAP.GRAY.LIGHT}
-            x={0}
-            width={width}
-            height={height}
-          />
-        )}
         {oldVersion && (
           <rect
             fill={COLOR_MAP.GREY_2}


### PR DESCRIPTION
When we block data, our vaccination map will display 0% vaccination, which is incorrect. This PR
- Changes "0%" to "--" when there is no data.
- Greys out the vaccination progress bar when there is no data.

Before:
![image](https://user-images.githubusercontent.com/46338131/148438485-1ac09146-6676-4fce-a1a9-9107f8a4c065.png)

After:
![image](https://user-images.githubusercontent.com/46338131/148456418-d188c37b-9b6f-4e6c-98f8-1bd1d4a1e064.png)