### PR TITLE
Fix looking up of region overrides to ignore overrides with a start/end date.

### DIFF
--- a/src/cms-content/region-overrides/index.ts
+++ b/src/cms-content/region-overrides/index.ts
@@ -31,13 +31,20 @@ interface RegionOverride {
   disclaimer?: Markdown;
 }
 
-/** Looks for any override applied to the specified region + metric and returns it. */
+/**
+ * Looks for an override (without start / end dates) applied to the specified
+ * region + metric and returns it.
+ */
 export function getRegionMetricOverride(
   region: Region,
   metric: Metric,
 ): RegionOverride | undefined {
   for (const override of getOverridesForRegion(region)) {
-    if (metric === getMetricForOverride(override)) {
+    if (
+      metric === getMetricForOverride(override) &&
+      !override.start_date &&
+      !override.end_date
+    ) {
       return override;
     }
   }


### PR DESCRIPTION
This fixes the Idaho disclaimer.  We were accidentally looking up a different date-based override for Idaho rather than the block w/ disclaimer one.

The frontend doesn't do anything with date-restricted overrides so we can just ignore them.