### PR TITLE
Fix hash links

### DIFF
--- a/src/components/Dialogs/utils.tsx
+++ b/src/components/Dialogs/utils.tsx
@@ -23,12 +23,10 @@ const metricToLearnLink: { [key in Metric]: string } = {
   [Metric.VACCINATIONS]: '/covid-risk-levels-metrics#percent-vaccinated',
 
   // TODO(8.2) - finalize hash links
-  [Metric.ADMISSIONS_PER_100K]:
-    '/covid-risk-levels-metrics#admissions-per-100k',
+  [Metric.ADMISSIONS_PER_100K]: '/covid-risk-levels-metrics#weekly-admissions',
   [Metric.RATIO_BEDS_WITH_COVID]:
-    '/covid-risk-levels-metrics#ratio-beds-with-covid',
-  [Metric.WEEKLY_CASES_PER_100K]:
-    '/covid-risk-levels-metrics#weekly-cases-per-100k',
+    '/covid-risk-levels-metrics#patients-with-covid',
+  [Metric.WEEKLY_CASES_PER_100K]: '/covid-risk-levels-metrics#weekly-new-cases',
 };
 
 export function getMetricModalContent(

--- a/src/components/Dialogs/utils.tsx
+++ b/src/components/Dialogs/utils.tsx
@@ -21,8 +21,6 @@ const metricToLearnLink: { [key in Metric]: string } = {
   [Metric.HOSPITAL_USAGE]: '/covid-risk-levels-metrics#icu-capacity-used',
   [Metric.POSITIVE_TESTS]: '/covid-risk-levels-metrics#positive-test-rate',
   [Metric.VACCINATIONS]: '/covid-risk-levels-metrics#percent-vaccinated',
-
-  // TODO(8.2) - finalize hash links
   [Metric.ADMISSIONS_PER_100K]: '/covid-risk-levels-metrics#weekly-admissions',
   [Metric.RATIO_BEDS_WITH_COVID]:
     '/covid-risk-levels-metrics#patients-with-covid',


### PR DESCRIPTION
Fixes item in launch list:

> How to get the “About the data” tooltip “Learn more” buttons to go to correct place in explainers. Not working for the 3 community level metrics.