### PR TITLE
update email alert body (1st pass)

### DIFF
--- a/scripts/alert_emails/send-test-email.ts
+++ b/scripts/alert_emails/send-test-email.ts
@@ -17,8 +17,8 @@ const locationAlert: Alert = {
   locationName: 'District of Columbia',
   locationURL: 'https://covidactnow.org/us/district_of_columbia-dc/',
   lastUpdated: '06/26/2020',
-  oldLevel: 2,
-  newLevel: 3,
+  oldLevel: 4,
+  newLevel: 1,
 };
 
 async function main(emailAddress: string) {

--- a/scripts/alert_emails/template.html
+++ b/scripts/alert_emails/template.html
@@ -110,7 +110,7 @@
                                             style="line-height:inherit;vertical-align:middle;border-width:0!important;border-style:none!important;border-color:white!important">
                                             <p
                                                 style="Margin-top:0;Margin-bottom:0;font-family:Arial,Helvetica,sans-serif;text-align:center;font-size:13px;line-height:15px">
-                                                <span style="line-height:inherit;color:#828282">on
+                                                <span style="line-height:inherit;color:#828282">On
                                                     {{last_updated}}</span>
                                             </p>
                                         </div>
@@ -134,8 +134,6 @@
                                                     data-tooltip-class="a1V">
                                                     <div class="aSK J-J5-Ji aYr"></div>
                                                 </div>
-                                            </div>
-                                            <div style="font-size: 13px; color: #828282">Note that risk is reduced for those who are vaccinated. As of January 2022 we have updated our “severe” risk label to “extremely high.” Risk thresholds remain the same.</div>
                                             </div>
                                         </div>
                                     </div>
@@ -211,11 +209,7 @@
                                             <p
                                                 style="Margin-top:0;Margin-bottom:0;font-style:normal;font-weight:normal;font-family:Arial,Helvetica,sans-serif;text-align:center;font-size:15px;line-height:21px">
                                                 <span style="line-height:inherit">
-                                                    <span style="line-height:inherit;color:#4f4f4f">Covid Act Now
-                                                        provides a 5-color risk score for states and counties across the
-                                                        nation so citizens and government officials can better
-                                                        understand COVID status in their area.
-                                                        Learn more at <a href="https://covidactnow.org/about?utm_source=risk_alerts&utm_medium=email"
+                                                    <span style="line-height:inherit;color:#4f4f4f">As of March 2022, Covid Act Now follows the CDC's Community Level framework to provide a 3-color community level assessment for states and counties across the nation so citizens and government officials can better understand COVID status in their area. Learn more at <a href="https://covidactnow.org/about?utm_source=risk_alerts&utm_medium=email"
                                                             style="line-height:inherit;color:#00bfea"
                                                             target="_blank">covidactnow.org/about</a></span>
                                                 </span>
@@ -231,8 +225,7 @@
                                                 <span style="line-height:inherit">
                                                     <span style="line-height:inherit;color:#4f4f4f">To avoid
                                                         overwhelming your inbox, we only send out Alerts on Mondays and
-                                                        Thursdays. For the most up-to-date risk
-                                                        assessments, check out the <a href="https://covidactnow.org?utm_source=risk_alerts&utm_medium=email"
+                                                        Thursdays. For the most up-to-date community level assessments, check out the <a href="https://covidactnow.org?utm_source=risk_alerts&utm_medium=email"
                                                             style="line-height:inherit;color:#00bfea"
                                                             target="_blank">real-time metrics on our site</a>.</span>
                                                 </span>

--- a/scripts/alert_emails/utils.ts
+++ b/scripts/alert_emails/utils.ts
@@ -3,15 +3,13 @@ import fs from 'fs-extra';
 import * as Handlebars from 'handlebars';
 import { Alert } from './interfaces';
 import { Level } from '../../src/common/level';
-import regions from '../../src/common/regions';
 import { LOCATION_SUMMARY_LEVELS } from '../../src/common/metrics/location_summary';
 import { fetchMainSnapshotNumber } from '../../src/common/utils/snapshots';
 import { DateFormat, formatDateTime } from '../../src/common/utils/time-utils';
 
 export const ALERT_EMAIL_GROUP_PREFIX = 'alert-email';
 
-const thermometerBaseURL =
-  'https://data.covidactnow.org/thermometer_screenshot';
+const thermometerBaseURL = 'https://covidactnow.org/images/email_alerts';
 const unsubscribeURL = 'https://covidactnow.org/alert_unsubscribe';
 
 export function toISO8601(date: Date): string {
@@ -104,11 +102,11 @@ function generateAlertEmailContent(
 
 function changeText(oldLevel: Level, newLevel: Level) {
   if (oldLevel === Level.UNKNOWN) {
-    return 'new risk score';
+    return 'new community level';
   } else if (oldLevel < newLevel) {
-    return 'risk increased';
+    return 'community level increased';
   } else {
-    return 'risk decreased';
+    return 'community level decreased';
   }
 }
 


### PR DESCRIPTION
First pass at updating the email alerts copy and images (see [CAN 8.2 COPY](https://docs.google.com/document/d/1pITjM1gctulpwyqez5SFrQLFIYO4vndJArDjFPnVMG4/edit#heading=h.ny2rjkbn6e9s)). Screenshot of the email:

<img width="902" alt="image" src="https://user-images.githubusercontent.com/114084/162258041-f63e8e5e-3064-40c7-aa5e-c07fcd264043.png">

## Notes

- Note that this email is generated with mocked data, so the date and current levels won't match current date/level.
- Also, Fai's PR updates the subject line and alt-text of the screenshot
