### PR TITLE
Add new metrics to data coverage table

### DIFF
--- a/src/components/DataCoverageTable/DataCoverageTable.tsx
+++ b/src/components/DataCoverageTable/DataCoverageTable.tsx
@@ -25,6 +25,18 @@ interface MetricField {
 
 export const FIELDS: MetricField[] = [
   { displayName: 'Overall risk level', field: 'riskLevels.overall' },
+  {
+    displayName: 'Weekly new reported cases',
+    field: 'metrics.weeklyNewCasesPer100k',
+  },
+  {
+    displayName: 'Weekly COVID admissions',
+    field: 'metrics.weeklyCovidAdmissionsPer100k',
+  },
+  {
+    displayName: 'Patients with COVID',
+    field: 'metrics.bedsWithCovidPatientsRatio',
+  },
   { displayName: 'Daily new cases', field: 'metrics.caseDensity' },
   { displayName: 'Infection rate', field: 'metrics.infectionRate' },
   { displayName: 'Positive test rate', field: 'metrics.testPositivityRatio' },


### PR DESCRIPTION
This PR addresses https://trello.com/c/xehsRNjy/567-update-data-api-page-coverage-section

The `yarn update-data-coverage-summary` script already calculated coverage for these new metrics, so they just needed to be added to the DataCoverageTable component