### PR TITLE
update script to generate the list of alert subscribers

### DIFF
--- a/scripts/alert_emails_report/generate-subscriber-emails-file.ts
+++ b/scripts/alert_emails_report/generate-subscriber-emails-file.ts
@@ -1,13 +1,18 @@
+import fs from 'fs';
 import _ from 'lodash';
 import { fetchAllAlertSubscriptions } from '../alert_emails/firestore';
 import { getFirestore } from '../common/firebase';
+import { isValidEmail } from '../../src/common/utils';
 
 async function main() {
   const db = getFirestore();
   const subscriptions = await fetchAllAlertSubscriptions(db);
-  const fs = require('fs');
-  const output = subscriptions.map(s => s.email).join(',');
-  fs.writeFileSync('subscriber-emails.txt', output);
+  const emailsCsvColumn = subscriptions
+    .map(s => s.email)
+    .filter(isValidEmail)
+    .join('\n');
+
+  fs.writeFileSync('subscriber-emails.csv', emailsCsvColumn);
 }
 
 if (require.main === module) {

--- a/scripts/alert_emails_report/generate-subscriber-emails-file.ts
+++ b/scripts/alert_emails_report/generate-subscriber-emails-file.ts
@@ -11,7 +11,6 @@
  *    yarn generate-subscriber-emails-file
  */
 import fs from 'fs';
-import _ from 'lodash';
 import { fetchAllAlertSubscriptions } from '../alert_emails/firestore';
 import { getFirestore } from '../common/firebase';
 import { isValidEmail } from '../../src/common/utils';

--- a/scripts/alert_emails_report/generate-subscriber-emails-file.ts
+++ b/scripts/alert_emails_report/generate-subscriber-emails-file.ts
@@ -1,3 +1,15 @@
+/**
+ * Generates a CSV file with the email addresses of all the subscribers to
+ * the alert emails.
+ *
+ * In order to run the script, you need to have a valid Google service account
+ * file in the `scripts/common/firebase` directory. Make sure that the file
+ * corresponds to the environment that you want to use to run the script.
+ *
+ * Usage:
+ *
+ *    yarn generate-subscriber-emails-file
+ */
 import fs from 'fs';
 import _ from 'lodash';
 import { fetchAllAlertSubscriptions } from '../alert_emails/firestore';

--- a/scripts/alert_emails_report/generate-subscriber-emails-file.ts
+++ b/scripts/alert_emails_report/generate-subscriber-emails-file.ts
@@ -9,6 +9,8 @@
  * Usage:
  *
  *    yarn generate-subscriber-emails-file
+ *
+ * - https://cloud.google.com/iam/docs/creating-managing-service-account-keys
  */
 import fs from 'fs';
 import { fetchAllAlertSubscriptions } from '../alert_emails/firestore';


### PR DESCRIPTION
Minor updates to the `scripts/alert_emails_report/generate-subscriber-emails-file.ts` script. 

### Changes

- Remove `lodash` import (it wasn't being used)  
- I filter out invalid emails when generating the list (the `isValidEmail` function is not very robust, but better than nothing)
- The emails are added in rows instead of columns (separating them by newlines `\n` instead of comma `,`)
- Added instructions on how to run it.

To test, make sure that you have a `google-service-account.json` file under `scripts/common/firebase` for the `covidactnow-dev` environment and then run

```sh
yarn generate-subscriber-emails-file
``` 

This will generate the `subscriber-emails.csv` file, which should have one email per line.