### PR TITLE
Move icons to be a part of recommendation

### DIFF
--- a/src/cms-content/recommendations/index.ts
+++ b/src/cms-content/recommendations/index.ts
@@ -59,10 +59,10 @@ export interface Recommendation {
   level: FedLevel | HarvardLevel;
   category: RecommendCategory;
   id: RecommendID;
+  icon: RecommendIcon;
 }
 
-export interface RecommendIcon {
-  category: RecommendCategory;
+interface RecommendIcon {
   altText: string;
   iconImage: ImageUrl;
 }
@@ -102,12 +102,5 @@ export interface RecommendationsModalContent {
   };
 }
 
-export interface RecommendationWithIcon {
-  recommendationInfo: Recommendation;
-  iconInfo: RecommendIcon;
-  index: number;
-}
-
-export const allIcons = recommendationsMain.icons as RecommendIcon[];
 export const mainContent = recommendationsMain as RecommendationsMainContent;
 export const modalContent = recommendationsModal as RecommendationsModalContent;

--- a/src/cms-content/recommendations/recommendations-main.json
+++ b/src/cms-content/recommendations/recommendations-main.json
@@ -50,47 +50,5 @@
     "feedbackButtonLabel": "Leave feedback",
     "modalButtonLabel": "Sources & Methodology",
     "shareText": "Please share with policy makers, business owners, and any other decision makers, especially if these recommendations don’t match reality."
-  },
-  "icons": [
-    {
-      "category": "MASKS",
-      "altText": "Mask icon",
-      "iconImage": "/images_cms/mask_recommends_icon.svg"
-    },
-    {
-      "category": "EXPOSURE_APP",
-      "altText": "Exposure App",
-      "iconImage": "/images_cms/exposure_recommends_icon.svg"
-    },
-    {
-      "category": "GATHERINGS",
-      "altText": "Gatherings icon",
-      "iconImage": "/images_cms/gathering_recommends_icon.svg"
-    },
-    {
-      "category": "RESTAURANTS",
-      "altText": "Restaurants icon",
-      "iconImage": "/images_cms/restaurant_recommends_icon.svg"
-    },
-    {
-      "category": "BARS",
-      "altText": "Bars icon",
-      "iconImage": "/images_cms/bar_recommends_icon.svg"
-    },
-    {
-      "category": "GYMS",
-      "altText": "Gyms icon",
-      "iconImage": "/images_cms/gym_recommends_icon.svg"
-    },
-    {
-      "category": "SCHOOLS",
-      "altText": "Schools icon",
-      "iconImage": "/images_cms/school_recommends_icon.svg"
-    },
-    {
-      "category": "TRAVEL",
-      "altText": "Airplane icon",
-      "iconImage": "/images_cms/recommendations-travel-icon.svg"
-    }
-  ]
+  }
 }

--- a/src/common/utils/recommend.ts
+++ b/src/common/utils/recommend.ts
@@ -9,11 +9,8 @@ import {
   FedLevel,
   Recommendation,
   RecommendationSource,
-  RecommendIcon,
-  RecommendationWithIcon,
   RecommendCategory,
   RecommendID,
-  allIcons,
 } from 'cms-content/recommendations';
 import { EventAction, EventCategory, trackEvent } from 'components/Analytics';
 import { formatDecimal } from '.';
@@ -49,6 +46,10 @@ function getExposureRecommendation(
     level: FedLevel.GREEN,
     category: RecommendCategory.EXPOSURE_APP,
     id: RecommendID.EXPOSURE_APP,
+    icon: {
+      iconImage: '/images_cms/exposure_recommends_icon.svg',
+      altText: 'Notification icon',
+    },
   };
 
   return showExposureNotifications(region) ? exposureRecommendation : null;
@@ -97,7 +98,7 @@ export function getRecommendations(
     ...otherRecommendations,
   ];
 
-  return allRecommendations.map(getIcon);
+  return allRecommendations;
 }
 
 /**
@@ -153,20 +154,6 @@ export function getDynamicIntroCopy(
   }, people in ${locationName} are advised to adhere to the following recommendations.`;
 
   return blurb;
-}
-
-function getIcon(
-  recommendation: Recommendation,
-  i: number,
-): RecommendationWithIcon {
-  const correspondingIcon = allIcons.filter(
-    (icon: RecommendIcon) => icon.category === recommendation.category,
-  );
-  return {
-    recommendationInfo: recommendation,
-    iconInfo: correspondingIcon[0],
-    index: i,
-  };
 }
 
 /*

--- a/src/components/Recommend/Recommend.tsx
+++ b/src/components/Recommend/Recommend.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import chunk from 'lodash/chunk';
 import ceil from 'lodash/ceil';
 import partition from 'lodash/partition';
-import { RecommendationWithIcon } from 'cms-content/recommendations';
+import { Recommendation } from 'cms-content/recommendations';
 import {
   RecommendationsContainer,
   RecommendationBody,
@@ -13,7 +13,7 @@ import {
 import { useBreakpoint } from 'common/hooks';
 
 const Recommend = (props: {
-  recommendations: RecommendationWithIcon[];
+  recommendations: Recommendation[];
   recommendationsRef: React.RefObject<HTMLDivElement>;
 }) => {
   const { recommendations, recommendationsRef } = props;
@@ -25,8 +25,12 @@ const Recommend = (props: {
   */
   const midpoint = ceil(recommendations.length / 2);
   const halvedInOrder = chunk(recommendations, midpoint);
+  const indexedRecommendations = recommendations.map((item, index) => ({
+    index,
+    ...item,
+  }));
   const partitionedByIndex = partition(
-    recommendations,
+    indexedRecommendations,
     item => item.index % 2 === 0,
   );
 
@@ -45,12 +49,12 @@ const Recommend = (props: {
                   highlight={false}
                 >
                   <Icon
-                    src={recommendation.iconInfo.iconImage}
-                    alt={recommendation.iconInfo.altText}
+                    src={recommendation.icon.iconImage}
+                    alt={recommendation.icon.altText}
                   />
                   <RecommendationBody
-                    className={recommendation.recommendationInfo.category}
-                    source={recommendation.recommendationInfo.body}
+                    className={recommendation.category}
+                    source={recommendation.body}
                   />
                 </RecommendationItem>
               );


### PR DESCRIPTION
This PR gets rid of icons as a separated list from recommendations, and add each icon to a recommendation item instead.