### PR TITLE
Summary stat hover fix

### DIFF
--- a/src/components/NewLocationPage/LocationOverview/LocationOverview.style.tsx
+++ b/src/components/NewLocationPage/LocationOverview/LocationOverview.style.tsx
@@ -55,7 +55,7 @@ const ClickableItemStyles = css`
   cursor: pointer;
   &:hover {
     ${Chevron} {
-      transform: translate(6px, 5.5px);
+      transform: translate(6px, -1px);
       transition: transform 0.06s ease-in-out;
     }
   }

--- a/src/components/NewLocationPage/SummaryStat/MobileSummaryStat.tsx
+++ b/src/components/NewLocationPage/SummaryStat/MobileSummaryStat.tsx
@@ -1,8 +1,12 @@
 import React from 'react';
 import MetricSubLabel from './MetricSubLabel';
 import MetricValue from './MetricValue';
-import { MetricLabel, StatContent, Row } from './SummaryStat.style';
-import { Chevron } from '../Shared/Shared.style';
+import {
+  MetricLabel,
+  StatContent,
+  Row,
+  CondensedChevron,
+} from './SummaryStat.style';
 import { metricSubLabelText, SummaryStatProps } from './utils';
 
 const MobileSummaryStat: React.FC<SummaryStatProps> = ({
@@ -25,7 +29,7 @@ const MobileSummaryStat: React.FC<SummaryStatProps> = ({
           iconColor={levelInfo.color}
           metric={metric}
         />
-        <Chevron />
+        <CondensedChevron />
       </Row>
     </StatContent>
   );


### PR DESCRIPTION
I edited the placement of the chevron icon but didn't make the same edit in its hover state, so hovering a summary stat makes the chevron animate diagonally (see here by hovering a summary stat). This pr fixes