### PR TITLE
Remove covid-data-public version from Snapshot Compare

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -25,7 +25,6 @@ export type ActualsTimeseries = Actualstimeseries;
 
 export interface SnapshotVersion {
   timestamp: string;
-  'covid-data-public': string;
   'covid-data-model': string;
 }
 

--- a/src/screens/internal/CompareSnapshots/SnapshotVersions.tsx
+++ b/src/screens/internal/CompareSnapshots/SnapshotVersions.tsx
@@ -37,9 +37,6 @@ function VersionInfo({ version }: { version: SnapshotVersion | null }) {
         <b>covid-data-model:</b>{' '}
         {JSON.stringify(version['covid-data-model']).replace(',', ', ')}
         <br />
-        <b>covid-data-public:</b>{' '}
-        {JSON.stringify(version['covid-data-public']).replace(',', ', ')}
-        <br />
       </div>
     )
   );


### PR DESCRIPTION
We removed the covid-data-public repo sha from the `version.json` file in [covid-data-model](https://github.com/covid-projections/covid-data-model/pull/1229/files#diff-d31ce0453051853c17ba2a5225b3d1bfab548e095bab0967d6acfd1b3ce1b35dL164), breaking the compare tool.

This removes the covid-data-public data from the compare tool to match those updates. 