### PR TITLE
Move thermometer block up in explainer intro

### DIFF
--- a/src/screens/Learn/MetricExplainer/MetricExplainer.tsx
+++ b/src/screens/Learn/MetricExplainer/MetricExplainer.tsx
@@ -65,8 +65,8 @@ const MetricExplainer = () => {
         <ExplainersHeading2 id={introSection[0].sectionId}>
           {introSection[0].sectionHeader}
         </ExplainersHeading2>
-        <MarkdownContent source={introSection[0].sectionIntro} />
         <ThermometerIntro />
+        <MarkdownContent source={introSection[0].sectionIntro} />
         {introSection[0].questions &&
           introSection[0].questions.map(question => (
             <Fragment key={question.questionId}>


### PR DESCRIPTION
Moved thermometer block up in the metric explainer intro. This matches the content flow of other metrics in the metric explainer page.
![image](https://user-images.githubusercontent.com/46338131/164568185-7cf4c0ea-c2f9-4a7f-a6b3-3181fda49f0c.png).

**Note:** The [card](https://trello.com/c/5UN69VKf/614-move-position-of-thermometer-for-community-level-explainer-above-the-final-paragraph) says to only move the thermometer up by one paragraph. This is a bit tricky since that paragraph is part of one big CMS text block. To separate that paragraph, we might need to isolate it from the rest of the section intro (i.e. text beginning with "A state or county’s community level..." and text beginning with "Covid Act Now’s former COVID risk framework..." would be separate CMS sections), which I'm not sure is worth the effort.
