### PR TITLE
Add color dot indicators to chart tabs

### DIFF
--- a/src/components/Charts/Groupings.tsx
+++ b/src/components/Charts/Groupings.tsx
@@ -13,7 +13,7 @@ import {
 import ChartTab from 'components/NewLocationPage/ChartTabs/ChartTab';
 import { MetricValues } from 'common/models/Projections';
 import { getAveragedSeriesForMetric } from 'components/Explore/utils';
-import { formatValue, getMetricName } from 'common/metric';
+import { formatValue, getMetricName, getLevelInfo } from 'common/metric';
 import { last } from 'components/Charts/utils';
 import { formatDecimal } from 'common/utils';
 import VaccinationChartTabs from 'components/NewLocationPage/ChartTabs/VaccinationChartTabs';
@@ -188,7 +188,7 @@ export function getValueInfo(
   const { metric, metricType } = metricItem;
   if (metricType === MetricType.KEY_METRIC) {
     const statValue = stats[metric as Metric];
-    // const levelInfo = getLevelInfo(metric as Metric, statValue);
+    const levelInfo = getLevelInfo(metric as Metric, statValue);
     const formattedValue = formatValue(
       metric as Metric,
       statValue,
@@ -197,7 +197,7 @@ export function getValueInfo(
     return {
       unformattedValue: statValue,
       formattedValue,
-      // levelColor: levelInfo.color,
+      levelColor: levelInfo.color,
     };
   } else {
     const smoothedSeries = getAveragedSeriesForMetric(

--- a/src/components/Charts/Groupings.tsx
+++ b/src/components/Charts/Groupings.tsx
@@ -118,6 +118,7 @@ export const CHART_GROUPS: ChartGroup[] = [
           <ChartTab
             metricName="Daily New Cases per 100k"
             metricValueInfo={metricValue}
+            showColorIndicator={false}
           />
         ),
         renderChart: projections => (
@@ -134,6 +135,7 @@ export const CHART_GROUPS: ChartGroup[] = [
           <ChartTab
             metricName={getMetricNameForStat(Metric.CASE_GROWTH_RATE)}
             metricValueInfo={metricValue}
+            showColorIndicator={false}
           />
         ),
         renderChart: projections => (
@@ -150,6 +152,7 @@ export const CHART_GROUPS: ChartGroup[] = [
           <ChartTab
             metricName={getMetricNameForStat(Metric.POSITIVE_TESTS)}
             metricValueInfo={metricValue}
+            showColorIndicator={false}
           />
         ),
         renderChart: projections => (

--- a/src/components/NewLocationPage/ChartTabs/ChartTab.tsx
+++ b/src/components/NewLocationPage/ChartTabs/ChartTab.tsx
@@ -14,7 +14,8 @@ const ChartTab: React.FC<{
   metricName: string;
   subLabel?: string[];
   metricValueInfo: ValueInfo;
-}> = ({ metricName, subLabel, metricValueInfo }) => {
+  showColorIndicator?: boolean;
+}> = ({ metricName, subLabel, metricValueInfo, showColorIndicator = true }) => {
   const isMobile = useBreakpoint(600);
 
   return (
@@ -26,7 +27,7 @@ const ChartTab: React.FC<{
         )}
       </TabTitle>
       <TabContent>
-        {metricValueInfo.levelColor && (
+        {showColorIndicator && metricValueInfo.levelColor && (
           <CircleIcon $iconColor={metricValueInfo.levelColor} />
         )}
         <Value>{metricValueInfo.formattedValue}</Value>


### PR DESCRIPTION
Add color dot indicators to chart tabs, as per [card](https://trello.com/c/yD9uJhYw/606-add-color-dot-indicators-to-community-levels-section).