### PR TITLE
Fix decimal values for ICU metric

### DIFF
--- a/src/components/Charts/utils.ts
+++ b/src/components/Charts/utils.ts
@@ -186,7 +186,7 @@ export const getXTickFormat = (
       date.getMonth() === 0 || date.getMonth() === 11
         ? DateFormat.MMM_YY
         : DateFormat.MMM;
-    return formatDateTime(date, dateFormat).replace(' ', " '");
+    return formatDateTime(date, dateFormat).replace(' ', "'");
   }
 };
 

--- a/src/components/Explore/SingleLocationChart.tsx
+++ b/src/components/Explore/SingleLocationChart.tsx
@@ -155,7 +155,7 @@ const SingleLocationChart: React.FC<{
   tooltipSubtext = '',
   marginTop = 10,
   marginBottom = 30,
-  marginLeft = 60,
+  marginLeft = 70,
   marginRight = 20,
   barOpacity,
   barOpacityHover,

--- a/src/components/Explore/utils.ts
+++ b/src/components/Explore/utils.ts
@@ -267,7 +267,7 @@ export const exploreMetricData: {
     name: 'Current COVID ICU Hospitalizations',
     chartId: 'icu-hospitalizations',
     dataMeasure: DataMeasure.INTEGER,
-    yAxisDecimalPlaces: 0,
+    yAxisDecimalPlaces: 1,
     seriesList: [
       {
         label: 'Current COVID ICU Hospitalizations',


### PR DESCRIPTION
The initial [fix](https://github.com/covid-projections/covid-projections/pull/4977) to fully display Y-axis labels ended up introducing a bug to small numbers for ICU hospitalization metric.

Attempts to fix:
- Tried playing around with `text` and `tspan` components within the `AxisLeft` component, but that messes with the rest of the graph as they're all nested in a generated SVG.
- Explored adding additional logic to display decimal depending on the range of values, but that seems pretty complicated for a white space fix.

Ended up just adjusting the left margin to accommodate the Y-axis labels and getting rid of white space on the X-axis.

Before:
![image](https://user-images.githubusercontent.com/46338131/148829693-29e09783-5d16-409a-b436-10bea0b6296b.png)

After:
![image](https://user-images.githubusercontent.com/46338131/148829594-5823b745-d9cc-48ba-82c4-08b13cb821f4.png)