### PR TITLE
Fix chart tab renaming bug

### DIFF
--- a/src/components/Charts/Groupings.tsx
+++ b/src/components/Charts/Groupings.tsx
@@ -60,7 +60,7 @@ export const CHART_GROUPS: ChartGroup[] = [
         metricType: MetricType.KEY_METRIC,
         renderTabLabel: (metricValue, projections) => (
           <ChartTab
-            metricName={getMetricNameForStat(Metric.WEEKLY_CASES_PER_100K)}
+            metricName={getMetricName(Metric.WEEKLY_CASES_PER_100K)}
             subLabel={metricSubLabelText[Metric.WEEKLY_CASES_PER_100K]}
             metricValueInfo={metricValue}
           />
@@ -77,7 +77,7 @@ export const CHART_GROUPS: ChartGroup[] = [
         metricType: MetricType.KEY_METRIC,
         renderTabLabel: (metricValue, projections) => (
           <ChartTab
-            metricName={getMetricNameForStat(Metric.ADMISSIONS_PER_100K)}
+            metricName={getMetricName(Metric.ADMISSIONS_PER_100K)}
             subLabel={metricSubLabelText[Metric.ADMISSIONS_PER_100K]}
             metricValueInfo={metricValue}
           />
@@ -94,7 +94,7 @@ export const CHART_GROUPS: ChartGroup[] = [
         metricType: MetricType.KEY_METRIC,
         renderTabLabel: (metricValue, projections) => (
           <ChartTab
-            metricName={getMetricNameForStat(Metric.RATIO_BEDS_WITH_COVID)}
+            metricName={getMetricName(Metric.RATIO_BEDS_WITH_COVID)}
             subLabel={metricSubLabelText[Metric.RATIO_BEDS_WITH_COVID]}
             metricValueInfo={metricValue}
           />


### PR DESCRIPTION
As a result of implementing abbreviated metric names above the fold (in summary stats) ([in this PR](https://github.com/covid-projections/covid-projections/commit/888ed6e51e6aa1e8ed766d0b878c238ff0bb8572#diff-ad0bea4234c14136dcbf94867550df9b205da399f1c021520778035df7b28b1aR20)), metric names in chart tabs were updated -- unintentionally. This reverts the chart tabs to their original metric name copy

So- abbreviated names remain implemented in summary stats (cases, patients, admissions), but the longer names are used in the corresponding chart tabs

Before:

![Screen Shot 2022-04-28 at 7 15 33 PM](https://user-images.githubusercontent.com/44076375/165862617-273dd907-2fdb-49fb-a690-eb9805c73922.png)

After:

![Screen Shot 2022-04-28 at 7 15 21 PM](https://user-images.githubusercontent.com/44076375/165862637-96796bf7-b3f8-4f24-88b6-7559c021bf6a.png)
