### PR TITLE
Fix dropdown arrow bug

### DIFF
--- a/src/components/ShareBlock/ShareBlock.style.tsx
+++ b/src/components/ShareBlock/ShareBlock.style.tsx
@@ -1,8 +1,8 @@
 import styled, { css } from 'styled-components';
-import theme from 'assets/theme';
 
 export const ShareContainer = styled.div`
-  margin: ${theme.spacing(6)}px ${theme.spacing(3)}px ${theme.spacing(9)}px;
+  margin-top: 48px;
+  margin-bottom: 72px;
   @media print {
     display: none;
   }

--- a/src/components/ShareBlock/ShareBlock.style.tsx
+++ b/src/components/ShareBlock/ShareBlock.style.tsx
@@ -1,8 +1,8 @@
 import styled, { css } from 'styled-components';
+import theme from 'assets/theme';
 
 export const ShareContainer = styled.div`
-  margin-top: 48px;
-  margin-bottom: 72px;
+  margin: ${theme.spacing(6)}px ${theme.spacing(3)}px ${theme.spacing(9)}px;
   @media print {
     display: none;
   }

--- a/src/screens/Donate/Donate.tsx
+++ b/src/screens/Donate/Donate.tsx
@@ -66,9 +66,9 @@ const Donate: React.FC = () => {
               <BodyCopy source={section.copy} />
             </Fragment>
           ))}
-          <ShareModelBlock />
         </ContentWrapper>
       </Container>
+      <ShareModelBlock />
     </>
   );
 };

--- a/src/screens/Donate/Donate.tsx
+++ b/src/screens/Donate/Donate.tsx
@@ -17,6 +17,7 @@ import GiveButterEmbed from 'screens/Donate/GiveButterEmbed';
 import donateContent from 'cms-content/donate';
 import ShareModelBlock from 'components/ShareBlock/ShareModelBlock';
 import { DesktopOnlyDonateButton } from 'components/DonateButton';
+import { Box } from '@material-ui/core';
 
 const Intro: React.FC = () => {
   const { headerLines } = donateContent;
@@ -68,7 +69,9 @@ const Donate: React.FC = () => {
           ))}
         </ContentWrapper>
       </Container>
-      <ShareModelBlock />
+      <Box marginX={3}>
+        <ShareModelBlock />
+      </Box>
     </>
   );
 };


### PR DESCRIPTION
I think `<ShareModelBlock>` was restored and misplaced, where the CSS of other containing components messed with the arrow appearance and caused the whole get alerts block to not be centered.

Before:
![image](https://user-images.githubusercontent.com/46338131/164068504-1bbdda2d-5058-4e06-812a-486f80feac60.png)

After:
![image](https://user-images.githubusercontent.com/46338131/164068697-b16dd63a-f572-4636-8945-d7f746e4d477.png)