### PR TITLE
Revert "Add holiday data update notice. (#4853)"

### DIFF
--- a/src/components/NewLocationPage/LocationName/LocationName.tsx
+++ b/src/components/NewLocationPage/LocationName/LocationName.tsx
@@ -25,8 +25,6 @@ const UpdatedDate: React.FC = () => {
         aria-label="Description of when data is updated"
         trackOpenTooltip={() => trackOpenTooltip(`Updated date`)}
       />
-      . <strong>NOTE:</strong> Data over the holidays might be delayed or
-      unreliable. Please interpret with caution.
     </UpdatedOnText>
   );
 };


### PR DESCRIPTION
This reverts commit c1d0b28be1a4615394d37ff3c3183c895d85ceae.

I assume this is safe to remove now?