### PR TITLE
Revert "Move thermometer block up in explainer intro"

### DIFF
--- a/src/screens/Learn/MetricExplainer/MetricExplainer.tsx
+++ b/src/screens/Learn/MetricExplainer/MetricExplainer.tsx
@@ -65,8 +65,8 @@ const MetricExplainer = () => {
         <ExplainersHeading2 id={introSection[0].sectionId}>
           {introSection[0].sectionHeader}
         </ExplainersHeading2>
-        <ThermometerIntro />
         <MarkdownContent source={introSection[0].sectionIntro} />
+        <ThermometerIntro />
         {introSection[0].questions &&
           introSection[0].questions.map(question => (
             <Fragment key={question.questionId}>


### PR DESCRIPTION
Turns out we don't need move the thermometer up. Mikayla just separated the copy into two sections in the CMS and that enabled the thermometer to sit where it ideally should.

Reverts covid-projections/covid-projections#5656