### PR TITLE
Add time period to shared component params

### DIFF
--- a/src/components/Explore/Explore.tsx
+++ b/src/components/Explore/Explore.tsx
@@ -228,6 +228,7 @@ const Explore: React.FunctionComponent<{
     const createSharedComponentId = async () => {
       return storeSharedComponentParams(SharedComponent.Explore, {
         currentMetric,
+        period,
         normalizeData,
         selectedFips: selectedLocations.map(location => location.fipsCode),
       });
@@ -266,6 +267,7 @@ const Explore: React.FunctionComponent<{
       if (sharedParams) {
         setCurrentMetric(sharedParams.currentMetric);
         setNormalizeData(sharedParams.normalizeData);
+        setPeriod(sharedParams.period);
         const locations = sharedParams.selectedFips.map(
           (fips: string) => regions.findByFipsCode(fips)!,
         );

--- a/src/screens/internal/ShareImage/ExploreChartExportImage.tsx
+++ b/src/screens/internal/ShareImage/ExploreChartExportImage.tsx
@@ -37,6 +37,7 @@ const ExploreChartExportImage = ({
   const lastUpdated = useModelLastUpdatedDate()!;
   const currentMetric = componentParams.currentMetric;
   const currentMetricName = getMetricName(currentMetric);
+  const currentPeriod = componentParams.period;
   const normalizeData = componentParams.normalizeData;
 
   const [selectedLocations] = useState<Region[]>(
@@ -66,7 +67,7 @@ const ExploreChartExportImage = ({
   const yTooltipFormat = getYFormat(dataMeasure, 1);
   const maxYFromDefinition = getMaxYFromDefinition(currentMetric);
 
-  const dateRange = getDateRange(Period.ALL);
+  const dateRange = getDateRange(currentPeriod);
 
   return (
     <ScreenshotWrapper className={SCREENSHOT_CLASS}>
@@ -95,7 +96,11 @@ const ExploreChartExportImage = ({
                 dateRange={dateRange}
                 yTickFormat={yTickFormat}
                 yTooltipFormat={yTooltipFormat}
-                xTickTimeUnit={TimeUnit.MONTHS}
+                xTickTimeUnit={
+                  currentPeriod === Period.ALL
+                    ? TimeUnit.MONTHS
+                    : TimeUnit.WEEKS
+                }
                 maxYFromDefinition={maxYFromDefinition}
               />
             )}

--- a/src/screens/internal/ShareImage/ExploreChartImage.tsx
+++ b/src/screens/internal/ShareImage/ExploreChartImage.tsx
@@ -32,6 +32,7 @@ const ExploreChartImage = ({ componentParams }: { componentParams: any }) => {
 
   const currentMetric = componentParams.currentMetric;
   const currentMetricName = getMetricName(currentMetric);
+  const currentPeriod = componentParams.period;
   const normalizeData = componentParams.normalizeData;
 
   const [selectedLocations] = useState<Region[]>(
@@ -52,7 +53,7 @@ const ExploreChartImage = ({ componentParams }: { componentParams: any }) => {
   const yTooltipFormat = getYFormat(dataMeasure, 1);
   const maxYFromDefinition = getMaxYFromDefinition(currentMetric);
 
-  const dateRange = getDateRange(Period.ALL);
+  const dateRange = getDateRange(currentPeriod);
 
   return (
     <DarkScreenshotWrapper className={SCREENSHOT_CLASS}>
@@ -86,7 +87,11 @@ const ExploreChartImage = ({ componentParams }: { componentParams: any }) => {
                   dateRange={dateRange}
                   yTickFormat={yTickFormat}
                   yTooltipFormat={yTooltipFormat}
-                  xTickTimeUnit={TimeUnit.MONTHS}
+                  xTickTimeUnit={
+                    currentPeriod === Period.ALL
+                      ? TimeUnit.MONTHS
+                      : TimeUnit.WEEKS
+                  }
                   maxYFromDefinition={maxYFromDefinition}
                 />
               )}


### PR DESCRIPTION
Currently in the Trends section, when the user selects a non-default time period and click share, the share link will save the selected metric and location/s, but not time period. This PR adds time period to shared parameters so the shared link will "remember" the selected time period too.

Addresses this [card](https://trello.com/c/DRB2OtuR/609-trends-sharing-doesnt-respect-past-of-days-setting).