### PR TITLE
Trends default time period update

### DIFF
--- a/src/common/hooks/index.ts
+++ b/src/common/hooks/index.ts
@@ -21,3 +21,4 @@ export * from './useGeolocatedRegions';
 export { default as useDialog } from './useDialog';
 export { default as useChartHeightForBreakpoint } from './useChartHeightForBreakpoint';
 export { default as useScrollToRecommendations } from './useScrollToRecommendations';
+export { default as useDefaultTrendsPeriod } from './useDefaultTrendsPeriod';

--- a/src/common/hooks/useDefaultTrendsPeriod.ts
+++ b/src/common/hooks/useDefaultTrendsPeriod.ts
@@ -1,0 +1,23 @@
+/**
+ * On mobile screens, we default the Trends view to show past-180-days
+ */
+
+import { useEffect, useState } from 'react';
+import useBreakpoint from './useBreakpoint';
+import { Period } from 'components/Explore/utils';
+
+export default function useDefaultTrendsPeriod(): Period {
+  const isMobile = useBreakpoint(800);
+  const [defaultTimePeriod, setDefaultTimePeriod] = useState<Period>(
+    Period.ALL,
+  );
+
+  useEffect(() => {
+    if (isMobile) {
+      setDefaultTimePeriod(Period.DAYS_180);
+    } else {
+      setDefaultTimePeriod(Period.ALL);
+    }
+  }, [isMobile]);
+  return defaultTimePeriod;
+}

--- a/src/components/Explore/Explore.tsx
+++ b/src/components/Explore/Explore.tsx
@@ -257,20 +257,16 @@ const Explore: React.FunctionComponent<{
 
     const defaultTimePeriod = useDefaultTrendsPeriod();
 
-    // if the pathname changes (ie. if navigating between location pages via compare or regionmap)-
-    // resets metric, time period, and locations
-    // (need to force the reset since the route doesnt change)
+    // Resets time period state variable when pathname changes (need to force the reset since the route doesn't change):
+    useEffect(() => {
+      setPeriod(defaultTimePeriod);
+    }, [pathname, defaultTimePeriod]);
+
+    // Resets locations+current metric state variables when pathname changes (need to force the reset since the route doesn't change):
     useEffect(() => {
       setSelectedLocations(initialLocations);
       setCurrentMetric(ExploreMetric.HOSPITALIZATIONS);
-      setPeriod(defaultTimePeriod);
-    }, [
-      pathname,
-      region,
-      initialLocations,
-      setCurrentMetric,
-      defaultTimePeriod,
-    ]);
+    }, [pathname, region, initialLocations, setCurrentMetric]);
 
     // checks for shared parameters (ie. if arriving from a share link)
     // and sets state according to the shared params

--- a/src/components/Explore/Explore.tsx
+++ b/src/components/Explore/Explore.tsx
@@ -56,7 +56,10 @@ import Dropdown from 'components/Explore/Dropdown/Dropdown';
 import { getLocationLabel } from 'components/AutocompleteRegions';
 import { ShareBlock } from 'components/Footer/Footer.style';
 import { EmptyPanel } from 'components/Charts/Charts.style';
-import { useChartHeightForBreakpoint } from 'common/hooks';
+import {
+  useChartHeightForBreakpoint,
+  useDefaultTrendsPeriod,
+} from 'common/hooks';
 import { assert } from 'common/utils';
 
 const MARGIN_SINGLE_LOCATION = 20;
@@ -252,14 +255,22 @@ const Explore: React.FunctionComponent<{
       }
     }, [pathname, scrollToExplore]);
 
+    const defaultTimePeriod = useDefaultTrendsPeriod();
+
     // if the pathname changes (ie. if navigating between location pages via compare or regionmap)-
     // resets metric, time period, and locations
     // (need to force the reset since the route doesnt change)
     useEffect(() => {
       setSelectedLocations(initialLocations);
       setCurrentMetric(ExploreMetric.HOSPITALIZATIONS);
-      setPeriod(Period.ALL);
-    }, [pathname, region, initialLocations, setCurrentMetric]);
+      setPeriod(defaultTimePeriod);
+    }, [
+      pathname,
+      region,
+      initialLocations,
+      setCurrentMetric,
+      defaultTimePeriod,
+    ]);
 
     // checks for shared parameters (ie. if arriving from a share link)
     // and sets state according to the shared params


### PR DESCRIPTION
Trello: https://trello.com/c/7COWZXOf/613-change-the-trend-defaults-on-mobile-to-180-days

Defaults trends view to 180-days on mobile