### PR TITLE
Fix repetitive USA labels in Explore

### DIFF
--- a/src/screens/HomePage/HomePage.tsx
+++ b/src/screens/HomePage/HomePage.tsx
@@ -65,7 +65,9 @@ export default function HomePage() {
     [largestMetroFips, userRegions],
   );
   // Add USA to default view (Fips code: 0).
-  exploreGeoLocations.push(regions.usa.fipsCode);
+  if (!exploreGeoLocations.includes(regions.usa.fipsCode)) {
+    exploreGeoLocations.push(regions.usa.fipsCode);
+  }
   const initialFipsListForExplore = exploreGeoLocations;
 
   useEffect(() => {


### PR DESCRIPTION
Currently USA fips code is added multiple times to the list feeding the Explore chart. This PR prevents this by ensuring USA fips code is only added if it doesn't exist in the list yet.

Before:
![image](https://user-images.githubusercontent.com/46338131/153474794-ba6f16d8-3bf5-44f2-b214-44ab1b9aa0cc.png)

After:
![image](https://user-images.githubusercontent.com/46338131/153474881-ffe1b450-a8de-44f0-83da-94c323c056e5.png)
