### PR TITLE
Add internal county data anomaly tracker

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -43,6 +43,7 @@ const CompareSnapshots = lazy(() =>
   import('screens/internal/CompareSnapshots/CompareSnapshots'),
 );
 const AllStates = lazy(() => import('screens/internal/AllStates/AllStates'));
+const Anomalies = lazy(() => import('screens/internal/Anomalies/Anomalies'));
 const ExportImage = lazy(() =>
   import('screens/internal/ShareImage/ChartExportImage'),
 );
@@ -267,6 +268,9 @@ export default function App() {
                     path="/internal/compare"
                     component={CompareSnapshots}
                   />
+
+                  {/** Internal endpoint for viewing data anomalies. */}
+                  <Route path="/internal/anomalies" component={Anomalies} />
 
                   {/** Internal endpoint for viewing all vaccination phase data **/}
                   <Route

--- a/src/common/metric.tsx
+++ b/src/common/metric.tsx
@@ -15,14 +15,14 @@ import { formatDecimal, formatPercent } from 'common/utils';
 import { Metric } from 'common/metricEnum';
 
 export const ALL_METRICS = [
+  Metric.WEEKLY_CASES_PER_100K,
+  Metric.RATIO_BEDS_WITH_COVID,
+  Metric.ADMISSIONS_PER_100K,
   Metric.CASE_DENSITY,
   Metric.CASE_GROWTH_RATE,
   Metric.POSITIVE_TESTS,
   Metric.HOSPITAL_USAGE,
   Metric.VACCINATIONS,
-  Metric.RATIO_BEDS_WITH_COVID,
-  Metric.ADMISSIONS_PER_100K,
-  Metric.WEEKLY_CASES_PER_100K,
 ];
 
 const ALL_METRICS_LEVEL_INFO_MAP: { [metric in Metric]: LevelInfoMap } = {

--- a/src/screens/internal/Anomalies/Anomalies.tsx
+++ b/src/screens/internal/Anomalies/Anomalies.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { orderBy } from 'lodash';
 import { useState, useEffect } from 'react';
-import { Container, Grid, Typography, Link } from '@material-ui/core';
+import { Container, Grid, Typography, Link, Box } from '@material-ui/core';
 import { fetchCountyProjectionsForState } from 'common/utils/model';
 import { State, statesByFips } from 'common/regions';
 import {
@@ -76,9 +76,9 @@ const AnomaliesWrapper = React.memo(function AnomaliesWrapper({
 
       <Typography>
         Anomalies formatted below as:{' '}
-        <b>
-          <em>Date, Anomaly Type, Original Value</em>
-        </b>
+        <Box fontWeight="fontWeightMedium" fontStyle="italic">
+          Date, Anomaly Type, Original Value
+        </Box>
       </Typography>
       <Grid container>
         <Grid item xs={12}>

--- a/src/screens/internal/Anomalies/Anomalies.tsx
+++ b/src/screens/internal/Anomalies/Anomalies.tsx
@@ -18,7 +18,7 @@ import {
   useSnapshotVersion,
 } from '../CompareSnapshots/SnapshotVersions';
 
-export function AnomaliesPage() {
+function AnomaliesPage() {
   const [options, setOptions] = useState<AnnotationOptions | null>(null);
   return (
     <Wrapper>
@@ -57,12 +57,11 @@ const AnomaliesWrapper = React.memo(function AnomaliesWrapper({
   projections = orderBy(
     projections,
     [
-      function (projection) {
-        return getAnomaliesForAnnotationType(
+      projection =>
+        getAnomaliesForAnnotationType(
           projection.primary.annotations,
           annotationType,
-        );
-      },
+        ),
     ],
     'desc',
   );
@@ -81,14 +80,12 @@ const AnomaliesWrapper = React.memo(function AnomaliesWrapper({
         </Box>
       </Typography>
       <Grid container>
-        <Grid item xs={12}>
-          {projections?.map(projection => (
-            <LocationAnomalies
-              annotationType={annotationType}
-              projection={projection}
-            />
-          ))}
-        </Grid>
+        {projections?.map(projection => (
+          <LocationAnomalies
+            annotationType={annotationType}
+            projection={projection}
+          />
+        ))}
       </Grid>
     </Container>
   );
@@ -105,15 +102,7 @@ const LocationAnomalies = ({
     projection.primary.annotations,
     annotationType,
   );
-  anomalies = orderBy(
-    anomalies,
-    [
-      function (anomaly) {
-        return anomaly.date;
-      },
-    ],
-    'desc',
-  );
+  anomalies = orderBy(anomalies, ['date'], 'desc');
   return (
     <Container>
       <Typography variant="h5">

--- a/src/screens/internal/Anomalies/Anomalies.tsx
+++ b/src/screens/internal/Anomalies/Anomalies.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import sortBy from 'lodash/sortBy';
+import {
+  RegionVaccinePhaseInfo,
+  RegionPhaseGroup,
+  stateVaccinationPhases,
+} from 'cms-content/vaccines/phases';
+import { useState, useEffect } from 'react';
+import { Container, Grid, Typography } from '@material-ui/core';
+import ExternalLink from 'components/ExternalLink';
+import { MarkdownContent } from 'components/Markdown';
+import { Metric } from 'common/metricEnum';
+import { fetchCountyProjectionsForState } from 'common/utils/model';
+import {
+  Region,
+  State,
+  getStateName,
+  statesByFips,
+  getCountyRegionFromZipCode,
+} from 'common/regions';
+import { getAnomaliesForMetric } from 'screens/internal/Anomalies/utils';
+import {
+  Anomalies,
+  AnomalyAnnotation,
+  TagType,
+  Date,
+  OriginalObservation,
+} from 'api/schema/RegionSummaryWithTimeseries';
+import { Projections } from 'common/models/Projections';
+
+interface LocationAnomalies {
+  region: Region;
+  anomalies: Anomalies;
+}
+
+const AnnotationLocation = ({
+  anomalies,
+}: {
+  anomalies: AnomalyAnnotation[];
+}) => {
+  return (
+    <Container>
+      <Grid container>
+        <Grid item xs={12}>
+          {anomalies.map(anomaly => (
+            <Typography>
+              {anomaly.date} {anomaly.type} {anomaly.original_observation}
+            </Typography>
+          ))}
+        </Grid>
+      </Grid>
+    </Container>
+  );
+};
+
+const AnomaliesPage = () => {
+  const projections = useCountyProjectionsFromRegion(statesByFips['12']);
+  let casesAnnotationsRaw: LocationAnomalies[];
+  projections?.forEach(projection => {
+    if (projections) {
+      const val = getAnomaliesForMetric(
+        projection.primary.annotations,
+        Metric.CASE_DENSITY,
+      );
+      casesAnnotationsRaw.push();
+    }
+  });
+  const casesAnnotations = casesAnnotationsRaw.filter(
+    anomalies => anomalies !== undefined,
+  ) as Anomalies[];
+
+  return (
+    <Container maxWidth="md">
+      <Grid container>
+        <Grid item xs={12}>
+          <Typography variant="h2">Anomalies</Typography>
+          {casesAnnotations.map(anomalies => (
+            <AnnotationLocation anomalies={anomalies} />
+          ))}
+        </Grid>
+      </Grid>
+    </Container>
+  );
+};
+
+export default AnomaliesPage;
+
+export function useCountyProjectionsFromRegion(region: State | null) {
+  const [projections, setProjections] = useState<Projections[]>();
+
+  useEffect(() => {
+    async function fetchData() {
+      if (region) {
+        const projections = await fetchCountyProjectionsForState(region);
+        setProjections(projections);
+      }
+    }
+
+    fetchData();
+  }, [region]);
+
+  return projections;
+}

--- a/src/screens/internal/Anomalies/AnomaliesSelector.tsx
+++ b/src/screens/internal/Anomalies/AnomaliesSelector.tsx
@@ -54,7 +54,7 @@ function AnnotationsSelectorInner({
   );
 
   const [stateFips, setLocations] = useState<string>(
-    getLocationsParamValue(params, '01'),
+    getStateFipsParamValue(params, '01'),
   );
 
   useEffect(() => {
@@ -124,7 +124,7 @@ function AnnotationsSelectorInner({
         />
       </FormControl>
       <FormControl style={{ width: '12rem', marginLeft: '1rem' }}>
-        <InputLabel focused={false}>Annotation Type:</InputLabel>
+        <InputLabel focused={false}>Field:</InputLabel>
         <Select value={annotationType} onChange={changeMetric}>
           {ANNOTATION_TYPES.map(annotationType => (
             <MenuItem key={annotationType} value={annotationType}>
@@ -147,7 +147,7 @@ function AnnotationsSelectorInner({
   );
 }
 
-function getLocationsParamValue(
+function getStateFipsParamValue(
   params: QueryString.ParsedQuery,
   defaultValue: string,
 ): string {

--- a/src/screens/internal/Anomalies/AnomaliesSelector.tsx
+++ b/src/screens/internal/Anomalies/AnomaliesSelector.tsx
@@ -20,10 +20,17 @@ import {
   AnnotationType,
   ANNOTATION_TYPES,
   annotationTypeNames,
-  AnnotationSelectorProps,
-  AnnotationSelectorInnerProps,
+  AnnotationOptions,
 } from './utils';
 import regions from 'common/regions';
+
+interface AnnotationSelectorProps {
+  onNewOptions: (options: AnnotationOptions) => void;
+}
+
+interface AnnotationSelectorInnerProps extends AnnotationSelectorProps {
+  mainSnapshot: number;
+}
 
 export function AnnotationsSelector(props: AnnotationSelectorProps) {
   const mainSnapshot = useMainSnapshot();
@@ -49,7 +56,7 @@ function AnnotationsSelectorInner({
 
   const [snapshotText, setSnapshotText] = useState(snapshot.toString());
 
-  const [annotationType, setMetric] = useState(
+  const [annotationType, setAnnotationType] = useState(
     getNumericParamValue(params, 'annotationType', AnnotationType.NEW_CASES),
   );
 
@@ -92,9 +99,9 @@ function AnnotationsSelectorInner({
   };
 
   // TODO: Figure out correct type for event.
-  const changeMetric = (event: any) => {
+  const changeAnnotationType = (event: any) => {
     const annotationType = parseInt(event.target.value);
-    setMetric(annotationType);
+    setAnnotationType(annotationType);
     setQueryParams({ annotationType });
   };
 
@@ -125,7 +132,7 @@ function AnnotationsSelectorInner({
       </FormControl>
       <FormControl style={{ width: '12rem', marginLeft: '1rem' }}>
         <InputLabel focused={false}>Field:</InputLabel>
-        <Select value={annotationType} onChange={changeMetric}>
+        <Select value={annotationType} onChange={changeAnnotationType}>
           {ANNOTATION_TYPES.map(annotationType => (
             <MenuItem key={annotationType} value={annotationType}>
               {annotationTypeNames[annotationType]}
@@ -152,7 +159,7 @@ function getStateFipsParamValue(
   defaultValue: string,
 ): string {
   let value = get(params, 'stateFips', defaultValue);
-  if (typeof value !== 'string' || regions.findByStateCode(value)) {
+  if (typeof value !== 'string' || regions.findByStateCode(value) === null) {
     fail(`Parameter 'stateFips' has unexpected value: ${value}`);
   } else {
     return value;

--- a/src/screens/internal/Anomalies/AnomaliesSelector.tsx
+++ b/src/screens/internal/Anomalies/AnomaliesSelector.tsx
@@ -1,0 +1,160 @@
+import get from 'lodash/get';
+import React, { useEffect, useState } from 'react';
+import { useLocation } from 'react-router';
+import { useHistory } from 'react-router-dom';
+import { fail } from 'common/utils';
+import * as QueryString from 'query-string';
+import { OptionsSelectorWrapper } from 'screens/internal/CompareSnapshots/OptionsSelector.style';
+import {
+  FormControl,
+  InputLabel,
+  MenuItem,
+  TextField,
+} from '@material-ui/core';
+import {
+  useMainSnapshot,
+  getNumericParamValue,
+  Select,
+} from '../CompareSnapshots/OptionsSelector';
+import {
+  AnnotationType,
+  ANNOTATION_TYPES,
+  annotationTypeNames,
+  AnnotationSelectorProps,
+  AnnotationSelectorInnerProps,
+} from './utils';
+import regions from 'common/regions';
+
+export function AnnotationsSelector(props: AnnotationSelectorProps) {
+  const mainSnapshot = useMainSnapshot();
+  if (!mainSnapshot) {
+    return null;
+  } else {
+    return <AnnotationsSelectorInner mainSnapshot={mainSnapshot} {...props} />;
+  }
+}
+
+function AnnotationsSelectorInner({
+  mainSnapshot,
+  onNewOptions,
+}: AnnotationSelectorInnerProps) {
+  const location = useLocation();
+  const history = useHistory();
+
+  const params = QueryString.parse(history.location.search);
+
+  const [snapshot, setSnapshot] = useState(
+    getNumericParamValue(params, 'snapshot', mainSnapshot),
+  );
+
+  const [snapshotText, setSnapshotText] = useState(snapshot.toString());
+
+  const [annotationType, setMetric] = useState(
+    getNumericParamValue(params, 'annotationType', AnnotationType.NEW_CASES),
+  );
+
+  const [stateFips, setLocations] = useState<string>(
+    getLocationsParamValue(params, '01'),
+  );
+
+  useEffect(() => {
+    onNewOptions({
+      snapshot,
+      stateFips,
+      annotationType,
+    });
+  }, [snapshot, stateFips, annotationType, onNewOptions]);
+
+  function setQueryParams(newParams: {
+    snapshot?: number;
+    annotationType?: number;
+    stateFips?: string;
+  }) {
+    const params = {
+      snapshot: snapshot,
+      annotationType: annotationType,
+      stateFips: stateFips,
+      ...newParams,
+    };
+
+    history.push({
+      ...location,
+      search: QueryString.stringify(params),
+    });
+  }
+
+  const changeSnapshot = () => {
+    const snapshot = parseInt(snapshotText);
+    if (!Number.isNaN(snapshot)) {
+      setSnapshot(snapshot);
+      setQueryParams({ snapshot });
+    }
+  };
+
+  // TODO: Figure out correct type for event.
+  const changeMetric = (event: any) => {
+    const annotationType = parseInt(event.target.value);
+    setMetric(annotationType);
+    setQueryParams({ annotationType });
+  };
+
+  // TODO: Figure out correct type for event.
+  const changeLocation = (event: any) => {
+    const value = event.target.value;
+    const stateFips = String(value);
+    setLocations(stateFips);
+    setQueryParams({ stateFips });
+  };
+
+  return (
+    <OptionsSelectorWrapper>
+      <FormControl style={{ width: '8rem', marginRight: '1rem' }}>
+        <TextField
+          id="snapshot"
+          label="Snapshot"
+          value={snapshotText}
+          onChange={e => setSnapshotText(e.target.value)}
+          onBlur={() => changeSnapshot()}
+          onKeyPress={ev => {
+            if (ev.key === 'Enter') {
+              changeSnapshot();
+              ev.preventDefault();
+            }
+          }}
+        />
+      </FormControl>
+      <FormControl style={{ width: '12rem', marginLeft: '1rem' }}>
+        <InputLabel focused={false}>Annotation Type:</InputLabel>
+        <Select value={annotationType} onChange={changeMetric}>
+          {ANNOTATION_TYPES.map(annotationType => (
+            <MenuItem key={annotationType} value={annotationType}>
+              {annotationTypeNames[annotationType]}
+            </MenuItem>
+          ))}
+        </Select>
+      </FormControl>
+      <FormControl style={{ width: '14rem', marginLeft: '1rem' }}>
+        <InputLabel focused={false}>State:</InputLabel>
+        <Select value={stateFips} onChange={changeLocation}>
+          {regions.states.map(state => (
+            <MenuItem key={state.fipsCode} value={state.fipsCode}>
+              {state.name}
+            </MenuItem>
+          ))}
+        </Select>
+      </FormControl>
+    </OptionsSelectorWrapper>
+  );
+}
+
+function getLocationsParamValue(
+  params: QueryString.ParsedQuery,
+  defaultValue: string,
+): string {
+  let value = get(params, 'stateFips', defaultValue);
+  if (typeof value !== 'string' || regions.findByStateCode(value)) {
+    fail(`Parameter 'stateFips' has unexpected value: ${value}`);
+  } else {
+    return value;
+  }
+}

--- a/src/screens/internal/Anomalies/utils.ts
+++ b/src/screens/internal/Anomalies/utils.ts
@@ -42,11 +42,3 @@ export interface AnnotationOptions {
   stateFips: string;
   annotationType: AnnotationType;
 }
-
-export interface AnnotationSelectorProps {
-  onNewOptions: (options: AnnotationOptions) => void;
-}
-
-export interface AnnotationSelectorInnerProps extends AnnotationSelectorProps {
-  mainSnapshot: number;
-}

--- a/src/screens/internal/Anomalies/utils.ts
+++ b/src/screens/internal/Anomalies/utils.ts
@@ -1,0 +1,26 @@
+import { Annotations, Anomalies } from 'api/schema/RegionSummaryWithTimeseries';
+import { Metric } from 'common/metricEnum';
+
+export function getAnomaliesForMetric(
+  annotations: Annotations,
+  metric: Metric,
+): Anomalies | undefined {
+  switch (metric) {
+    case Metric.CASE_DENSITY:
+      return annotations?.caseDensity?.anomalies;
+    case Metric.CASE_GROWTH_RATE:
+      return annotations?.infectionRate?.anomalies;
+    case Metric.POSITIVE_TESTS:
+      return annotations?.testPositivityRatio?.anomalies;
+    case Metric.HOSPITAL_USAGE:
+      return annotations?.icuCapacityRatio?.anomalies;
+    case Metric.VACCINATIONS:
+      // TODO(michael): Ideally the backend would be more consistent about where it sticks sources.
+      const provenance =
+        annotations?.vaccinationsInitiated ||
+        annotations?.vaccinationsInitiatedRatio ||
+        annotations?.vaccinationsCompleted ||
+        annotations?.vaccinationsCompletedRatio;
+      return provenance?.anomalies;
+  }
+}

--- a/src/screens/internal/CompareSnapshots/OptionsSelector.tsx
+++ b/src/screens/internal/CompareSnapshots/OptionsSelector.tsx
@@ -98,7 +98,7 @@ function OptionsSelectorInner({
     getNumericParamValue(params, 'sort', SortType.METRIC_DIFF),
   );
   const [metric, setMetric] = useState(
-    getNumericParamValue(params, 'metric', Metric.CASE_DENSITY),
+    getNumericParamValue(params, 'metric', Metric.WEEKLY_CASES_PER_100K),
   );
 
   const [locations, setLocations] = useState<string | number>(

--- a/src/screens/internal/CompareSnapshots/OptionsSelector.tsx
+++ b/src/screens/internal/CompareSnapshots/OptionsSelector.tsx
@@ -39,7 +39,7 @@ interface OptionsSelectorProps {
  * page (all graphs, etc.) to re-render causing a big perf hiccup.  See:
  * https://stackoverflow.com/q/60682426
  */
-const Select: React.FunctionComponent<SelectProps> = ({
+export const Select: React.FunctionComponent<SelectProps> = ({
   children,
   ...props
 }) => {
@@ -263,7 +263,7 @@ function OptionsSelectorInner({
   );
 }
 
-function getNumericParamValue(
+export function getNumericParamValue(
   params: QueryString.ParsedQuery,
   param: string,
   defaultValue: number,
@@ -304,7 +304,7 @@ function getLocationsParamValue(
   return value;
 }
 
-function useMainSnapshot(): number | null {
+export function useMainSnapshot(): number | null {
   const [snapshot, setSnapshot] = useState<number | null>(null);
   useEffect(() => {
     async function fetchData() {

--- a/src/screens/internal/CompareSnapshots/SnapshotVersions.tsx
+++ b/src/screens/internal/CompareSnapshots/SnapshotVersions.tsx
@@ -47,12 +47,20 @@ export function useSnapshotVersion(
 ): SnapshotVersion | null {
   const [version, setVersion] = useState<SnapshotVersion | null>(null);
   useEffect(() => {
-    setVersion(null);
-    if (snapshot !== null) {
-      new Api(snapshotUrl(snapshot)).fetchVersionInfo().then(version => {
-        setVersion(version);
-      });
+    async function fetchVersion() {
+      setVersion(null);
+      if (snapshot !== null) {
+        try {
+          const version = await new Api(
+            snapshotUrl(snapshot),
+          ).fetchVersionInfo();
+          setVersion(version);
+        } catch (e) {
+          setVersion(null);
+        }
+      }
     }
+    fetchVersion();
   }, [snapshot]);
 
   return version;

--- a/src/screens/internal/CompareSnapshots/SnapshotVersions.tsx
+++ b/src/screens/internal/CompareSnapshots/SnapshotVersions.tsx
@@ -28,7 +28,7 @@ export function SnapshotVersions({
   );
 }
 
-function VersionInfo({ version }: { version: SnapshotVersion | null }) {
+export function VersionInfo({ version }: { version: SnapshotVersion | null }) {
   return (
     version && (
       <div style={{ fontSize: 'small' }}>


### PR DESCRIPTION
Creates an internal page for viewing county-level data anomalies.

Preview: https://covid-projections-n9nq7lcr5-covidactnow.vercel.app/internal/anomalies

This is helpful for tracking down anomalies or looking at what anomalies exist for a specific location, but it isn't so helpful for identifying what anomalies were introduced in a given snapshot. We might want to extend this to have an option to list all of the anomalies for a given metric in reverse chronological order, or something similar. 
