### PR TITLE
Create CTA buttons for Recommendations section

### DIFF
--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -4,7 +4,7 @@
 backend:
   name: github
   repo: covid-projections/covid-projections
-  branch: cms-content-entry
+  branch: faihegberg/update-recommendations-section
   base_url: https://api.netlify.com
 
 # To use the CMS locally during development, run:

--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -310,6 +310,13 @@ collections:
               - { label: Category, name: category, widget: string }
               - { label: Alt text, name: altText, widget: string }
               - { label: Icon image, name: iconImage, widget: image }
+          - label: CTA
+            name: ctaLinks
+            widget: list
+            fields:
+              - { label: Category, name: category, widget: string }
+              - { label: Link, name: link, widget: string }
+              - { label: Button type, name: buttonType, widget: string }
       - name: Recommendations-Modal
         label: 'Modal'
         file: src/cms-content/recommendations/recommendations-modal.json

--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -4,7 +4,7 @@
 backend:
   name: github
   repo: covid-projections/covid-projections
-  branch: faihegberg/update-recommendations-section
+  branch: cms-content-entry
   base_url: https://api.netlify.com
 
 # To use the CMS locally during development, run:
@@ -310,13 +310,6 @@ collections:
               - { label: Category, name: category, widget: string }
               - { label: Alt text, name: altText, widget: string }
               - { label: Icon image, name: iconImage, widget: image }
-          - label: CTA
-            name: ctaLinks
-            widget: list
-            fields:
-              - { label: Category, name: category, widget: string }
-              - { label: Link, name: link, widget: string }
-              - { label: Button type, name: buttonType, widget: string }
       - name: Recommendations-Modal
         label: 'Modal'
         file: src/cms-content/recommendations/recommendations-modal.json

--- a/src/cms-content/recommendations/index.ts
+++ b/src/cms-content/recommendations/index.ts
@@ -67,6 +67,12 @@ export interface RecommendIcon {
   iconImage: ImageUrl;
 }
 
+export interface RecommendCTA {
+  category: RecommendCategory;
+  link: string;
+  buttonType: string;
+}
+
 interface FullFedLevel {
   color: FedLevel;
   content: Markdown;
@@ -86,6 +92,7 @@ export interface RecommendationsMainContent {
     shareText: Markdown;
   };
   icons: RecommendIcon[];
+  ctaLinks: RecommendCTA[];
 }
 
 export interface RecommendationsModalContent {
@@ -105,9 +112,11 @@ export interface RecommendationsModalContent {
 export interface RecommendationWithIcon {
   recommendationInfo: Recommendation;
   iconInfo: RecommendIcon;
+  ctaInfo: RecommendCTA;
   index: number;
 }
 
 export const allIcons = recommendationsMain.icons as RecommendIcon[];
+export const allCtaLinks = recommendationsMain.ctaLinks as RecommendCTA[];
 export const mainContent = recommendationsMain as RecommendationsMainContent;
 export const modalContent = recommendationsModal as RecommendationsModalContent;

--- a/src/cms-content/recommendations/index.ts
+++ b/src/cms-content/recommendations/index.ts
@@ -71,6 +71,7 @@ export interface RecommendCTA {
   category: RecommendCategory;
   link: string;
   buttonType: string;
+  buttonText: string;
 }
 
 interface FullFedLevel {

--- a/src/cms-content/recommendations/recommendations-main.json
+++ b/src/cms-content/recommendations/recommendations-main.json
@@ -80,13 +80,15 @@
   "ctaLinks": [
     {
       "category": "MASKS",
-      "link": "https://www.google.ca/",
-      "buttonType": "FILL"
+      "link": "https://www.covidactnow.org/",
+      "buttonType": "FILL",
+      "buttonText": "Masks placeholder text"
     },
     {
       "category": "GATHERINGS",
       "link": "https://www.covidactnow.org/",
-      "buttonType": "OUTLINE"
+      "buttonType": "OUTLINE",
+      "buttonText": "Gatherings placeholder text"
     }
   ]
 }

--- a/src/cms-content/recommendations/recommendations-main.json
+++ b/src/cms-content/recommendations/recommendations-main.json
@@ -5,7 +5,12 @@
       "source": "FED",
       "category": "MASKS",
       "level": "ALL",
-      "id": "MASKS_ALL"
+      "id": "MASKS_ALL",
+      "cta": {
+        "buttonType": "FILL",
+        "text": "Mask placeholder",
+        "url": "https://www.covidactnow.org/"
+      }
     },
     {
       "body": "**Indoor gatherings** should be avoided with people outside the immediate household, unless you are fully vaccinated. See [guidance for vaccinated individuals](https://www.cdc.gov/coronavirus/2019-ncov/vaccines/fully-vaccinated.html). Outdoor gatherings with masks and distancing are a safer alternative.",

--- a/src/cms-content/recommendations/recommendations-main.json
+++ b/src/cms-content/recommendations/recommendations-main.json
@@ -76,5 +76,17 @@
       "altText": "Airplane icon",
       "iconImage": "/images_cms/recommendations-travel-icon.svg"
     }
+  ],
+  "ctaLinks": [
+    {
+      "category": "MASKS",
+      "link": "https://www.google.ca/",
+      "buttonType": "FILL"
+    },
+    {
+      "category": "GATHERINGS",
+      "link": "https://www.covidactnow.org/",
+      "buttonType": "OUTLINE"
+    }
   ]
 }

--- a/src/cms-content/recommendations/recommendations-main.json
+++ b/src/cms-content/recommendations/recommendations-main.json
@@ -77,18 +77,5 @@
       "iconImage": "/images_cms/recommendations-travel-icon.svg"
     }
   ],
-  "ctaLinks": [
-    {
-      "category": "MASKS",
-      "link": "https://www.covidactnow.org/",
-      "buttonType": "FILL",
-      "buttonText": "Masks placeholder text"
-    },
-    {
-      "category": "GATHERINGS",
-      "link": "https://www.covidactnow.org/",
-      "buttonType": "OUTLINE",
-      "buttonText": "Gatherings placeholder text"
-    }
-  ]
+  "ctaLinks": []
 }

--- a/src/cms-content/recommendations/recommendations-main.json
+++ b/src/cms-content/recommendations/recommendations-main.json
@@ -7,9 +7,9 @@
       "level": "ALL",
       "id": "MASKS_ALL",
       "cta": {
-        "buttonType": "FILL",
-        "text": "Mask placeholder",
-        "url": "https://www.covidactnow.org/"
+        "buttonType": null,
+        "text": "",
+        "url": ""
       }
     },
     {

--- a/src/common/utils/recommend.ts
+++ b/src/common/utils/recommend.ts
@@ -10,10 +10,12 @@ import {
   Recommendation,
   RecommendationSource,
   RecommendIcon,
+  RecommendCTA,
   RecommendationWithIcon,
   RecommendCategory,
   RecommendID,
   allIcons,
+  allCtaLinks,
 } from 'cms-content/recommendations';
 import { EventAction, EventCategory, trackEvent } from 'components/Analytics';
 import { formatDecimal } from '.';
@@ -162,9 +164,13 @@ function getIcon(
   const correspondingIcon = allIcons.filter(
     (icon: RecommendIcon) => icon.category === recommendation.category,
   );
+  const correspondingCta = allCtaLinks.filter(
+    (ctaLink: RecommendCTA) => ctaLink.category === recommendation.category,
+  );
   return {
     recommendationInfo: recommendation,
     iconInfo: correspondingIcon[0],
+    ctaInfo: correspondingCta[0],
     index: i,
   };
 }

--- a/src/components/Recommend/CTAButton.tsx
+++ b/src/components/Recommend/CTAButton.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import OpenInNewIcon from '@material-ui/icons/OpenInNew';
+import { StyledFilledButton, StyledOutlinedButton } from './Recommend.style';
+import { EventCategory } from 'components/Analytics';
+import { RecommendCTA } from 'cms-content/recommendations';
+import { ButtonType } from 'assets/theme/buttons';
+
+function getButtonType(rawButtonType: string): ButtonType {
+  if (!rawButtonType) {
+    return ButtonType.FILL;
+  }
+  const buttonType = rawButtonType.toUpperCase();
+  switch (buttonType) {
+    case 'OUTLINE':
+      return ButtonType.OUTLINE;
+    case 'TEXT':
+      return ButtonType.TEXT;
+    default:
+      return ButtonType.FILL;
+  }
+}
+
+const CTAButton: React.FC<RecommendCTA> = ({
+  category,
+  link,
+  buttonType,
+  buttonText,
+}) => {
+  if (getButtonType(buttonType) === ButtonType.FILL) {
+    return (
+      <StyledFilledButton
+        trackingCategory={EventCategory.RECOMMENDATIONS}
+        trackingLabel={`${category}: CTA button`}
+        href={link}
+        endIcon={<OpenInNewIcon />}
+      >
+        {buttonText}
+      </StyledFilledButton>
+    );
+  } else if (getButtonType(buttonType) === ButtonType.OUTLINE) {
+    return (
+      <StyledOutlinedButton
+        trackingCategory={EventCategory.RECOMMENDATIONS}
+        trackingLabel={`${category}: CTA button`}
+        href={link}
+        endIcon={<OpenInNewIcon />}
+      >
+        {buttonText}
+      </StyledOutlinedButton>
+    );
+  }
+  return null;
+};
+
+export default CTAButton;

--- a/src/components/Recommend/Recommend.style.tsx
+++ b/src/components/Recommend/Recommend.style.tsx
@@ -2,6 +2,8 @@ import styled from 'styled-components';
 import { COLOR_MAP } from 'common/colors';
 import { materialSMBreakpoint } from 'assets/theme/sizes';
 import { MarkdownContent, anchorStyles } from 'components/Markdown';
+import { FilledButton, OutlinedButton } from 'components/ButtonSystem';
+import { ButtonType } from 'assets/theme/buttons';
 
 export const Column = styled.div`
   display: flex;
@@ -50,6 +52,8 @@ export const RecommendationsContainer = styled.div`
   }
 `;
 
+export const RecommendationContent = styled.div``;
+
 export const RecommendationBody = styled(MarkdownContent)`
   margin: auto 0;
 
@@ -71,4 +75,31 @@ export const RecommendationBody = styled(MarkdownContent)`
 export const Icon = styled.img`
   margin-right: 1.25rem;
   min-width: 2rem;
+`;
+
+export const StyledFilledButton = styled(FilledButton)`
+  width: 100%;
+  margin: 0.5rem 0;
+
+  @media (min-width: ${materialSMBreakpoint}) {
+    width: initial;
+    margin: 0.75rem 0 1rem 0;
+  }
+`;
+
+export const StyledOutlinedButton = styled(OutlinedButton)`
+  width: 100%;
+  margin: 0.5rem 0;
+
+  &:hover {
+    background-color: ${props =>
+      props.theme.buttons[ButtonType.OUTLINE].backgroundHover};
+    border: ${props =>
+      `1px solid ${props.theme.buttons[ButtonType.OUTLINE].borderHover}`};
+  }
+
+  @media (min-width: ${materialSMBreakpoint}) {
+    width: initial;
+    margin: 0.75rem 0 1rem 0;
+  }
 `;

--- a/src/components/Recommend/Recommend.tsx
+++ b/src/components/Recommend/Recommend.tsx
@@ -52,6 +52,7 @@ const Recommend = (props: {
                     className={recommendation.recommendationInfo.category}
                     source={recommendation.recommendationInfo.body}
                   />
+                  {recommendation.ctaInfo && <div>test</div>}
                 </RecommendationItem>
               );
             })}

--- a/src/components/Recommend/Recommend.tsx
+++ b/src/components/Recommend/Recommend.tsx
@@ -9,8 +9,10 @@ import {
   Icon,
   Column,
   RecommendationItem,
+  RecommendationContent,
 } from './Recommend.style';
 import { useBreakpoint } from 'common/hooks';
+import CTAButton from './CTAButton';
 
 const Recommend = (props: {
   recommendations: RecommendationWithIcon[];
@@ -48,11 +50,20 @@ const Recommend = (props: {
                     src={recommendation.iconInfo.iconImage}
                     alt={recommendation.iconInfo.altText}
                   />
-                  <RecommendationBody
-                    className={recommendation.recommendationInfo.category}
-                    source={recommendation.recommendationInfo.body}
-                  />
-                  {recommendation.ctaInfo && <div>test</div>}
+                  <RecommendationContent>
+                    <RecommendationBody
+                      className={recommendation.recommendationInfo.category}
+                      source={recommendation.recommendationInfo.body}
+                    />
+                    {recommendation.ctaInfo && (
+                      <CTAButton
+                        category={recommendation.ctaInfo.category}
+                        link={recommendation.ctaInfo.link}
+                        buttonType={recommendation.ctaInfo.buttonType}
+                        buttonText={recommendation.ctaInfo.buttonText}
+                      />
+                    )}
+                  </RecommendationContent>
                 </RecommendationItem>
               );
             })}


### PR DESCRIPTION
This PR creates CTA buttons for the Recommentations section. To test:
1. Pull this branch.
2. Add content to "CTALinks" in `recommendations-main.json`, such as:

```
 "ctaLinks": [
    {
      "category": "MASKS",
      "link": "https://www.covidactnow.org/",
      "buttonType": "FILL",
      "buttonText": "Masks placeholder text"
    },
    {
      "category": "GATHERINGS",
      "link": "https://www.covidactnow.org/",
      "buttonType": "OUTLINE",
      "buttonText": "Gatherings placeholder text"
    }
  ]
```
3. Check out Recommendations section on any location page.