### PR TITLE
Wire up alert emails option so we can send them to everybody.

### DIFF
--- a/.github/workflows/send-alert-emails.yml
+++ b/.github/workflows/send-alert-emails.yml
@@ -15,13 +15,20 @@ on:
         description: 'Snapshot to send alerts for (auto uses currently deployed snapshot).'
         required: true
         default: auto
+      send_to_everybody:
+        description: 'Whether to send emails to everybody (as if old level was unknown)'
+        required: true
+        default: false
 
 env:
   SNAPSHOT_ID: ${{ github.event.inputs.snapshot_id }}
   # Should be 'dev', 'staging', or 'prod'. Determines which Firebase project to use.
   FIREBASE_ENV: ${{ github.event.inputs.firebase_env }}
-  # 'true' or 'false' to indicuate whether we should send the emails or just run (true will send the emails)
+  # 'true' or 'false' to indicate whether we should send the emails or just run (true will send the emails)
   SEND_EMAILS: ${{ github.event.inputs.send_emails }}
+  # 'true' or 'false' to indicate whether we should send emails to everybody.
+  SEND_TO_EVERYBODY: ${{ github.event.inputs.send_to_everybody }}
+
 jobs:
   send-alert-emails:
     runs-on: ubuntu-latest
@@ -52,7 +59,7 @@ jobs:
           SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_PROD }}
 
       # Generate / send emails.
-      - run: yarn generate-daily-alerts ${{ env.SNAPSHOT_ID }}
+      - run: yarn generate-daily-alerts ${{ env.SNAPSHOT_ID }} ${{ env.SEND_TO_EVERYBODY }}
       - run: yarn create-lists-to-email alerts.json ${{ env.SNAPSHOT_ID }}
       - name: Send emails
         run: yarn send-emails alerts.json ${{ env.SNAPSHOT_ID }} ${{env.SEND_EMAILS}}

--- a/scripts/alert_emails/generate_daily_alerts.ts
+++ b/scripts/alert_emails/generate_daily_alerts.ts
@@ -28,7 +28,7 @@ const summariesFolder = path.join(__dirname, 'summaries');
 const outputFile = path.join(__dirname, 'alerts.json');
 
 async function main() {
-  const { newSnap } = await parseArgs();
+  const { newSnap, sendToEverybody } = await parseArgs();
   const oldSnap = await getLastSnapshotNumber();
 
   const oldSummaries: SummariesMap = await fs.readJSON(
@@ -43,7 +43,8 @@ async function main() {
     const region = regions.findByFipsCodeStrict(fips);
     const newSummary = newSummaries[fips];
     const oldSummary = oldSummaries[fips];
-    const oldLevel = oldSummary ? oldSummary.level : Level.UNKNOWN;
+    const oldLevel =
+      oldSummary && !sendToEverybody ? oldSummary.level : Level.UNKNOWN;
     const newLevel = newSummary.level;
     const locationName = region.fullName;
     const locationURL = region.canonicalUrl;
@@ -69,14 +70,17 @@ async function main() {
   console.log(`Done. Generated ${outputFile}`);
 }
 
-async function parseArgs(): Promise<{ newSnap: number }> {
+async function parseArgs(): Promise<{
+  newSnap: number;
+  sendToEverybody: boolean;
+}> {
   const args = process.argv.slice(2);
-  if (args.length === 1) {
-    const newSnap = await resolveSnapshot(args[0]);
-    return { newSnap };
-  } else {
+  if (args.length === 0) {
     exitWithUsage();
   }
+  const newSnap = await resolveSnapshot(args[0]);
+  const sendToEverybody = args[1] === 'true';
+  return { newSnap, sendToEverybody };
 }
 
 function exitWithUsage(): never {


### PR DESCRIPTION
Tested locally by running `yarn generate-daily-alerts 3207 true` and inspecting the output at scripts/alert_emails/alerts.jso to see that all locations are included and have an oldLevel of 4 (UNKNOWN).

We should further validate before actually sending email alerts by:
1. Doing a dev or staging run with the new option set to true.
2. Doing a prod dry-run with the new option set to true (this will tell us how many emails will be sent, etc.).
