### PR TITLE
Add 'new' to Weekly Covid Admissions chart copy

### DIFF
--- a/src/common/metrics/admissions_per_100k.tsx
+++ b/src/common/metrics/admissions_per_100k.tsx
@@ -121,7 +121,7 @@ function renderStatus(projections: Projections): React.ReactElement {
   return (
     <Fragment>
       Over the last week, {projections.isCounty ? hsaCopy : locationName} had{' '}
-      {weeklyNewCovidAdmissionsText} COVID hospital admissions (
+      {weeklyNewCovidAdmissionsText} new COVID hospital admissions (
       <b>{formatDecimal(weeklyCovidAdmissionsPer100k, 1)}</b> for every 100,000
       residents).
     </Fragment>


### PR DESCRIPTION
Per copy doc: 

```
Add “new” to copy: 
“Over the last week, [STATE/METRO/HSA] had [X] new COVID hospital admissions ([X] for every 100,000 residents). “
```