### PR TITLE
Update geolocated cards

### DIFF
--- a/src/components/RegionItem/RegionItem.tsx
+++ b/src/components/RegionItem/RegionItem.tsx
@@ -13,21 +13,29 @@ import { Region, State } from 'common/regions';
 import { StyledRegionName } from 'components/SharedComponents';
 import { getSummaryFromFips } from 'common/location_summaries';
 import { EventAction, EventCategory, trackEvent } from 'components/Analytics';
-import { vaccineColorFromLocationSummary } from 'common/colors';
-import { summaryToStats } from 'components/NewLocationPage/SummaryStat/utils';
-import { Metric } from 'common/metricEnum';
-import { formatPercent } from 'common/utils';
+import { colorFromLocationSummary } from 'common/colors';
+import { Level } from 'common/level';
+
+function getLevelName(level: Level): string {
+  switch (level) {
+    case Level.LOW:
+      return 'Low';
+    case Level.MEDIUM:
+      return 'Medium';
+    case Level.HIGH:
+      return 'High';
+    default:
+      return 'Unknown';
+  }
+}
 
 const RegionItem: React.FC<{ region: Region }> = ({ region }) => {
   const regionSummary = getSummaryFromFips(region.fipsCode);
   const showStateCode = !(region instanceof State);
-  const iconColor = vaccineColorFromLocationSummary(regionSummary);
+  const iconColor = colorFromLocationSummary(regionSummary);
 
-  const vaccinatedStat = regionSummary
-    ? summaryToStats(regionSummary)[Metric.VACCINATIONS]
-    : null;
-  const levelDescriptionCopy = vaccinatedStat
-    ? `${formatPercent(vaccinatedStat, 0)} with 1+ dose`
+  const levelDescriptionCopy = regionSummary
+    ? `${getLevelName(regionSummary.level)} community level`
     : '';
 
   return (
@@ -48,7 +56,7 @@ const RegionItem: React.FC<{ region: Region }> = ({ region }) => {
             showStateCode={showStateCode}
             truncateText
           />
-          {vaccinatedStat && (
+          {regionSummary && (
             <LevelContainer>
               <IconContainer>
                 <CircleIcon $iconColor={iconColor} />

--- a/src/components/RegionItem/RegionItem.tsx
+++ b/src/components/RegionItem/RegionItem.tsx
@@ -14,20 +14,7 @@ import { StyledRegionName } from 'components/SharedComponents';
 import { getSummaryFromFips } from 'common/location_summaries';
 import { EventAction, EventCategory, trackEvent } from 'components/Analytics';
 import { colorFromLocationSummary } from 'common/colors';
-import { Level } from 'common/level';
-
-function getLevelName(level: Level): string {
-  switch (level) {
-    case Level.LOW:
-      return 'Low';
-    case Level.MEDIUM:
-      return 'Medium';
-    case Level.HIGH:
-      return 'High';
-    default:
-      return 'Unknown';
-  }
-}
+import { LOCATION_SUMMARY_LEVELS } from 'common/metrics/location_summary';
 
 const RegionItem: React.FC<{ region: Region }> = ({ region }) => {
   const regionSummary = getSummaryFromFips(region.fipsCode);
@@ -35,7 +22,7 @@ const RegionItem: React.FC<{ region: Region }> = ({ region }) => {
   const iconColor = colorFromLocationSummary(regionSummary);
 
   const levelDescriptionCopy = regionSummary
-    ? `${getLevelName(regionSummary.level)} community level`
+    ? `${LOCATION_SUMMARY_LEVELS[regionSummary.level].name} community level`
     : '';
 
   return (


### PR DESCRIPTION
Update geolocated cards on the homepage to display community level instead of vaccination metric, as per [card](https://trello.com/c/OEUhP0m1/598-geolocation-cards-should-probably-show-community-level-color-not-vaccine).

![image](https://user-images.githubusercontent.com/46338131/164302429-96af49ff-398e-41ca-84a5-2ea89643911f.png)
