### PR TITLE
Fix share link scrolling functionality 

### DIFF
--- a/src/components/Charts/ChartBlock.tsx
+++ b/src/components/Charts/ChartBlock.tsx
@@ -26,32 +26,9 @@ const ChartBlock: React.FC<{
   projections: Projections;
   group: ChartGroup;
   clickedStatMetric: Metric | null;
-  chartIdFromUrl: Metric;
-}> = ({
-  projections,
-  stats,
-  group,
-  region,
-  clickedStatMetric,
-  chartIdFromUrl,
-}) => {
+  chartId?: string;
+}> = ({ projections, stats, group, region, clickedStatMetric, chartId }) => {
   const { metricList, groupHeader } = group;
-
-  useEffect(() => {
-    const metricsInMetricList = metricList.map(
-      metricListItem => metricListItem.metric,
-    );
-    if (metricsInMetricList.includes((chartIdFromUrl as unknown) as number)) {
-      console.log('metricsInMetricList', metricsInMetricList);
-      console.log('chartIdFromUrl', chartIdFromUrl);
-      console.log('yes');
-      const idx = findIndex(metricList, item => item.metric === chartIdFromUrl);
-      console.log('idx', idx);
-      setActiveTabIndex(idx);
-    } else {
-      console.log('no');
-    }
-  }, [chartIdFromUrl, metricList]);
 
   // TODO (chelsi) - revisit placement of these state/setState variables
   const [activeTabIndex, setActiveTabIndex] = useState(0);
@@ -81,6 +58,21 @@ const ChartBlock: React.FC<{
     projections,
   );
   const hasValue = Number.isFinite(unformattedValue);
+
+  // Checks if url is a chart-share-link (ie. it contains a chartId)
+  // If so - selects tab of respective metric's chart tab
+  useEffect(() => {
+    const metricsInMetricListAsString = metricList
+      .map(metricListItem => metricListItem.metric)
+      .map(item => item.toString());
+    if (chartId && metricsInMetricListAsString.includes(chartId)) {
+      const idx = findIndex(
+        metricsInMetricListAsString,
+        item => item === chartId,
+      );
+      setActiveTabIndex(idx);
+    }
+  }, [activeTabIndex, chartId, metricList]);
 
   return (
     <>

--- a/src/components/Charts/ChartBlock.tsx
+++ b/src/components/Charts/ChartBlock.tsx
@@ -67,21 +67,27 @@ const ChartBlock: React.FC<{
   // Checks if url is a chart-share-link (ie. it contains a chartId)
   // If so - selects tab of respective metric's chart tab
   useEffect(() => {
-    // Turn all metrics into strings so we check for equivalence against chartId
-    const metricsInMetricListAsString = metricList
-      .map(metricListItem => metricListItem.metric)
-      .map(item => item.toString());
-    if (
-      chartId &&
-      metricsInMetricListAsString.includes(chartId) &&
-      !hasSelectedSharedTab
-    ) {
-      const idx = findIndex(
-        metricsInMetricListAsString,
-        item => item === chartId,
+    if (!chartId) {
+      return;
+    } else {
+      // Turn all metrics into strings so we check for equivalence against chartId
+      const metricsInMetricListAsString = metricList.map(item =>
+        item.metric.toString(),
       );
-      setActiveTabIndex(idx);
-      setHasSelectedSharedTab(true);
+      if (
+        chartId &&
+        metricsInMetricListAsString.includes(chartId) &&
+        !hasSelectedSharedTab
+      ) {
+        const idx = findIndex(
+          metricsInMetricListAsString,
+          item => item === chartId,
+        );
+        if (idx >= 0) {
+          setActiveTabIndex(idx);
+          setHasSelectedSharedTab(true);
+        }
+      }
     }
   }, [activeTabIndex, chartId, metricList, hasSelectedSharedTab]);
 

--- a/src/components/Charts/ChartBlock.tsx
+++ b/src/components/Charts/ChartBlock.tsx
@@ -59,6 +59,11 @@ const ChartBlock: React.FC<{
   );
   const hasValue = Number.isFinite(unformattedValue);
 
+  // Used to make sure user can change tabs after landing on a page via a share link (and having a tab auto-selected)
+  const [hasSelectedSharedTab, setHasSelectedSharedTab] = useState<boolean>(
+    false,
+  );
+
   // Checks if url is a chart-share-link (ie. it contains a chartId)
   // If so - selects tab of respective metric's chart tab
   useEffect(() => {
@@ -66,14 +71,19 @@ const ChartBlock: React.FC<{
     const metricsInMetricListAsString = metricList
       .map(metricListItem => metricListItem.metric)
       .map(item => item.toString());
-    if (chartId && metricsInMetricListAsString.includes(chartId)) {
+    if (
+      chartId &&
+      metricsInMetricListAsString.includes(chartId) &&
+      !hasSelectedSharedTab
+    ) {
       const idx = findIndex(
         metricsInMetricListAsString,
         item => item === chartId,
       );
       setActiveTabIndex(idx);
+      setHasSelectedSharedTab(true);
     }
-  }, [activeTabIndex, chartId, metricList]);
+  }, [activeTabIndex, chartId, metricList, hasSelectedSharedTab]);
 
   return (
     <>

--- a/src/components/Charts/ChartBlock.tsx
+++ b/src/components/Charts/ChartBlock.tsx
@@ -62,6 +62,7 @@ const ChartBlock: React.FC<{
   // Checks if url is a chart-share-link (ie. it contains a chartId)
   // If so - selects tab of respective metric's chart tab
   useEffect(() => {
+    // Turn all metrics into strings so we check for equivalence against chartId
     const metricsInMetricListAsString = metricList
       .map(metricListItem => metricListItem.metric)
       .map(item => item.toString());

--- a/src/components/Charts/ChartBlock.tsx
+++ b/src/components/Charts/ChartBlock.tsx
@@ -26,8 +26,32 @@ const ChartBlock: React.FC<{
   projections: Projections;
   group: ChartGroup;
   clickedStatMetric: Metric | null;
-}> = ({ projections, stats, group, region, clickedStatMetric }) => {
+  chartIdFromUrl: Metric;
+}> = ({
+  projections,
+  stats,
+  group,
+  region,
+  clickedStatMetric,
+  chartIdFromUrl,
+}) => {
   const { metricList, groupHeader } = group;
+
+  useEffect(() => {
+    const metricsInMetricList = metricList.map(
+      metricListItem => metricListItem.metric,
+    );
+    if (metricsInMetricList.includes((chartIdFromUrl as unknown) as number)) {
+      console.log('metricsInMetricList', metricsInMetricList);
+      console.log('chartIdFromUrl', chartIdFromUrl);
+      console.log('yes');
+      const idx = findIndex(metricList, item => item.metric === chartIdFromUrl);
+      console.log('idx', idx);
+      setActiveTabIndex(idx);
+    } else {
+      console.log('no');
+    }
+  }, [chartIdFromUrl, metricList]);
 
   // TODO (chelsi) - revisit placement of these state/setState variables
   const [activeTabIndex, setActiveTabIndex] = useState(0);

--- a/src/components/Charts/Groupings.tsx
+++ b/src/components/Charts/Groupings.tsx
@@ -51,6 +51,16 @@ export interface ChartGroup {
   metricList: MetricChartInfo[];
 }
 
+// function getGroupHeaderFromMetric (metric:Metric): GroupHeader {
+//   const groupObj = find(CHART_GROUPS, group => find(group.metricList, listItem => listItem.metric === metric))
+//   if (!groupObj){
+//   return GroupHeader.COMMUNITY_LEVEL
+// } else {
+//   // return groupObj.groupHeader
+//   return GroupHeader.COMMUNITY_LEVEL
+// }
+// }
+
 export const CHART_GROUPS: ChartGroup[] = [
   {
     groupHeader: GroupHeader.COMMUNITY_LEVEL,

--- a/src/components/Charts/Groupings.tsx
+++ b/src/components/Charts/Groupings.tsx
@@ -51,16 +51,6 @@ export interface ChartGroup {
   metricList: MetricChartInfo[];
 }
 
-// function getGroupHeaderFromMetric (metric:Metric): GroupHeader {
-//   const groupObj = find(CHART_GROUPS, group => find(group.metricList, listItem => listItem.metric === metric))
-//   if (!groupObj){
-//   return GroupHeader.COMMUNITY_LEVEL
-// } else {
-//   // return groupObj.groupHeader
-//   return GroupHeader.COMMUNITY_LEVEL
-// }
-// }
-
 export const CHART_GROUPS: ChartGroup[] = [
   {
     groupHeader: GroupHeader.COMMUNITY_LEVEL,

--- a/src/components/LocationPage/ChartsHolder.tsx
+++ b/src/components/LocationPage/ChartsHolder.tsx
@@ -73,6 +73,7 @@ const ChartsHolder = React.memo(({ region, chartId }: ChartsHolderProps) => {
     [],
   );
 
+  // A map of each metric to the ref of its chart group
   const metricRefs = useMemo(
     () => ({
       [Metric.CASE_DENSITY]: transmissionMetricsRef,

--- a/src/components/LocationPage/ChartsHolder.tsx
+++ b/src/components/LocationPage/ChartsHolder.tsx
@@ -58,7 +58,6 @@ interface ChartsHolderProps {
 
 const ChartsHolder = React.memo(({ region, chartId }: ChartsHolderProps) => {
   const projections = useProjectionsFromRegion(region);
-  console.log('chartId', chartId);
 
   const locationSummary = useLocationSummariesForFips(region.fipsCode);
 
@@ -108,15 +107,12 @@ const ChartsHolder = React.memo(({ region, chartId }: ChartsHolderProps) => {
 
   const [scrolledWithUrl, setScrolledWithUrl] = useState(false);
 
-  const chartIdFromUrl = (chartId as unknown) as Metric;
-
   useEffect(() => {
     const scrollToChart = () => {
       const timeoutId = setTimeout(() => {
         if (chartId in metricRefs) {
-          const metricGroupRef = metricRefs[chartIdFromUrl];
+          const metricGroupRef = metricRefs[(chartId as unknown) as Metric];
           if (metricGroupRef.current && !scrolledWithUrl) {
-            console.log('metricGroupRef.current');
             setScrolledWithUrl(true);
             scrollTo(metricGroupRef.current);
           }
@@ -126,7 +122,7 @@ const ChartsHolder = React.memo(({ region, chartId }: ChartsHolderProps) => {
     };
 
     scrollToChart();
-  }, [chartId, chartIdFromUrl, metricRefs, scrolledWithUrl]);
+  }, [chartId, metricRefs, scrolledWithUrl]);
 
   useScrollToRecommendations(recommendationsRef);
 
@@ -239,7 +235,7 @@ const ChartsHolder = React.memo(({ region, chartId }: ChartsHolderProps) => {
                         stats={stats}
                         group={group}
                         clickedStatMetric={clickedStatMetric}
-                        chartIdFromUrl={chartIdFromUrl}
+                        chartId={chartId}
                       />
                     </LocationPageBlock>
                   )}

--- a/src/components/LocationPage/ChartsHolder.tsx
+++ b/src/components/LocationPage/ChartsHolder.tsx
@@ -62,24 +62,28 @@ const ChartsHolder = React.memo(({ region, chartId }: ChartsHolderProps) => {
 
   const locationSummary = useLocationSummariesForFips(region.fipsCode);
 
-  const caseDensityRef = useRef<HTMLDivElement>(null);
-  const caseGrowthRateRef = useRef<HTMLDivElement>(null);
-  const positiveTestsRef = useRef<HTMLDivElement>(null);
-  const hospitalUsageRef = useRef<HTMLDivElement>(null);
-  const vaccinationsRef = useRef<HTMLDivElement>(null);
-  const weeklyNewCasesRef = useRef<HTMLDivElement>(null);
-  const admissionsPer100kRef = useRef<HTMLDivElement>(null);
-  const ratioBedsWithCovidRef = useRef<HTMLDivElement>(null);
+  const communityMetricsRef = useRef<HTMLDivElement>(null);
+  const vaccinationsBlockRef = useRef<HTMLDivElement>(null);
+  const transmissionMetricsRef = useRef<HTMLDivElement>(null);
+  const chartBlockRefs = useMemo(
+    () => ({
+      [GroupHeader.COMMUNITY_LEVEL]: communityMetricsRef,
+      [GroupHeader.VACCINATED]: vaccinationsBlockRef,
+      [GroupHeader.TRANSMISSION]: transmissionMetricsRef,
+    }),
+    [],
+  );
+
   const metricRefs = useMemo(
     () => ({
-      [Metric.CASE_DENSITY]: caseDensityRef,
-      [Metric.CASE_GROWTH_RATE]: caseGrowthRateRef,
-      [Metric.POSITIVE_TESTS]: positiveTestsRef,
-      [Metric.HOSPITAL_USAGE]: hospitalUsageRef,
-      [Metric.VACCINATIONS]: vaccinationsRef,
-      [Metric.WEEKLY_CASES_PER_100K]: weeklyNewCasesRef,
-      [Metric.ADMISSIONS_PER_100K]: admissionsPer100kRef,
-      [Metric.RATIO_BEDS_WITH_COVID]: ratioBedsWithCovidRef,
+      [Metric.CASE_DENSITY]: transmissionMetricsRef,
+      [Metric.CASE_GROWTH_RATE]: transmissionMetricsRef,
+      [Metric.POSITIVE_TESTS]: transmissionMetricsRef,
+      [Metric.HOSPITAL_USAGE]: transmissionMetricsRef,
+      [Metric.VACCINATIONS]: vaccinationsBlockRef,
+      [Metric.WEEKLY_CASES_PER_100K]: communityMetricsRef,
+      [Metric.ADMISSIONS_PER_100K]: communityMetricsRef,
+      [Metric.RATIO_BEDS_WITH_COVID]: communityMetricsRef,
     }),
     [],
   );
@@ -104,32 +108,17 @@ const ChartsHolder = React.memo(({ region, chartId }: ChartsHolderProps) => {
 
   const [scrolledWithUrl, setScrolledWithUrl] = useState(false);
 
-  // TODO(8.2) rename ref once group header is finalized // confirm that removing refs doesn't break anything
-  const communityMetricsRef = useRef<HTMLDivElement>(null);
-  const vaccinationsBlockRef = useRef<HTMLDivElement>(null);
-  const transmissionMetricsRef = useRef<HTMLDivElement>(null);
-  const chartBlockRefs = useMemo(
-    () => ({
-      [GroupHeader.COMMUNITY_LEVEL]: communityMetricsRef,
-      [GroupHeader.VACCINATED]: vaccinationsBlockRef,
-      [GroupHeader.TRANSMISSION]: transmissionMetricsRef,
-    }),
-    [],
-  );
-
-  //chartBlockRefs[groupHeader] --> ref, scroll to that ref
+  const chartIdFromUrl = (chartId as unknown) as Metric;
 
   useEffect(() => {
     const scrollToChart = () => {
-      const metricRef = metricRefs[(chartId as unknown) as Metric];
       const timeoutId = setTimeout(() => {
         if (chartId in metricRefs) {
-          if (metricRef.current) {
-            console.log('CURRENT');
+          const metricGroupRef = metricRefs[chartIdFromUrl];
+          if (metricGroupRef.current && !scrolledWithUrl) {
+            console.log('metricGroupRef.current');
             setScrolledWithUrl(true);
-            scrollTo(metricRef.current);
-          } else {
-            console.log('IN THE ELSE');
+            scrollTo(metricGroupRef.current);
           }
         }
       }, 1000);
@@ -137,7 +126,7 @@ const ChartsHolder = React.memo(({ region, chartId }: ChartsHolderProps) => {
     };
 
     scrollToChart();
-  }, [chartId, metricRefs, scrolledWithUrl]);
+  }, [chartId, chartIdFromUrl, metricRefs, scrolledWithUrl]);
 
   useScrollToRecommendations(recommendationsRef);
 
@@ -250,6 +239,7 @@ const ChartsHolder = React.memo(({ region, chartId }: ChartsHolderProps) => {
                         stats={stats}
                         group={group}
                         clickedStatMetric={clickedStatMetric}
+                        chartIdFromUrl={chartIdFromUrl}
                       />
                     </LocationPageBlock>
                   )}

--- a/src/components/LocationPage/ChartsHolder.tsx
+++ b/src/components/LocationPage/ChartsHolder.tsx
@@ -58,6 +58,7 @@ interface ChartsHolderProps {
 
 const ChartsHolder = React.memo(({ region, chartId }: ChartsHolderProps) => {
   const projections = useProjectionsFromRegion(region);
+  console.log('chartId', chartId);
 
   const locationSummary = useLocationSummariesForFips(region.fipsCode);
 
@@ -116,17 +117,22 @@ const ChartsHolder = React.memo(({ region, chartId }: ChartsHolderProps) => {
     [],
   );
 
+  //chartBlockRefs[groupHeader] --> ref, scroll to that ref
+
   useEffect(() => {
     const scrollToChart = () => {
+      const metricRef = metricRefs[(chartId as unknown) as Metric];
       const timeoutId = setTimeout(() => {
         if (chartId in metricRefs) {
-          const metricRef = metricRefs[(chartId as unknown) as Metric];
-          if (metricRef.current && !scrolledWithUrl) {
+          if (metricRef.current) {
+            console.log('CURRENT');
             setScrolledWithUrl(true);
             scrollTo(metricRef.current);
+          } else {
+            console.log('IN THE ELSE');
           }
         }
-      }, 200);
+      }, 1000);
       return () => clearTimeout(timeoutId);
     };
 


### PR DESCRIPTION
Trello: https://trello.com/c/VJ1QU320/603-share-links-dont-navigate-the-user-to-the-corresponding-metric

For QA:
[Not a share URL](https://covid-projections-git-casulin-chart-scrolling-covidactnow.vercel.app/us/new_york-ny/?s=32582081)
[Invalid share URL](https://covid-projections-git-casulin-chart-scrolling-covidactnow.vercel.app/us/new_york-ny/chart/17?s=32582081)
[Weekly new cases](https://covid-projections-git-casulin-chart-scrolling-covidactnow.vercel.app/us/new_york-ny/chart/9?s=32582081)
[Weekly covid admissions](https://covid-projections-git-casulin-chart-scrolling-covidactnow.vercel.app/us/new_york-ny/chart/8?s=32582081)
[Patients w/ covid](https://covid-projections-git-casulin-chart-scrolling-covidactnow.vercel.app/us/new_york-ny/chart/7?s=32582081)
[Daily new cases](https://covid-projections-git-casulin-chart-scrolling-covidactnow.vercel.app/us/new_york-ny/chart/5?s=32582081)
[Infection rate](https://covid-projections-git-casulin-chart-scrolling-covidactnow.vercel.app/us/new_york-ny/chart/0?s=32582081)
[Positive test rate](https://covid-projections-git-casulin-chart-scrolling-covidactnow.vercel.app/us/new_york-ny/chart/1?s=32582081)
[Vaccinations](https://covid-projections-git-casulin-chart-scrolling-covidactnow.vercel.app/us/new_york-ny/chart/6?s=32582081)