### PR TITLE
Fix hospitalizations per 100k compare column font size.

### DIFF
--- a/src/components/Compare/columns.tsx
+++ b/src/components/Compare/columns.tsx
@@ -189,7 +189,7 @@ class HospitalizationsDensityColumn implements ColumnDefinition {
       <DataCellValue
         $valueUnknown={hd === null}
         $textAlign="left"
-        $fontSize="14px"
+        $fontSize="16px"
       >
         {formattedValue}
       </DataCellValue>


### PR DESCRIPTION
I think Mime copy/pasted the CCVI font size.  This fixes it to be consistent with the other columns.