### PR TITLE
Export subscribers emails to text file

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "send-emails": "ts-node-script -r tsconfig-paths/register scripts/alert_emails/send_emails.ts",
     "send-test-email": "ts-node-script -r tsconfig-paths/register scripts/alert_emails/send-test-email.ts",
     "report-alert-emails": "ts-node-script -r tsconfig-paths/register scripts/alert_emails_report/generate-report.ts",
+    "generate-subscriber-emails-file": "ts-node-script -r tsconfig-paths/register scripts/alert_emails_report/generate-subscriber-emails-file.ts",
     "generate-county-history-data": "ts-node-script -r tsconfig-paths/register scripts/county_history_data/generate.ts",
     "generate-metro-areas": "ts-node-script -r tsconfig-paths/register scripts/cbsa/parse-metro-areas.ts",
     "generate-sitemap": "ts-node-script -r tsconfig-paths/register scripts/generate_sitemap/index.ts",

--- a/scripts/alert_emails/firestore.ts
+++ b/scripts/alert_emails/firestore.ts
@@ -19,6 +19,7 @@ export async function fetchAllAlertSubscriptions(
       .stream()
       .on('data', subscription => {
         const data = subscription.data();
+        data.email = subscription.id;
         // Convert Firestore timestamp to plain Date.
         data.subscribedAt = data.subscribedAt && data.subscribedAt.toDate();
         subscriptions.push(data);

--- a/scripts/alert_emails_report/generate-report.ts
+++ b/scripts/alert_emails_report/generate-report.ts
@@ -35,22 +35,23 @@ interface FipsCount {
 async function main() {
   const db = getFirestore();
   const subscriptions = await fetchAllAlertSubscriptions(db);
-  await updateSubscriptionsByLocation(subscriptions);
-  await updateSubscriptionsByDate(subscriptions);
+  console.log(subscriptions.keys);
+  // await updateSubscriptionsByLocation(subscriptions);
+  // await updateSubscriptionsByDate(subscriptions);
 
-  try {
-    // TODO(michael): Get engagement stats from AWS.
-    // await updateEngagementStats();
-  } catch (err) {
-    console.error('Error updating engagement stats', err);
-  }
+  // try {
+  //   // TODO(michael): Get engagement stats from AWS.
+  //   // await updateEngagementStats();
+  // } catch (err) {
+  //   console.error('Error updating engagement stats', err);
+  // }
 
-  const spreadsheetId = getSpreadsheetId();
-  const reportUrl = `https://docs.google.com/spreadsheets/d/${spreadsheetId}`;
+  // const spreadsheetId = getSpreadsheetId();
+  // const reportUrl = `https://docs.google.com/spreadsheets/d/${spreadsheetId}`;
 
-  console.info('Done.');
-  console.info(`Check the report: ${reportUrl}`);
-  process.exit(0);
+  // console.info('Done.');
+  // console.info(`Check the report: ${reportUrl}`);
+  // process.exit(0);
 }
 
 async function updateSubscriptionsByLocation(subscriptions: Subscription[]) {

--- a/scripts/alert_emails_report/generate-report.ts
+++ b/scripts/alert_emails_report/generate-report.ts
@@ -35,23 +35,22 @@ interface FipsCount {
 async function main() {
   const db = getFirestore();
   const subscriptions = await fetchAllAlertSubscriptions(db);
-  console.log(subscriptions.keys);
-  // await updateSubscriptionsByLocation(subscriptions);
-  // await updateSubscriptionsByDate(subscriptions);
+  await updateSubscriptionsByLocation(subscriptions);
+  await updateSubscriptionsByDate(subscriptions);
 
-  // try {
-  //   // TODO(michael): Get engagement stats from AWS.
-  //   // await updateEngagementStats();
-  // } catch (err) {
-  //   console.error('Error updating engagement stats', err);
-  // }
+  try {
+    // TODO(michael): Get engagement stats from AWS.
+    // await updateEngagementStats();
+  } catch (err) {
+    console.error('Error updating engagement stats', err);
+  }
 
-  // const spreadsheetId = getSpreadsheetId();
-  // const reportUrl = `https://docs.google.com/spreadsheets/d/${spreadsheetId}`;
+  const spreadsheetId = getSpreadsheetId();
+  const reportUrl = `https://docs.google.com/spreadsheets/d/${spreadsheetId}`;
 
-  // console.info('Done.');
-  // console.info(`Check the report: ${reportUrl}`);
-  // process.exit(0);
+  console.info('Done.');
+  console.info(`Check the report: ${reportUrl}`);
+  process.exit(0);
 }
 
 async function updateSubscriptionsByLocation(subscriptions: Subscription[]) {

--- a/scripts/alert_emails_report/generate-subscriber-emails-file.ts
+++ b/scripts/alert_emails_report/generate-subscriber-emails-file.ts
@@ -6,7 +6,7 @@ async function main() {
   const db = getFirestore();
   const subscriptions = await fetchAllAlertSubscriptions(db);
   const fs = require('fs');
-  let output = subscriptions.map(s => s.email).join(',');
+  const output = subscriptions.map(s => s.email).join(',');
   fs.writeFileSync('subscriber-emails.txt', output);
 }
 

--- a/scripts/alert_emails_report/generate-subscriber-emails-file.ts
+++ b/scripts/alert_emails_report/generate-subscriber-emails-file.ts
@@ -1,0 +1,21 @@
+import _ from 'lodash';
+import { fetchAllAlertSubscriptions } from '../alert_emails/firestore';
+import { getFirestore } from '../common/firebase';
+
+async function main() {
+  const db = getFirestore();
+  const subscriptions = await fetchAllAlertSubscriptions(db);
+  const fs = require('fs');
+  let output = '';
+  subscriptions.map(subscription => {
+    output = output.concat(subscription.email, ',');
+  });
+  fs.writeFileSync('subscriber-emails.txt', output);
+}
+
+if (require.main === module) {
+  main().catch(err => {
+    console.error(err);
+    process.exit(-1);
+  });
+}

--- a/scripts/alert_emails_report/generate-subscriber-emails-file.ts
+++ b/scripts/alert_emails_report/generate-subscriber-emails-file.ts
@@ -6,10 +6,7 @@ async function main() {
   const db = getFirestore();
   const subscriptions = await fetchAllAlertSubscriptions(db);
   const fs = require('fs');
-  let output = '';
-  subscriptions.map(subscription => {
-    output = output.concat(subscription.email, ',');
-  });
+  let output = subscriptions.map(s => s.email).join(',');
   fs.writeFileSync('subscriber-emails.txt', output);
 }
 


### PR DESCRIPTION
Create a script to export alert subscriber emails to a text file. Some notes below:
- Creating a separate script called `generate-subscriber-emails-file` in case we need to do something like this again in the future.
- Exporting to a text file instead of a CSV, since we only need one column.
- Currently outputting the text file to the repo's main folder. If there is somewhere better in the repo to output the file, let me know :)