### PR TITLE
Optimize the y-axis limit of Patients w/ Covid chart

### DIFF
--- a/src/components/Charts/ChartRatioBedsWithCovidPatients.tsx
+++ b/src/components/Charts/ChartRatioBedsWithCovidPatients.tsx
@@ -4,8 +4,8 @@ import { formatPercent } from 'common/utils';
 import { Column } from 'common/models/Projection';
 import { RATIO_BEDS_WITH_COVID_PATIENTS_LEVEL_INFO_MAP } from 'common/metrics/ratio_beds_with_covid_patients';
 
-// TODO(8.2) - confirm thresholds/chart/tooltip content, y-cap
-const CAP_Y = 1;
+// Add CAP_PADDING% extra padding above the maximum chart value
+const CAP_PADDING = 0.05;
 
 const getPointText = (valueY: number) => formatPercent(valueY, 1);
 
@@ -14,6 +14,15 @@ const getTooltipContent = (valueY: number) => ({
   body: `${formatPercent(valueY, 0)} of all beds`,
   width: '125px',
 });
+
+const maxColumnValue = (data: Column[]) => {
+  return Math.max.apply(
+    null,
+    data.map(function (column) {
+      return column.y;
+    }),
+  );
+};
 
 const ChartRatioBedsWithCovidPatients = ({
   columnData,
@@ -25,7 +34,7 @@ const ChartRatioBedsWithCovidPatients = ({
   <ChartZones
     height={height}
     columnData={columnData}
-    capY={CAP_Y}
+    capY={maxColumnValue(columnData) + CAP_PADDING}
     zones={RATIO_BEDS_WITH_COVID_PATIENTS_LEVEL_INFO_MAP}
     getTooltipContent={getTooltipContent}
     getPointText={getPointText}

--- a/src/components/Charts/ChartRatioBedsWithCovidPatients.tsx
+++ b/src/components/Charts/ChartRatioBedsWithCovidPatients.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import max from 'lodash/max';
 import ChartZones from './ChartZones';
 import { formatPercent } from 'common/utils';
 import { Column } from 'common/models/Projection';
@@ -6,6 +7,8 @@ import { RATIO_BEDS_WITH_COVID_PATIENTS_LEVEL_INFO_MAP } from 'common/metrics/ra
 
 // Add (100 * CAP_PADDING)% extra padding above the maximum chart value
 const CAP_PADDING = 0.05;
+const MIN_Y_LIMIT = 0.2; // 20%
+const maxColumnValue = (data: Column[]) => max(data.map(col => col.y));
 
 const getPointText = (valueY: number) => formatPercent(valueY, 1);
 
@@ -14,15 +17,6 @@ const getTooltipContent = (valueY: number) => ({
   body: `${formatPercent(valueY, 0)} of all beds`,
   width: '125px',
 });
-
-const maxColumnValue = (data: Column[]) => {
-  return Math.max.apply(
-    null,
-    data.map(function (column) {
-      return column.y;
-    }),
-  );
-};
 
 const ChartRatioBedsWithCovidPatients = ({
   columnData,
@@ -34,7 +28,7 @@ const ChartRatioBedsWithCovidPatients = ({
   <ChartZones
     height={height}
     columnData={columnData}
-    capY={maxColumnValue(columnData) + CAP_PADDING}
+    capY={Math.max(maxColumnValue(columnData) + CAP_PADDING, MIN_Y_LIMIT)}
     zones={RATIO_BEDS_WITH_COVID_PATIENTS_LEVEL_INFO_MAP}
     getTooltipContent={getTooltipContent}
     getPointText={getPointText}

--- a/src/components/Charts/ChartRatioBedsWithCovidPatients.tsx
+++ b/src/components/Charts/ChartRatioBedsWithCovidPatients.tsx
@@ -4,7 +4,7 @@ import { formatPercent } from 'common/utils';
 import { Column } from 'common/models/Projection';
 import { RATIO_BEDS_WITH_COVID_PATIENTS_LEVEL_INFO_MAP } from 'common/metrics/ratio_beds_with_covid_patients';
 
-// Add CAP_PADDING% extra padding above the maximum chart value
+// Add (100 * CAP_PADDING)% extra padding above the maximum chart value
 const CAP_PADDING = 0.05;
 
 const getPointText = (valueY: number) => formatPercent(valueY, 1);


### PR DESCRIPTION
Addresses https://trello.com/c/qJQcto7M/612-optimize-the-y-axis-limit-to-show-only-part-of-the-high-band-in-community-level-components

Limits the height of the Patients w/ Covid chart to the maximum value plus 5% extra padding. The ticket is a little vague on whether the limit should be dynamic or fixed (e.g. something like the old percent positivity chart that capped at 40%) so I can rework this if need be.