### PR TITLE
Make hospitalizations default trend

### DIFF
--- a/scripts/update_location_summaries.ts
+++ b/scripts/update_location_summaries.ts
@@ -96,6 +96,8 @@ async function buildSiteSummaryData() {
 
     twoWeekPercentChangeInCases: usaProjection.twoWeekPercentChangeInCases,
     twoWeekPercentChangeInDeaths: usaProjection.twoWeekPercentChangeInDeaths,
+    twoWeekPercentChangeInHospitalizations:
+      usaProjection.twoWeekPercentChangeInHospitalizations,
 
     totalVaccinationsInitiated:
       usaProjection.vaccinationsInfo?.peopleInitiated ?? null,

--- a/src/assets/data/site-summary.json
+++ b/src/assets/data/site-summary.json
@@ -1,1 +1,1 @@
-{"usa":{"lastDate":1642982400000,"totalCases":71697688,"totalDeaths":867868,"twoWeekPercentChangeInCases":-0.050349592555248825,"twoWeekPercentChangeInDeaths":0.3912423454408187,"totalVaccinationsInitiated":250964433,"totalPopulation":331486822}}
+{"usa":{"lastDate":1642982400000,"totalCases":71697688,"totalDeaths":867868,"twoWeekPercentChangeInCases":-0.050349592555248825,"twoWeekPercentChangeInDeaths":0.3912423454408187,"twoWeekPercentChangeInHospitalizations":0.1313993298482107,"totalVaccinationsInitiated":250964433,"totalPopulation":331486822}}

--- a/src/common/models/Projection.ts
+++ b/src/common/models/Projection.ts
@@ -321,6 +321,10 @@ export class Projection {
     return this.getTwoWeekPercentChange(this.smoothedDailyDeaths);
   }
 
+  get twoWeekPercentChangeInHospitalizations() {
+    return this.getTwoWeekPercentChange(this.smoothedHospitalizations);
+  }
+
   private getTwoWeekPercentChange(series: any[]): number | null {
     const lastIndex = indexOfLastValue(series);
     assert(lastIndex != null, 'series is empty');

--- a/src/components/Explore/Explore.tsx
+++ b/src/components/Explore/Explore.tsx
@@ -252,7 +252,7 @@ const Explore: React.FunctionComponent<{
     // (need to force the reset since the route doesnt change)
     useEffect(() => {
       setSelectedLocations(initialLocations);
-      setCurrentMetric(ExploreMetric.CASES);
+      setCurrentMetric(ExploreMetric.HOSPITALIZATIONS);
       setPeriod(Period.ALL);
     }, [pathname, region, initialLocations, setCurrentMetric]);
 

--- a/src/components/NationalText/utils.tsx
+++ b/src/components/NationalText/utils.tsx
@@ -20,6 +20,7 @@ interface SiteSummary {
   lastDate: number;
   twoWeekPercentChangeInCases: number | null;
   twoWeekPercentChangeInDeaths: number | null;
+  twoWeekPercentChangeInHospitalizations: number | null;
 }
 
 export function getNationalText(): React.ReactElement {
@@ -28,8 +29,8 @@ export function getNationalText(): React.ReactElement {
     totalCases,
     totalDeaths,
     lastDate,
-    twoWeekPercentChangeInCases,
     twoWeekPercentChangeInDeaths,
+    twoWeekPercentChangeInHospitalizations,
   } = usa;
 
   const lastDateFormatted: string = formatUTCDateTime(
@@ -49,14 +50,16 @@ export function getNationalText(): React.ReactElement {
   return (
     <Fragment>
       As of {lastDateFormatted}, there have been roughly{' '}
-      {getTotalCasesCopy(totalCases)} cases and{' '}
-      {formatEstimate(totalDeaths, 3).toLocaleString()} deaths from COVID in the
+      {getTotalCasesCopy(totalCases)} reported cases, and{' '}
+      {formatEstimate(totalDeaths, 3).toLocaleString()} COVID deaths in the
       United States.{' '}
-      {!isNull(twoWeekPercentChangeInCases) &&
+      {!isNull(twoWeekPercentChangeInHospitalizations) &&
       !isNull(twoWeekPercentChangeInDeaths)
-        ? `Over the last 14 days, daily new
-    cases have ${getChangeDescriptorCopy(twoWeekPercentChangeInCases)} and daily
-    deaths have ${getChangeDescriptorCopy(twoWeekPercentChangeInDeaths)}.`
+        ? `Over the last 14 days, hospitalizations have ${getChangeDescriptorCopy(
+            twoWeekPercentChangeInHospitalizations,
+          )} and daily deaths have ${getChangeDescriptorCopy(
+            twoWeekPercentChangeInDeaths,
+          )}.`
         : ''}
     </Fragment>
   );

--- a/src/screens/HomePage/HomePage.tsx
+++ b/src/screens/HomePage/HomePage.tsx
@@ -51,7 +51,9 @@ export default function HomePage() {
 
   const { userRegions, isLoading } = useGeolocatedRegions();
 
-  const [currentMetric, setCurrentMetric] = useState(ExploreMetric.CASES);
+  const [currentMetric, setCurrentMetric] = useState(
+    ExploreMetric.HOSPITALIZATIONS,
+  );
 
   const largestMetroFips = largestMetroFipsForExplore;
   const exploreGeoLocations = useMemo(
@@ -61,6 +63,8 @@ export default function HomePage() {
         : largestMetroFips,
     [largestMetroFips, userRegions],
   );
+  // Add USA to default view (Fips code: 0).
+  exploreGeoLocations.push('0');
   const initialFipsListForExplore = exploreGeoLocations;
 
   useEffect(() => {
@@ -110,7 +114,6 @@ export default function HomePage() {
       )}
     </>
   );
-
   return (
     <>
       <EnsureSharingIdInUrl />

--- a/src/screens/HomePage/HomePage.tsx
+++ b/src/screens/HomePage/HomePage.tsx
@@ -39,6 +39,7 @@ import VaccinationsTable from 'components/VaccinationsTable/VaccinationsTable';
 import NationalText from 'components/NationalText';
 import DonationBanner from 'components/Banner/DonationBanner';
 import Box from '@material-ui/core/Box';
+import regions from 'common/regions';
 
 function getPageDescription() {
   const date = formatMetatagDate();
@@ -64,7 +65,7 @@ export default function HomePage() {
     [largestMetroFips, userRegions],
   );
   // Add USA to default view (Fips code: 0).
-  exploreGeoLocations.push('0');
+  exploreGeoLocations.push(regions.usa.fipsCode);
   const initialFipsListForExplore = exploreGeoLocations;
 
   useEffect(() => {


### PR DESCRIPTION
This PR does the following:
- Make hospitalizations per 100k the default metric in Trends section on the homepage.
- Add USA to the default view in Trends section.

For testing:
1. Use node v12! Otherwise, the generated file in the next step may be too large and the command will likely fail.
2. Run `yarn update-location-summaries`.
3. Test site as per usual.

Note: `site-summary.json` is only included in this PR for testing purposes. This will be removed once this PR is approved and ready to merge.