### PR TITLE
CAN 8.2 content update first pass

### DIFF
--- a/scripts/alert_emails/utils.ts
+++ b/scripts/alert_emails/utils.ts
@@ -85,7 +85,7 @@ function generateAlertEmailContent(
   const data: AlertTemplateData = {
     change: changeText(oldLevel, newLevel),
     location_name: locationName,
-    img_alt: `Image depicting that ${locationName} went from "${oldLevelText}" to "${newLevelText}" (where ${oldLevelText} and ${newLevelText} can be: Low, Medium, High COVID Community Level)`,
+    img_alt: `Image depicting that ${locationName} went from ${oldLevelText} to ${newLevelText}`,
     img_url: `${thermometerBaseURL}/therm-${newLevel}-${oldLevel}.png`,
     last_updated: lastUpdated,
     location_url: `${locationURL}?utm_source=risk_alerts&utm_medium=email`,

--- a/scripts/alert_emails/utils.ts
+++ b/scripts/alert_emails/utils.ts
@@ -85,7 +85,7 @@ function generateAlertEmailContent(
   const data: AlertTemplateData = {
     change: changeText(oldLevel, newLevel),
     location_name: locationName,
-    img_alt: `Image depicting that ${locationName} went from "${oldLevelText}" to "${newLevelText}"`,
+    img_alt: `Image depicting that ${locationName} went from "${oldLevelText}" to "${newLevelText}" (where ${oldLevelText} and ${newLevelText} can be: Low, Medium, High COVID Community Level)`,
     img_url: `${thermometerBaseURL}/therm-${newLevel}-${oldLevel}.png`,
     last_updated: lastUpdated,
     location_url: `${locationURL}?utm_source=risk_alerts&utm_medium=email`,
@@ -118,7 +118,7 @@ export function generateAlertEmailData(
 ) {
   const { locationName } = locationAlert;
   const htmlContent = generateAlertEmailContent(emailAddress, locationAlert);
-  const subjectLine = `${locationName}'s Risk Level Has Changed`;
+  const subjectLine = `${locationName}'s Community Level Has Changed`;
 
   return {
     Subject: subjectLine,

--- a/src/common/metrics/admissions_per_100k.tsx
+++ b/src/common/metrics/admissions_per_100k.tsx
@@ -19,7 +19,7 @@ export const AdmissionsPer100kMetric: MetricDefinition = {
   metricName: 'Weekly Covid Admissions per 100k',
   extendedMetricName: 'Weekly Covid Admissions per 100k population',
   metricNameForCompare: `Weekly Covid Admissions per 100k`,
-  metricNameForSummaryStat: 'Admissions',
+  metricNameForSummaryStat: 'Weekly New Admissions',
 };
 
 export const ADMISSIONS_PER_100K_LEVEL_INFO_MAP: LevelInfoMap = {

--- a/src/common/metrics/location_summary.tsx
+++ b/src/common/metrics/location_summary.tsx
@@ -12,10 +12,12 @@ const HIGH_NAME = 'Very high';
 const SUPER_CRITICAL_NAME = 'Extremely high';
 const UNKNOWN = 'Unknown';
 
-const LEGEND_SUMMARY_LOW = 'Low risk';
-const LEGEND_SUMMARY_MEDIUM = 'Medium risk';
-const LEGEND_SUMMARY_MEDIUM_HIGH = 'High risk';
-const LEGEND_SUMMARY_HIGH = 'Very high risk';
+const LEGEND_SUMMARY_LOW = 'Low COVID Community Level';
+const LEGEND_SUMMARY_MEDIUM = 'Medium COVID Community Level';
+const LEGEND_SUMMARY_HIGH = 'High COVID Community Level';
+
+// TODO (Fai): Remove once community level changes are shipped.
+const LEGEND_SUMMARY_MEDIUM_HIGH = 'Very high risk';
 const LEGEND_SUMMARY_SUPER_CRITICAL = 'Extremely high risk';
 
 const recommendationsLink = (

--- a/src/common/metrics/location_summary.tsx
+++ b/src/common/metrics/location_summary.tsx
@@ -16,7 +16,7 @@ const LEGEND_SUMMARY_LOW = 'Low COVID Community Level';
 const LEGEND_SUMMARY_MEDIUM = 'Medium COVID Community Level';
 const LEGEND_SUMMARY_HIGH = 'High COVID Community Level';
 
-// TODO (Fai): Remove once community level changes are shipped.
+// TODO(8.2): Remove once community level changes are shipped.
 const LEGEND_SUMMARY_MEDIUM_HIGH = 'Very high risk';
 const LEGEND_SUMMARY_SUPER_CRITICAL = 'Extremely high risk';
 

--- a/src/common/metrics/ratio_beds_with_covid_patients.tsx
+++ b/src/common/metrics/ratio_beds_with_covid_patients.tsx
@@ -19,7 +19,7 @@ export const RatioBedsWithCovidPatientsMetric: MetricDefinition = {
   metricName: '% Hospital beds with Covid patients',
   extendedMetricName: '% Hospital beds with Covid patients',
   metricNameForCompare: `% Hospital beds with Covid patients`,
-  metricNameForSummaryStat: 'COVID Patients',
+  metricNameForSummaryStat: 'Patients w/ COVID',
 };
 
 export const RATIO_BEDS_WITH_COVID_PATIENTS_LEVEL_INFO_MAP: LevelInfoMap = {

--- a/src/components/Charts/Groupings.tsx
+++ b/src/components/Charts/Groupings.tsx
@@ -42,10 +42,10 @@ export interface MetricChartInfo {
 
 // TODO(8.2) Finalize group header
 export enum GroupHeader {
-  NEW = 'New',
+  COMMUNITY_LEVEL_COMPONENTS = 'Community Level Components',
   VACCINATED = '% Vaccinated',
   CASES = 'Cases',
-  HOSPITALIZATIONS = 'Hospitalizations',
+  HOSPITALIZATIONS = 'Additional Hospitalization Metrics',
   DEATHS = 'Deaths',
 }
 
@@ -57,7 +57,7 @@ export interface ChartGroup {
 // TODO(8.2) Replace with final group header
 export const CHART_GROUPS: ChartGroup[] = [
   {
-    groupHeader: GroupHeader.NEW,
+    groupHeader: GroupHeader.COMMUNITY_LEVEL_COMPONENTS,
     metricList: [
       {
         metric: Metric.WEEKLY_CASES_PER_100K,

--- a/src/components/EmailAlertsFooter/EmailAlertsFooter.tsx
+++ b/src/components/EmailAlertsFooter/EmailAlertsFooter.tsx
@@ -22,7 +22,8 @@ const EmailAlertsFooter: React.FC<{ defaultRegions: Region[] }> = ({
         <Section key="header">
           <Heading2>Get alerts</Heading2>
           <Paragraph>
-            We’ll email you when selected locations see a change in risk level.
+            We’ll email you when selected locations see a change in community
+            level.
           </Paragraph>
         </Section>
         <Section key="email-form">

--- a/src/components/Header/HomePageHeader.tsx
+++ b/src/components/Header/HomePageHeader.tsx
@@ -25,7 +25,7 @@ const HomePageHeader: React.FC = () => {
   return (
     <Wrapper>
       <Content>
-        <Header>U.S. COVID Risk &amp; Vaccine Tracker</Header>
+        <Header>U.S. COVID Community Level &amp; Vaccine Tracker</Header>
         <Subcopy>
           Updated on {formatDateTime(lastUpdatedDate, DateFormat.MMMM_D)}{' '}
           {renderInfoTooltip(lastUpdatedDate)}

--- a/src/components/LocationPage/ChartsHolder.tsx
+++ b/src/components/LocationPage/ChartsHolder.tsx
@@ -111,7 +111,7 @@ const ChartsHolder = React.memo(({ region, chartId }: ChartsHolderProps) => {
   const deathsBlockRed = useRef<HTMLDivElement>(null);
   const chartBlockRefs = useMemo(
     () => ({
-      [GroupHeader.NEW]: newBlockRef,
+      [GroupHeader.COMMUNITY_LEVEL_COMPONENTS]: newBlockRef,
       [GroupHeader.VACCINATED]: vaccinationsBlockRef,
       [GroupHeader.CASES]: casesBlockRef,
       [GroupHeader.HOSPITALIZATIONS]: hospitalizationsBlockRef,

--- a/src/screens/HomePage/HomePage.tsx
+++ b/src/screens/HomePage/HomePage.tsx
@@ -139,8 +139,8 @@ export default function HomePage() {
             </ColumnCentered>
 
             <MapBlock
-              title="Community transmission levels"
-              subtitle="Risk is reduced for those who are vaccinated."
+              title="Community levels"
+              subtitle=""
               renderMap={locationScope => (
                 <USRiskMap showCounties={locationScope === MapView.COUNTIES} />
               )}


### PR DESCRIPTION
First pass at updating some content for CAN-82, based on [this doc](https://docs.google.com/document/d/1pITjM1gctulpwyqez5SFrQLFIYO4vndJArDjFPnVMG4/edit#). I avoided updating the chart sections for the location page for now since they don't seem to be finalized yet.