### PR TITLE
Remove cases and deaths from trends

### DIFF
--- a/src/components/Explore/Explore.tsx
+++ b/src/components/Explore/Explore.tsx
@@ -253,7 +253,7 @@ const Explore: React.FunctionComponent<{
     // (need to force the reset since the route doesnt change)
     useEffect(() => {
       setSelectedLocations(initialLocations);
-      setCurrentMetric(ExploreMetric.HOSPITALIZATIONS);
+      setCurrentMetric(ExploreMetric.WEEKLY_CASES_PER_100K);
       setPeriod(Period.ALL);
     }, [pathname, region, initialLocations, setCurrentMetric]);
 

--- a/src/components/Explore/interfaces.ts
+++ b/src/components/Explore/interfaces.ts
@@ -21,19 +21,26 @@ export interface Series {
   params?: SeriesParams;
 }
 
+/**
+ * Indices assigned to each enumerated explore metric needs to match
+ * the order of the dropdown items in EXPLORE_METRICS in Explore/utils.ts.
+ *
+ * So if we change the ordering of items in EXPLORE_METRIC,
+ * we need to update these assigned indices to match.
+ */
 export enum ExploreMetric {
-  CASES,
-  DEATHS,
-  HOSPITALIZATIONS,
-  ICU_HOSPITALIZATIONS,
-  VACCINATIONS_FIRST_DOSE,
-  VACCINATIONS_COMPLETED,
-  VACCINATIONS_ADDITIONAL_DOSE,
-  ICU_USED,
-  POSITIVITY_RATE,
-  ADMISSIONS_PER_100K,
-  RATIO_BEDS_WITH_COVID,
-  WEEKLY_CASES_PER_100K,
+  CASES = 10,
+  DEATHS = 11,
+  HOSPITALIZATIONS = 0,
+  ICU_HOSPITALIZATIONS = 1,
+  VACCINATIONS_FIRST_DOSE = 2,
+  VACCINATIONS_COMPLETED = 3,
+  VACCINATIONS_ADDITIONAL_DOSE = 4,
+  ICU_USED = 5,
+  POSITIVITY_RATE = 6,
+  ADMISSIONS_PER_100K = 7,
+  RATIO_BEDS_WITH_COVID = 8,
+  WEEKLY_CASES_PER_100K = 9,
 }
 
 export enum DataMeasure {

--- a/src/components/Explore/interfaces.ts
+++ b/src/components/Explore/interfaces.ts
@@ -25,12 +25,10 @@ export interface Series {
  * Indices assigned to each enumerated explore metric needs to match
  * the order of the dropdown items in EXPLORE_METRICS in Explore/utils.ts.
  *
- * So if we change the ordering of items in EXPLORE_METRIC,
+ * So if we change the ordering of items in EXPLORE_METRICS in Explore/utils.ts,
  * we need to update these assigned indices to match.
  */
 export enum ExploreMetric {
-  CASES = 10,
-  DEATHS = 11,
   HOSPITALIZATIONS = 0,
   ICU_HOSPITALIZATIONS = 1,
   VACCINATIONS_FIRST_DOSE = 2,
@@ -41,6 +39,14 @@ export enum ExploreMetric {
   ADMISSIONS_PER_100K = 7,
   RATIO_BEDS_WITH_COVID = 8,
   WEEKLY_CASES_PER_100K = 9,
+
+  /**
+   * Cases and Deaths no longer used in Trends
+   * (i.e. no longer included in EXPLORE_METRICS in Explore/utils.ts),
+   * and so we order them last in the enum.
+   */
+  CASES = 10,
+  DEATHS = 11,
 }
 
 export enum DataMeasure {

--- a/src/components/Explore/utils.ts
+++ b/src/components/Explore/utils.ts
@@ -84,6 +84,11 @@ export function getDateRange(period: Period): Date[] {
   return [dateFrom, dateTo];
 }
 
+/**
+ * If we change the ordering of items in the following array,
+ * we need to adjust indices assigned to each enumerated explore metric
+ * in ExploreMetric enum in Explore/interfaces.ts.
+ */
 export const EXPLORE_METRICS = [
   ExploreMetric.HOSPITALIZATIONS,
   ExploreMetric.ICU_HOSPITALIZATIONS,
@@ -705,7 +710,6 @@ export function getChartSeries(
   regions: Region[],
   normalizeData: boolean,
 ): Promise<Series[]> {
-  console.log(metric);
   if (regions.length === 1) {
     return getProjectionForRegion(regions[0]).then(projection =>
       getAllSeriesForMetric(metric, projection),

--- a/src/components/Explore/utils.ts
+++ b/src/components/Explore/utils.ts
@@ -85,8 +85,6 @@ export function getDateRange(period: Period): Date[] {
 }
 
 export const EXPLORE_METRICS = [
-  ExploreMetric.CASES,
-  ExploreMetric.DEATHS,
   ExploreMetric.HOSPITALIZATIONS,
   ExploreMetric.ICU_HOSPITALIZATIONS,
   ExploreMetric.VACCINATIONS_FIRST_DOSE,
@@ -707,6 +705,7 @@ export function getChartSeries(
   regions: Region[],
   normalizeData: boolean,
 ): Promise<Series[]> {
+  console.log(metric);
   if (regions.length === 1) {
     return getProjectionForRegion(regions[0]).then(projection =>
       getAllSeriesForMetric(metric, projection),

--- a/src/components/LocationPage/ChartsHolder.tsx
+++ b/src/components/LocationPage/ChartsHolder.tsx
@@ -93,11 +93,11 @@ const ChartsHolder = React.memo(({ region, chartId }: ChartsHolderProps) => {
 
   const [currentExploreMetric, setCurrentExploreMetric] = useState<
     ExploreMetric
-  >(ExploreMetric.CASES);
+  >(ExploreMetric.WEEKLY_CASES_PER_100K);
 
   useEffect(() => {
     if (hash === '#explore-chart') {
-      setCurrentExploreMetric(ExploreMetric.HOSPITALIZATIONS);
+      setCurrentExploreMetric(ExploreMetric.WEEKLY_CASES_PER_100K);
     }
   }, [hash]);
 


### PR DESCRIPTION
- Remove daily cases and deaths from Trends.
- Select "Weekly new cases per 100k" by default in Trends.

As per these two cards:
- https://trello.com/c/XaHrtmmV/549-trends-remove-daily-new-cases-daily-new-deaths
- https://trello.com/c/toG5398D/554-update-trends-add-weekly-new-deaths-minor-updates