### PR TITLE
Add percent positivity and infection rate to `summaries.json` file

### DIFF
--- a/src/common/models/Projections.ts
+++ b/src/common/models/Projections.ts
@@ -68,6 +68,8 @@ export class Projections {
       Metric.RATIO_BEDS_WITH_COVID,
       Metric.WEEKLY_CASES_PER_100K,
       Metric.VACCINATIONS,
+      Metric.CASE_GROWTH_RATE,
+      Metric.POSITIVE_TESTS,
     ];
     for (const metric of summaryMetrics) {
       const value = this.getMetricValue(metric);


### PR DESCRIPTION
Metric tabs were empty/missing due to metrics being removed from `summaries.json` file during cleanup. 

before (prod):
<img width="959" alt="image" src="https://user-images.githubusercontent.com/55333380/164023529-4ee36b93-1d33-449b-84f5-66c2f316ee05.png">

after:
<img width="959" alt="image" src="https://user-images.githubusercontent.com/55333380/164023617-85a19d29-cc5d-49f7-9026-f623a432de8f.png">
