### PR TITLE
Alphabetize metric dropdown

### DIFF
--- a/src/components/Explore/Explore.tsx
+++ b/src/components/Explore/Explore.tsx
@@ -308,7 +308,7 @@ const Explore: React.FunctionComponent<{
             buttonSelectionLabel={metricMenuLabel}
             itemLabels={metricLabels}
             onSelect={onSelectCurrentMetric}
-            maxWidth={250}
+            maxWidth={336}
           />
           <Dropdown
             menuLabel="Past # of days"
@@ -321,7 +321,7 @@ const Explore: React.FunctionComponent<{
             regions={autocompleteLocations}
             selectedRegions={selectedLocations}
             onChangeSelectedRegions={onChangeSelectedLocations}
-            maxWidth={400}
+            maxWidth={314}
             regionNamesMenuLabel={regionsMenuLabel}
           />
         </Styles.ChartControlsContainer>

--- a/src/components/Explore/utils.ts
+++ b/src/components/Explore/utils.ts
@@ -85,20 +85,20 @@ export function getDateRange(period: Period): Date[] {
 }
 
 export const EXPLORE_METRICS = [
-  ExploreMetric.RATIO_BEDS_WITH_COVID,
-  ExploreMetric.ADMISSIONS_PER_100K,
-  ExploreMetric.WEEKLY_DEATHS,
-  ExploreMetric.WEEKLY_CASES,
   ExploreMetric.CASES,
+  ExploreMetric.DAILY_CASES_PER_100K,
   ExploreMetric.DEATHS,
   ExploreMetric.HOSPITALIZATIONS,
+  ExploreMetric.ICU_USED,
   ExploreMetric.ICU_HOSPITALIZATIONS,
+  ExploreMetric.RATIO_BEDS_WITH_COVID,
   ExploreMetric.VACCINATIONS_FIRST_DOSE,
   ExploreMetric.VACCINATIONS_COMPLETED,
   ExploreMetric.VACCINATIONS_ADDITIONAL_DOSE,
-  ExploreMetric.ICU_USED,
   ExploreMetric.POSITIVITY_RATE,
-  ExploreMetric.DAILY_CASES_PER_100K,
+  ExploreMetric.ADMISSIONS_PER_100K,
+  ExploreMetric.WEEKLY_DEATHS,
+  ExploreMetric.WEEKLY_CASES,
 ];
 
 // Note that these specifically are counts, not percentages, and can normalized


### PR DESCRIPTION
Alphabetize metric dropdown in explore and widen the dropdown menu to prevent wrapping, as per [card](https://trello.com/c/vlSH46La/574-alphabetize-and-widen-the-trends-dropdown-menu).