### PR TITLE
ICU Y-axis fix

### DIFF
--- a/src/components/Explore/utils.ts
+++ b/src/components/Explore/utils.ts
@@ -267,7 +267,7 @@ export const exploreMetricData: {
     name: 'Current COVID ICU Hospitalizations',
     chartId: 'icu-hospitalizations',
     dataMeasure: DataMeasure.INTEGER,
-    yAxisDecimalPlaces: 1,
+    yAxisDecimalPlaces: 0,
     seriesList: [
       {
         label: 'Current COVID ICU Hospitalizations',


### PR DESCRIPTION
Fixes Y-axis for ICU hospitalizations so the numbers don't get truncated.

Before:
![image](https://user-images.githubusercontent.com/46338131/148655970-cbcb617c-7326-4d99-9d85-8bf0e439102b.png)

After:
![image](https://user-images.githubusercontent.com/46338131/148655960-14bfc1aa-f953-48b2-b2f2-69e5f6f7e1d0.png)