### PR TITLE
Trends wording tweaks

### DIFF
--- a/src/components/Explore/interfaces.ts
+++ b/src/components/Explore/interfaces.ts
@@ -29,10 +29,10 @@ export interface Series {
  * we need to update these assigned indices to match.
  */
 export enum ExploreMetric {
-  ADMISSIONS_PER_100K = 0,
-  RATIO_BEDS_WITH_COVID = 1,
-  WEEKLY_CASES = 2,
-  WEEKLY_DEATHS = 3,
+  RATIO_BEDS_WITH_COVID = 0,
+  ADMISSIONS_PER_100K = 1,
+  WEEKLY_DEATHS = 2,
+  WEEKLY_CASES = 3,
   CASES = 4,
   DEATHS = 5,
   HOSPITALIZATIONS = 6,

--- a/src/components/Explore/utils.ts
+++ b/src/components/Explore/utils.ts
@@ -90,10 +90,10 @@ export function getDateRange(period: Period): Date[] {
  * in ExploreMetric enum in Explore/interfaces.ts.
  */
 export const EXPLORE_METRICS = [
-  ExploreMetric.ADMISSIONS_PER_100K,
   ExploreMetric.RATIO_BEDS_WITH_COVID,
-  ExploreMetric.WEEKLY_CASES,
+  ExploreMetric.ADMISSIONS_PER_100K,
   ExploreMetric.WEEKLY_DEATHS,
+  ExploreMetric.WEEKLY_CASES,
   ExploreMetric.CASES,
   ExploreMetric.DEATHS,
   ExploreMetric.HOSPITALIZATIONS,

--- a/src/components/NationalText/utils.tsx
+++ b/src/components/NationalText/utils.tsx
@@ -57,7 +57,7 @@ export function getNationalText(): React.ReactElement {
       !isNull(twoWeekPercentChangeInDeaths)
         ? `Over the last 14 days, hospitalizations have ${getChangeDescriptorCopy(
             twoWeekPercentChangeInHospitalizations,
-          )} and daily deaths have ${getChangeDescriptorCopy(
+          )} and weekly deaths have ${getChangeDescriptorCopy(
             twoWeekPercentChangeInDeaths,
           )}.`
         : ''}


### PR DESCRIPTION
Small tweak to the national text under "Trends" on the homepage and re-ordering (again 😑 ) of the dropdown items in the Trends chart cos I re-ordered them based on variable names in our code instead of the metric names the user sees. Sorry!