### PR TITLE
Reverse engineer weekly admissions actual for counties

### DIFF
--- a/src/common/metrics/admissions_per_100k.tsx
+++ b/src/common/metrics/admissions_per_100k.tsx
@@ -81,8 +81,21 @@ function renderStatus(projections: Projections): React.ReactElement {
   const weeklyCovidAdmissionsPer100k = projections.getMetricValue(
     Metric.ADMISSIONS_PER_100K,
   );
+
+  // NOTE: We reverse engineer the actual weekly admissions number for counties because the HHS source
+  // data does not match due to data suppression.
+  let weeklyCovidAdmissionsCdc: number | null = null;
+  if (
+    weeklyCovidAdmissionsPer100k !== null &&
+    projections.primary.hsaPopulation !== null
+  ) {
+    weeklyCovidAdmissionsCdc =
+      weeklyCovidAdmissionsPer100k *
+      (projections.primary.hsaPopulation / 100_000);
+  }
+
   const weeklyNewCovidAdmissions = projections.isCounty
-    ? currentHsaHospitalInfo.weeklyCovidAdmissions
+    ? weeklyCovidAdmissionsCdc
     : currentWeeklyCovidAdmissions;
   const locationName = projections.locationName;
   if (

--- a/src/common/metrics/admissions_per_100k.tsx
+++ b/src/common/metrics/admissions_per_100k.tsx
@@ -75,7 +75,6 @@ function renderStatus(projections: Projections): React.ReactElement {
   const {
     totalPopulation,
     currentWeeklyCovidAdmissions,
-    currentHsaHospitalInfo,
     hsaName,
   } = projections.primary;
   const weeklyCovidAdmissionsPer100k = projections.getMetricValue(


### PR DESCRIPTION
Reverse engineer actual weekly admissions for county-level locations (HSA-level data) to fix discrepancies between CDC metrics and HHS data. 