### PR TITLE
adjust style of title (metric share image)

### DIFF
--- a/src/screens/internal/ShareImage/ChartShareImage.style.ts
+++ b/src/screens/internal/ShareImage/ChartShareImage.style.ts
@@ -14,13 +14,13 @@ export const Headers = styled.div`
   margin-top: 20px;
 `;
 
-export const Title = styled.div`
+export const Title = styled.h1`
+  font-size: 18px;
+  line-height: 1.05;
   font-family: 'Roboto';
-  font-weight: bold;
-  font-size: 24px;
-  line-height: 18px;
   text-transform: capitalize;
   width: 400px;
+  margin-bottom: 0;
 `;
 
 export const ExploreTitle = styled(Title)`
@@ -33,7 +33,6 @@ export const ExploreTitle = styled(Title)`
 
 export const Subtitle = styled.div`
   margin-top: 5px;
-
   font-family: 'Source Code Pro';
   font-weight: 500;
   font-size: 16px;


### PR DESCRIPTION
Updating the style of the title for the share cards to ensure that the title doesn't overlap with itself when shown in 2 lines.

#### Weekly Cases

[Before](https://covidactnow.org/internal/share-image/states/washington-wa/chart/9) / [After](https://covid-projections-git-pablo-share-images-title-fix-covidactnow.vercel.app/internal/share-image/states/washington-wa/chart/9)

![image](https://user-images.githubusercontent.com/114084/164052297-d4f41f2d-fc12-49b3-bf46-1b7a73f284ee.png)

#### Admissions
[Before](https://covidactnow.org/internal/share-image/states/washington-wa/chart/8) / [After](https://covid-projections-git-pablo-share-images-title-fix-covidactnow.vercel.app/internal/share-image/states/washington-wa/chart/8)

![image](https://user-images.githubusercontent.com/114084/164052311-2145dade-d2cb-4484-baed-901f25bd8ebf.png)

#### Patients w/ COVID

[Before](https://covidactnow.org/internal/share-image/states/washington-wa/chart/7) / [After](https://covid-projections-git-pablo-share-images-title-fix-covidactnow.vercel.app/internal/share-image/states/washington-wa/chart/7)


![image](https://user-images.githubusercontent.com/114084/164052326-175cfdc7-7288-4026-aa5c-005f4930b703.png)
