### PR TITLE
Hyperlink state code in county location page header

### DIFF
--- a/src/components/NewLocationPage/LocationName/LocationName.style.tsx
+++ b/src/components/NewLocationPage/LocationName/LocationName.style.tsx
@@ -22,7 +22,7 @@ export const UpdatedOnText = styled.span`
   font-size: 0.9rem;
 `;
 
-export const UnstyledLink = styled(Link)`
+export const PlainLink = styled(Link)`
   color: inherit;
   text-underline-offset: 1px;
 `;

--- a/src/components/NewLocationPage/LocationName/LocationName.style.tsx
+++ b/src/components/NewLocationPage/LocationName/LocationName.style.tsx
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 import { materialSMBreakpoint } from 'assets/theme/sizes';
 import { COLOR_MAP } from 'common/colors';
+import { Link } from 'react-router-dom';
 
 export const RegionNameContainer = styled.div`
   text-align: center;
@@ -19,4 +20,9 @@ export const RegionNameText = styled.h1`
 export const UpdatedOnText = styled.span`
   color: ${COLOR_MAP.GREY_4};
   font-size: 0.9rem;
+`;
+
+export const UnstyledLink = styled(Link)`
+  color: inherit;
+  text-underline-offset: 1px;
 `;

--- a/src/components/NewLocationPage/LocationName/LocationName.tsx
+++ b/src/components/NewLocationPage/LocationName/LocationName.tsx
@@ -5,7 +5,7 @@ import {
   RegionNameContainer,
   RegionNameText,
   UpdatedOnText,
-  UnstyledLink,
+  PlainLink,
 } from './LocationName.style';
 import { useModelLastUpdatedDate } from 'common/utils/model';
 import { DateFormat, formatDateTime } from 'common/utils/time-utils';
@@ -38,9 +38,9 @@ function renderStyledRegionName(region: Region) {
         <strong>{countyName}</strong>
         {countySuffix && ` ${countySuffix}`}
         {', '}
-        <UnstyledLink to={region.state.relativeUrl}>
+        <PlainLink to={region.state.relativeUrl}>
           {region.state.stateCode}
-        </UnstyledLink>
+        </PlainLink>
       </>
     );
   } else if (region instanceof MetroArea) {

--- a/src/components/NewLocationPage/LocationName/LocationName.tsx
+++ b/src/components/NewLocationPage/LocationName/LocationName.tsx
@@ -5,6 +5,7 @@ import {
   RegionNameContainer,
   RegionNameText,
   UpdatedOnText,
+  UnstyledLink,
 } from './LocationName.style';
 import { useModelLastUpdatedDate } from 'common/utils/model';
 import { DateFormat, formatDateTime } from 'common/utils/time-utils';
@@ -36,7 +37,10 @@ function renderStyledRegionName(region: Region) {
       <>
         <strong>{countyName}</strong>
         {countySuffix && ` ${countySuffix}`}
-        {`, ${region.state.stateCode}`}
+        {', '}
+        <UnstyledLink to={region.state.relativeUrl}>
+          {region.state.stateCode}
+        </UnstyledLink>
       </>
     );
   } else if (region instanceof MetroArea) {


### PR DESCRIPTION
Trello: https://trello.com/c/CfyHZ21J/631-add-hyperlink-to-state-abbreviation

[Example](https://covid-projections-git-casulin-hyperlink-statecode-covidactnow.vercel.app/us/new_york-ny/county/kings_county/?s=33202135)