### PR TITLE
New homepage H1 + summary stat alignment edit

### DIFF
--- a/src/components/Header/HomePageHeader.tsx
+++ b/src/components/Header/HomePageHeader.tsx
@@ -25,7 +25,7 @@ const HomePageHeader: React.FC = () => {
   return (
     <Wrapper>
       <Content>
-        <Header>U.S. COVID Community Level &amp; Vaccine Tracker</Header>
+        <Header>U.S. COVID Tracker</Header>
         <Subcopy>
           Updated on {formatDateTime(lastUpdatedDate, DateFormat.MMMM_D)}{' '}
           {renderInfoTooltip(lastUpdatedDate)}

--- a/src/components/NewLocationPage/LocationOverview/LocationOverview.style.tsx
+++ b/src/components/NewLocationPage/LocationOverview/LocationOverview.style.tsx
@@ -29,7 +29,8 @@ export const GridContainer = styled.div`
     grid-template-areas:
       'level level progress progress'
       'metric1 metric2 metric3 metricVax';
-    grid-gap: 1.5rem;
+    column-gap: 1.5rem;
+    row-gap: 1rem;
   }
 
   // Note: 1.8fr instead of 2fr to manipulate wrapping of summary stat metric names
@@ -81,6 +82,7 @@ export const GridItemProgress = styled.div`
   @media (min-width: ${materialSMBreakpoint}) {
     padding-bottom: 0;
     border-bottom: none;
+    margin-top: auto;
   }
 `;
 

--- a/src/components/NewLocationPage/SummaryStat/DesktopSummaryStat.tsx
+++ b/src/components/NewLocationPage/SummaryStat/DesktopSummaryStat.tsx
@@ -1,8 +1,12 @@
 import React from 'react';
 import MetricSubLabel from './MetricSubLabel';
 import MetricValue from './MetricValue';
-import { StatContent, Row, MetricLabel } from './SummaryStat.style';
-import { Chevron } from '../Shared/Shared.style';
+import {
+  StatContent,
+  Row,
+  MetricLabel,
+  CondensedChevron,
+} from './SummaryStat.style';
 import { metricSubLabelText, SummaryStatProps } from './utils';
 import { Metric } from 'common/metricEnum';
 
@@ -17,7 +21,7 @@ const DesktopSummaryStat: React.FC<SummaryStatProps> = ({
     <StatContent>
       <Row>
         <MetricLabel>{metricName}</MetricLabel>
-        <Chevron />
+        <CondensedChevron />
       </Row>
       <Row>
         <MetricValue

--- a/src/components/NewLocationPage/SummaryStat/SummaryStat.style.tsx
+++ b/src/components/NewLocationPage/SummaryStat/SummaryStat.style.tsx
@@ -8,7 +8,8 @@ export const StatContent = styled.div`
 
   @media (min-width: ${materialSMBreakpoint}) {
     flex-direction: column;
-    justify-content: unset;
+    height: 100%;
+    justify-content: space-between;
   }
 `;
 

--- a/src/components/NewLocationPage/SummaryStat/SummaryStat.style.tsx
+++ b/src/components/NewLocationPage/SummaryStat/SummaryStat.style.tsx
@@ -1,15 +1,17 @@
 import styled from 'styled-components';
 import { materialSMBreakpoint } from 'assets/theme/sizes';
-import { GrayTitle } from '../Shared/Shared.style';
+import { GrayTitle, Chevron } from '../Shared/Shared.style';
 
 export const StatContent = styled.div`
   display: flex;
   justify-content: space-between;
+  align-items: center;
 
   @media (min-width: ${materialSMBreakpoint}) {
     flex-direction: column;
     height: 100%;
-    justify-content: space-between;
+    justify-content: flex-end;
+    align-items: unset;
   }
 `;
 
@@ -82,4 +84,10 @@ export const Row = styled.div`
       align-items: center;
     }
   }
+`;
+
+// Alignment specific to desktop summary stat:
+export const CondensedChevron = styled(Chevron)`
+  transform: translateY(-1px);
+  margin: auto 0 auto 0.4rem;
 `;

--- a/src/components/SocialLocationPreview/SocialLocationPreview.style.tsx
+++ b/src/components/SocialLocationPreview/SocialLocationPreview.style.tsx
@@ -103,14 +103,14 @@ export const AlarmLevel = styled.div`
   padding: 0.25rem 0.5rem;
 `;
 
-export const HeaderHeader = styled(Typography)`
+export const SocialLocationPreviewHeader = styled(Typography)`
   font-size: 1.125rem;
   line-height: 1.25rem;
   margin-bottom: 0.5rem;
   font-weight: 700;
 `;
 
-export const MapHeaderHeader = styled(Typography)`
+export const MapHeader = styled(Typography)`
   font-size: 1rem;
   line-height: 1rem;
   font-weight: 700;

--- a/src/components/SocialLocationPreview/SocialLocationPreview.tsx
+++ b/src/components/SocialLocationPreview/SocialLocationPreview.tsx
@@ -6,7 +6,7 @@ import {
   Wrapper,
   PreviewHeader,
   HeaderText,
-  HeaderHeader,
+  SocialLocationPreviewHeader,
   HeaderSubhead,
   AlarmLevel,
   PreviewBody,
@@ -35,7 +35,9 @@ const SocialLocationPreview = (props: {
     <Wrapper>
       <PreviewHeader>
         <HeaderText>
-          <HeaderHeader>{props.projections?.region.fullName}</HeaderHeader>
+          <SocialLocationPreviewHeader>
+            {props.projections?.region.fullName}
+          </SocialLocationPreviewHeader>
           <HeaderSubhead>covid community level</HeaderSubhead>
         </HeaderText>
         <AlarmLevel color={fillColor}>{levelInfo.name}</AlarmLevel>

--- a/src/components/SocialLocationPreview/SocialLocationPreviewMap.tsx
+++ b/src/components/SocialLocationPreview/SocialLocationPreviewMap.tsx
@@ -5,7 +5,7 @@ import {
   Wrapper,
   USMapPreviewHeader,
   USMapHeaderText,
-  MapHeaderHeader,
+  MapHeader,
   LastUpdatedWrapper,
   PreviewFooter,
   FooterText,
@@ -39,7 +39,7 @@ const SocialLocationPreview = (props: {
 
   return (
     <Wrapper noShadow={!isEmbedPreview} border={border}>
-      <MapHeaderHeader>US COVID Tracker</MapHeaderHeader>
+      <MapHeader>US COVID Tracker</MapHeader>
       {!isEmbedPreview && (
         <LastUpdatedWrapper>Updated {lastUpdatedDateString}</LastUpdatedWrapper>
       )}

--- a/src/components/SocialLocationPreview/SocialLocationPreviewMap.tsx
+++ b/src/components/SocialLocationPreview/SocialLocationPreviewMap.tsx
@@ -39,9 +39,7 @@ const SocialLocationPreview = (props: {
 
   return (
     <Wrapper noShadow={!isEmbedPreview} border={border}>
-      <MapHeaderHeader>
-        US COVID Community Levels & Vaccine Tracker
-      </MapHeaderHeader>
+      <MapHeaderHeader>US COVID Tracker</MapHeaderHeader>
       {!isEmbedPreview && (
         <LastUpdatedWrapper>Updated {lastUpdatedDateString}</LastUpdatedWrapper>
       )}

--- a/src/screens/HomePage/HomePage.tsx
+++ b/src/screens/HomePage/HomePage.tsx
@@ -117,7 +117,7 @@ export default function HomePage() {
       <EnsureSharingIdInUrl />
       <AppMetaTags
         canonicalUrl="/"
-        pageTitle="US COVID Community Levels & Vaccine Tracker"
+        pageTitle="US COVID Tracker"
         pageDescription={getPageDescription()}
       />
       <NavAllOtherPages

--- a/src/screens/LocationPage/utils.ts
+++ b/src/screens/LocationPage/utils.ts
@@ -16,7 +16,7 @@ function locationName(region: Region) {
 
 export function getPageTitle(region: Region): string {
   const location = locationName(region);
-  return `${location} - U.S. COVID Community Level & Vaccine Tracker`;
+  return `${location} - U.S. COVID Tracker`;
 }
 
 export function getPageDescription(region: Region): string {


### PR DESCRIPTION
- Edits alignments/spacing of summary stats per [these figma mocks](https://www.figma.com/file/QPrDUez0XG8Be0UVW8qcm7/8.2%2B%2B?node-id=127%3A4032)

- Changes homepage h1 (and therefore meta tags, page title, social map header) per this item in the launch doc: 
![Screen Shot 2022-04-18 at 1 47 38 PM](https://user-images.githubusercontent.com/44076375/163850613-df4eaba3-bcbc-438b-8165-5107ec413ec1.png)
