### PR TITLE
Increase `--max-old-space-size` to fix " Update to new data snapshot" action

### DIFF
--- a/.github/workflows/update-snapshot.yml
+++ b/.github/workflows/update-snapshot.yml
@@ -12,6 +12,8 @@ env:
   SNAPSHOT_ID: ${{ github.event.inputs.snapshot_id }}
   # Used in the shared images URL and in the PR branch.
   RUN_ID: ${{ github.event.inputs.snapshot_id }}-${{github.run_number}}
+  # 4gb might be overkill, the default is 512mb, but this works.
+  NODE_OPTIONS: "--max-old-space-size=4096"
 
 jobs:
   update-data-snapshot:


### PR DESCRIPTION
Fixes out of memory issue reintroduced in #5619 for the snapshot updater action

Solution from https://stackoverflow.com/questions/53230823/fatal-error-ineffective-mark-compacts-near-heap-limit-allocation-failed-javas