### PR TITLE
Revert trends default to hospitalizations per 100k

### DIFF
--- a/src/components/Explore/Explore.tsx
+++ b/src/components/Explore/Explore.tsx
@@ -253,7 +253,7 @@ const Explore: React.FunctionComponent<{
     // (need to force the reset since the route doesnt change)
     useEffect(() => {
       setSelectedLocations(initialLocations);
-      setCurrentMetric(ExploreMetric.WEEKLY_CASES);
+      setCurrentMetric(ExploreMetric.HOSPITALIZATIONS);
       setPeriod(Period.ALL);
     }, [pathname, region, initialLocations, setCurrentMetric]);
 


### PR DESCRIPTION
Per [Launch Checklist](https://www.dropbox.com/scl/fi/u23ob7sqtyqyo3e9n37bx/CAN-8.2-CDC%2B%2B-Launch-Checklist.paper?dl=0&oref=e&rlkey=ebmgo5rcj5i3mesd8bkeglac3):

```
Revert trends default to hospitalizations per 100k. 
Ideally we’d use weekly admissions, but not enough historical data.
```

If we end up using historical HHS data to backfill the hospital metrics we may want to update this again to be weekly covid admissions.