### PR TITLE
Update recommendations ordering

### DIFF
--- a/src/common/utils/recommend.ts
+++ b/src/common/utils/recommend.ts
@@ -22,10 +22,10 @@ export function getRecommendations(
   recommendations: Recommendation[],
 ): any[] {
   const recommendationCategoryOrdering = [
-    RecommendCategory.BOOSTER,
+    RecommendCategory.MASKS,
     RecommendCategory.TESTING,
     RecommendCategory.VACCINATION,
-    RecommendCategory.MASKS,
+    RecommendCategory.BOOSTER,
   ];
 
   let remainingRecommendations = recommendations;

--- a/src/components/LocationPage/Recommendations.tsx
+++ b/src/components/LocationPage/Recommendations.tsx
@@ -81,14 +81,6 @@ const Recommendations = ({
           >
             CDC
           </ExternalLink>
-          {', '}
-          <ExternalLink
-            style={{ color: 'inherit' }}
-            href="https://www.nytimes.com/"
-            onClick={() => trackSourceClick('NYT')}
-          >
-            NYT
-          </ExternalLink>
         </DisclaimerWrapper>
         <ShareButtons
           eventCategory={EventCategory.RECOMMENDATIONS}


### PR DESCRIPTION
Update recommendations ordering and remove NYT source as per [request](https://actnowcoalition.slack.com/archives/C01DNUNLC56/p1646794084730719).