### PR TITLE
Fix Weekly Covid Admissions chart copy value and update hospital chart copy for counties

### DIFF
--- a/src/common/metrics/admissions_per_100k.tsx
+++ b/src/common/metrics/admissions_per_100k.tsx
@@ -101,7 +101,7 @@ function renderStatus(projections: Projections): React.ReactElement {
     );
   }
 
-  const hsaCopy = `The ${hsaName} health service area`;
+  const hsaCopy = `The ${hsaName} Health Service Area`;
   // Try not to round to zero (since it will probably be >0 per 100k).
   const weeklyNewCovidAdmissionsText =
     weeklyNewCovidAdmissions >= 0.1 && weeklyNewCovidAdmissions < 1

--- a/src/common/metrics/admissions_per_100k.tsx
+++ b/src/common/metrics/admissions_per_100k.tsx
@@ -74,15 +74,23 @@ export const ADMISSIONS_PER_100K_LEVEL_INFO_MAP: LevelInfoMap = {
 };
 
 function renderStatus(projections: Projections): React.ReactElement {
-  const { totalPopulation, currentDailyAverageCases } = projections.primary;
+  const {
+    totalPopulation,
+    currentWeeklyCovidAdmissions,
+    currentHsaHospitalInfo,
+    hsaName,
+  } = projections.primary;
   const weeklyCovidAdmissionsPer100k = projections.getMetricValue(
     Metric.ADMISSIONS_PER_100K,
   );
+  const weeklyNewCovidAdmissions = projections.isCounty
+    ? currentHsaHospitalInfo.weeklyCovidAdmissions
+    : currentWeeklyCovidAdmissions;
   const locationName = projections.locationName;
   if (
     weeklyCovidAdmissionsPer100k === null ||
     totalPopulation === null ||
-    currentDailyAverageCases === null
+    weeklyNewCovidAdmissions === null
   ) {
     return (
       <Fragment>
@@ -93,18 +101,19 @@ function renderStatus(projections: Projections): React.ReactElement {
     );
   }
 
-  const newCasesPerDay = currentDailyAverageCases;
-  // Try not to round cases/day to zero (since it will probably be >0 per 100k).
-  const newCasesPerDayText =
-    newCasesPerDay >= 0.1 && newCasesPerDay < 1
-      ? formatDecimal(newCasesPerDay, 1)
-      : formatInteger(newCasesPerDay);
+  const hsaCopy = `The ${hsaName} health service area`;
+  // Try not to round to zero (since it will probably be >0 per 100k).
+  const weeklyNewCovidAdmissionsText =
+    weeklyNewCovidAdmissions >= 0.1 && weeklyNewCovidAdmissions < 1
+      ? formatDecimal(weeklyNewCovidAdmissions, 1)
+      : formatInteger(weeklyNewCovidAdmissions);
 
   return (
     <Fragment>
-      Over the last week, {locationName} had {newCasesPerDayText} COVID hospital
-      admissions (<b>{formatDecimal(weeklyCovidAdmissionsPer100k, 1)}</b> for
-      every 100,000 residents).
+      Over the last week, {projections.isCounty ? hsaCopy : locationName} had{' '}
+      {weeklyNewCovidAdmissionsText} COVID hospital admissions (
+      <b>{formatDecimal(weeklyCovidAdmissionsPer100k, 1)}</b> for every 100,000
+      residents).
     </Fragment>
   );
 }

--- a/src/common/metrics/hospitalizations.tsx
+++ b/src/common/metrics/hospitalizations.tsx
@@ -103,7 +103,7 @@ function renderStatus(projections: Projections): React.ReactElement {
     );
   }
 
-  const hsaCopy = `The ${projections.primary.hsaName} health service area`;
+  const hsaCopy = `The ${projections.primary.hsaName} Health Service Area`;
   const totalICUBeds = formatInteger(icu.totalBeds);
   const totalICUPatients = formatInteger(icu.totalPatients);
   if (icu.metricValue === null) {

--- a/src/common/metrics/ratio_beds_with_covid_patients.tsx
+++ b/src/common/metrics/ratio_beds_with_covid_patients.tsx
@@ -89,7 +89,7 @@ function renderStatus(projections: Projections): React.ReactElement {
     );
   }
 
-  const hsaCopy = `the ${projections.primary.hsaName} health service area`;
+  const hsaCopy = `the ${projections.primary.hsaName} Health Service Area`;
   return (
     <Fragment>
       {formatPercent(currentRatioBedsWithCovid)} of staffed inpatient beds in{' '}

--- a/src/common/metrics/ratio_beds_with_covid_patients.tsx
+++ b/src/common/metrics/ratio_beds_with_covid_patients.tsx
@@ -89,10 +89,12 @@ function renderStatus(projections: Projections): React.ReactElement {
     );
   }
 
+  const hsaCopy = `the ${projections.primary.hsaName} health service area`;
   return (
     <Fragment>
       {formatPercent(currentRatioBedsWithCovid)} of staffed inpatient beds in{' '}
-      {locationName} are occupied by COVID patients.
+      {projections.isCounty ? hsaCopy : locationName} are occupied by COVID
+      patients.
     </Fragment>
   );
 }

--- a/src/common/models/Projection.ts
+++ b/src/common/models/Projection.ts
@@ -158,6 +158,7 @@ export class Projection {
   readonly currentDailyDeaths: number | null;
   readonly currentHsaIcuInfo: HospitalResourceUtilization;
   readonly currentHsaHospitalInfo: HospitalResourceUtilizationWithAdmissions;
+  readonly currentWeeklyCovidAdmissions: number | null;
   readonly canCommunityLevel: Level;
 
   private readonly cumulativeActualDeaths: Array<number | null>;
@@ -310,6 +311,9 @@ export class Projection {
 
     this.currentHsaIcuInfo = summaryWithTimeseries.actuals.hsaIcuBeds;
     this.currentHsaHospitalInfo = summaryWithTimeseries.actuals.hsaHospitalBeds;
+    // For counties, in most cases we will want to access hsaHospitalBeds (usually via currentHsaHospitalInfo)
+    this.currentWeeklyCovidAdmissions =
+      summaryWithTimeseries.actuals.hospitalBeds.weeklyCovidAdmissions;
 
     this.annotations = summaryWithTimeseries.annotations;
   }

--- a/src/components/NewLocationPage/ChartFooter/utils.ts
+++ b/src/components/NewLocationPage/ChartFooter/utils.ts
@@ -34,7 +34,7 @@ export function getAddedMetricStatusText(
     ].includes(metric)
   ) {
     const hsaFormattedValue = formattedHsaCovidUsage(metric, projections);
-    return `Over the last week, the ${projections.primary.hsaName} health service area has reported having ${hsaFormattedValue} ${exploreMetricToFooterContentMap[metric].statusTextMeasure}, for an estimated ${value} coming from ${region.shortName}.`;
+    return `Over the last week, the ${projections.primary.hsaName} Health Service Area has reported having ${hsaFormattedValue} ${exploreMetricToFooterContentMap[metric].statusTextMeasure}, for an estimated ${value} coming from ${region.shortName}.`;
   }
 
   return `Over the last week, ${region.shortName} has averaged ${value} ${exploreMetricToFooterContentMap[metric].statusTextMeasure}.`;


### PR DESCRIPTION
And drive-by formatting to capitalize Health Service Area to match [Copy Doc](https://docs.google.com/document/d/1pITjM1gctulpwyqez5SFrQLFIYO4vndJArDjFPnVMG4/edit#). 

Continuing to use existing HSA name copy/style until copy updates are confirmed (see [slack thread](https://actnowcoalition.slack.com/archives/C02UQBS8X8W/p1649724516819879) for context)