### PR TITLE
Remove extra fields from summaries file.

### DIFF
--- a/src/common/location_summaries.ts
+++ b/src/common/location_summaries.ts
@@ -15,11 +15,8 @@ export interface LocationSummary {
   metrics: {
     [metric in Metric]?: MetricSummary;
   };
-  ccvi: number | null;
   /** vaccinationsCompleted */
   vc: number | null;
-  /** hospitalizations density */
-  hd: number | null;
 }
 
 export type SummariesMap = { [fips: string]: LocationSummary };

--- a/src/common/models/Projections.ts
+++ b/src/common/models/Projections.ts
@@ -63,7 +63,13 @@ export class Projections {
    */
   summary(ccvi: number): LocationSummary {
     const metrics = {} as { [metric in Metric]: MetricSummary };
-    for (const metric of ALL_METRICS) {
+    const summaryMetrics = [
+      Metric.ADMISSIONS_PER_100K,
+      Metric.RATIO_BEDS_WITH_COVID,
+      Metric.WEEKLY_CASES_PER_100K,
+      Metric.VACCINATIONS,
+    ];
+    for (const metric of summaryMetrics) {
       const value = this.getMetricValue(metric);
       const roundedValue = roundMetricValue(metric, value);
 
@@ -75,14 +81,10 @@ export class Projections {
 
     const vaccinationsCompleted =
       this.primary.vaccinationsInfo?.ratioVaccinated ?? null;
-    const hospitalizationsDensity =
-      this.primary.hospitalizationInfo?.hospitalizationsDensity ?? null;
     return {
       level: this.getAlarmLevel(),
       metrics,
-      ccvi,
       vc: vaccinationsCompleted,
-      hd: hospitalizationsDensity,
     };
   }
 


### PR DESCRIPTION
Should fix crash Sean noticed (see https://github.com/covid-projections/covid-projections/runs/6068853288?check_suite_focus=true).

It also just removes extra stuff we don't need from the summaries file which will speed up page loads.

Run with this branch: https://github.com/covid-projections/covid-projections/runs/6068807801?check_suite_focus=true