### PR TITLE
update community levels to include unknown

### DIFF
--- a/scripts/alert_emails/send-test-email.ts
+++ b/scripts/alert_emails/send-test-email.ts
@@ -17,8 +17,8 @@ const locationAlert: Alert = {
   locationName: 'District of Columbia',
   locationURL: 'https://covidactnow.org/us/district_of_columbia-dc/',
   lastUpdated: '06/26/2020',
-  oldLevel: 2,
-  newLevel: 3,
+  oldLevel: 4,
+  newLevel: 2,
 };
 
 async function main(emailAddress: string) {

--- a/scripts/alert_emails/utils.ts
+++ b/scripts/alert_emails/utils.ts
@@ -3,13 +3,13 @@ import fs from 'fs-extra';
 import * as Handlebars from 'handlebars';
 import { Alert } from './interfaces';
 import { Level } from '../../src/common/level';
-import regions from '../../src/common/regions';
 import { LOCATION_SUMMARY_LEVELS } from '../../src/common/metrics/location_summary';
 import { fetchMainSnapshotNumber } from '../../src/common/utils/snapshots';
 import { DateFormat, formatDateTime } from '../../src/common/utils/time-utils';
 
 export const ALERT_EMAIL_GROUP_PREFIX = 'alert-email';
 
+// TODO(8.2): Update the thermometerBaseURL
 const thermometerBaseURL =
   'https://data.covidactnow.org/thermometer_screenshot';
 const unsubscribeURL = 'https://covidactnow.org/alert_unsubscribe';
@@ -18,6 +18,7 @@ export function toISO8601(date: Date): string {
   return formatDateTime(date, DateFormat.YYYY_MM_DD);
 }
 
+// TODO(8.2): Update the template.html copy
 const alertTemplate = Handlebars.compile(
   fs.readFileSync(path.join(__dirname, 'template.html'), 'utf8'),
 );
@@ -102,6 +103,7 @@ function generateAlertEmailContent(
   return alertTemplate(data);
 }
 
+// TODO(8.2): Update copy for the change summary
 function changeText(oldLevel: Level, newLevel: Level) {
   if (oldLevel === Level.UNKNOWN) {
     return 'new risk score';
@@ -118,6 +120,7 @@ export function generateAlertEmailData(
 ) {
   const { locationName } = locationAlert;
   const htmlContent = generateAlertEmailContent(emailAddress, locationAlert);
+  // TODO(8.2) - Update the copy of the subject line
   const subjectLine = `${locationName}'s Risk Level Has Changed`;
 
   return {

--- a/src/common/community_level.ts
+++ b/src/common/community_level.ts
@@ -1,7 +1,8 @@
 export enum CommunityLevel {
-  LOW,
-  MEDIUM,
-  HIGH,
+  LOW = 0,
+  MEDIUM = 1,
+  HIGH = 2,
+  UNKNOWN = 4,
 }
 
 export const ALL_COMMUNITY_LEVELS = [


### PR DESCRIPTION
This PR adds an `UNKNOWN` level to the community levels enum. We will need this option to send the initial alert email once we launch 8.2.

The email alerts rely on specific numeric values for each level in order to determine which thermometer to show in the email. For example, if the change is from `LOW` to `MEDIUM`, the image will be named `therm-1-0.png`. I added the values for each level in the enum to ensure that they match this convention.

I added some TODOs for places that we will need to update once we have the copy for the email, I will update those on a follow-up PR.