### PR TITLE
Add CAN GA4 property

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,21 +1,19 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <!--link rel="icon" href="%PUBLIC_URL%/favicon.ico" /-->
-    <meta
-      name="viewport"
-      content="minimum-scale=1, initial-scale=1, width=device-width"
-    />
 
-    <meta name="theme-color" content="#000000" />
-    <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
-    <!--
+<head>
+  <meta charset="utf-8" />
+  <!--link rel="icon" href="%PUBLIC_URL%/favicon.ico" /-->
+  <meta name="viewport" content="minimum-scale=1, initial-scale=1, width=device-width" />
+
+  <meta name="theme-color" content="#000000" />
+  <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
+  <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <!--
+  <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+  <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.
       Only files inside the `public` folder can be referenced from the HTML.
@@ -25,76 +23,54 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
 
-    <!-- General meta tags (per-page) -->
-    <title data-react-helmet="true">Covid Act Now</title>
-    <link
-      data-react-helmet="true"
-      rel="canonical"
-      href="https://covidactnow.org/"
-    />
-    <meta
-      data-react-helmet="true"
-      name="description"
-      content="U.S. COVID Risk & Vaccine Tracker. All 50 states. 3,000+ counties."
-    />
-    <meta data-react-helmet="true" name="image" content="" />
+  <!-- General meta tags (per-page) -->
+  <title data-react-helmet="true">Covid Act Now</title>
+  <link data-react-helmet="true" rel="canonical" href="https://covidactnow.org/" />
+  <meta data-react-helmet="true" name="description"
+    content="U.S. COVID Risk & Vaccine Tracker. All 50 states. 3,000+ counties." />
+  <meta data-react-helmet="true" name="image" content="" />
 
-    <!-- Facebook Open Graph meta tags (site-wide) -->
-    <meta property="og:type" content="website" />
-    <meta property="og:site_name" content="Covid Act Now" />
-    <meta property="og:image:type" content="image/png" />
-    <meta property="fb:app_id" content="743805156345210" />
+  <!-- Facebook Open Graph meta tags (site-wide) -->
+  <meta property="og:type" content="website" />
+  <meta property="og:site_name" content="Covid Act Now" />
+  <meta property="og:image:type" content="image/png" />
+  <meta property="fb:app_id" content="743805156345210" />
 
-    <!-- Facebook Open Graph meta tags (per-page) -->
-    <!-- NOTE: These are replaced at build time by scripts/generate_index_pages.ts -->
-    <meta property="og:url" content="https://covidactnow.org" />
-    <meta
-      property="og:image:url"
-      content="https://covidactnow.org/covidactnow.png?fbrefresh=v3"
-    />
-    <meta property="og:image:width" content="1200" />
-    <meta property="og:image:height" content="630" />
-    <meta property="og:title" content="U.S. COVID Risk & Vaccine Tracker" />
-    <meta
-      property="og:description"
-      content="Covid Act Now has real-time tracking of your community's COVID level. Explore how your community is doing."
-    />
+  <!-- Facebook Open Graph meta tags (per-page) -->
+  <!-- NOTE: These are replaced at build time by scripts/generate_index_pages.ts -->
+  <meta property="og:url" content="https://covidactnow.org" />
+  <meta property="og:image:url" content="https://covidactnow.org/covidactnow.png?fbrefresh=v3" />
+  <meta property="og:image:width" content="1200" />
+  <meta property="og:image:height" content="630" />
+  <meta property="og:title" content="U.S. COVID Risk & Vaccine Tracker" />
+  <meta property="og:description"
+    content="Covid Act Now has real-time tracking of your community's COVID level. Explore how your community is doing." />
 
-    <!-- Twitter meta tags (site-wide) -->
-    <meta name="twitter:card" content="summary_large_image" />
+  <!-- Twitter meta tags (site-wide) -->
+  <meta name="twitter:card" content="summary_large_image" />
 
-    <!-- Twitter meta tags (per-page) -->
-    <!-- NOTE: These are replaced at build time by scripts/generate_index_pages.ts -->
-    <meta
-      name="twitter:image"
-      content="https://covidactnow.org/covidactnow.png"
-    />
-    <meta name="twitter:title" content="U.S. COVID Risk & Vaccine Tracker" />
-    <meta
-      name="twitter:description"
-      content="Covid Act Now has real-time tracking of your community's COVID level. Explore how your community is doing."
-    />
+  <!-- Twitter meta tags (per-page) -->
+  <!-- NOTE: These are replaced at build time by scripts/generate_index_pages.ts -->
+  <meta name="twitter:image" content="https://covidactnow.org/covidactnow.png" />
+  <meta name="twitter:title" content="U.S. COVID Risk & Vaccine Tracker" />
+  <meta name="twitter:description"
+    content="Covid Act Now has real-time tracking of your community's COVID level. Explore how your community is doing." />
 
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 
-    <link
-      rel="stylesheet"
-      href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;700&family=Roboto:wght@400;500;700&display=swap"
-    />
+  <link rel="stylesheet"
+    href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;700&family=Roboto:wght@400;500;700&display=swap" />
 
-    <!-- Google Optimize for A/B testing: Uncomment when running experiments -->
-    <script
-      async
-      src="https://www.googleoptimize.com/optimize.js?id=OPT-WT27VPR"
-    ></script>
+  <!-- Google Optimize for A/B testing: Uncomment when running experiments -->
+  <script async src="https://www.googleoptimize.com/optimize.js?id=OPT-WT27VPR"></script>
 
-    <!-- Twitter universal website tag code -->
-    <script async>
-      !(function (e, t, n, s, u, a) {
-        e.twq ||
-          ((s = e.twq = function () {
-            s.exe ? s.exe.apply(s, arguments) : s.queue.push(arguments);
-          }),
+  <!-- Twitter universal website tag code -->
+  <script async>
+    !(function (e, t, n, s, u, a) {
+      e.twq ||
+        ((s = e.twq = function () {
+          s.exe ? s.exe.apply(s, arguments) : s.queue.push(arguments);
+        }),
           (s.version = '1.1'),
           (s.queue = []),
           (u = t.createElement(n)),
@@ -102,79 +78,82 @@
           (u.src = '//static.ads-twitter.com/uwt.js'),
           (a = t.getElementsByTagName(n)[0]),
           a.parentNode.insertBefore(u, a));
-      })(window, document, 'script');
-      // Insert Twitter Pixel ID and Standard Event data below
-      twq('init', 'o3f92');
-      twq('track', 'PageView');
-    </script>
-    <!-- End Twitter universal website tag code -->
+    })(window, document, 'script');
+    // Insert Twitter Pixel ID and Standard Event data below
+    twq('init', 'o3f92');
+    twq('track', 'PageView');
+  </script>
+  <!-- End Twitter universal website tag code -->
 
-    <!-- Facebook Pixel Code -->
-    <script>
-      !(function (f, b, e, v, n, t, s) {
-        if (f.fbq) return;
-        n = f.fbq = function () {
-          n.callMethod
-            ? n.callMethod.apply(n, arguments)
-            : n.queue.push(arguments);
-        };
-        if (!f._fbq) f._fbq = n;
-        n.push = n;
-        n.loaded = !0;
-        n.version = '2.0';
-        n.queue = [];
-        t = b.createElement(e);
-        t.async = !0;
-        t.src = v;
-        s = b.getElementsByTagName(e)[0];
-        s.parentNode.insertBefore(t, s);
-      })(
-        window,
-        document,
-        'script',
-        'https://connect.facebook.net/en_US/fbevents.js',
-      );
-      fbq('init', '538941662941644');
-      fbq('track', 'PageView');
-    </script>
-    <!-- End Facebook Pixel Code -->
+  <!-- Facebook Pixel Code -->
+  <script>
+    !(function (f, b, e, v, n, t, s) {
+      if (f.fbq) return;
+      n = f.fbq = function () {
+        n.callMethod
+          ? n.callMethod.apply(n, arguments)
+          : n.queue.push(arguments);
+      };
+      if (!f._fbq) f._fbq = n;
+      n.push = n;
+      n.loaded = !0;
+      n.version = '2.0';
+      n.queue = [];
+      t = b.createElement(e);
+      t.async = !0;
+      t.src = v;
+      s = b.getElementsByTagName(e)[0];
+      s.parentNode.insertBefore(t, s);
+    })(
+      window,
+      document,
+      'script',
+      'https://connect.facebook.net/en_US/fbevents.js',
+    );
+    fbq('init', '538941662941644');
+    fbq('track', 'PageView');
+  </script>
+  <!-- End Facebook Pixel Code -->
 
-    <!-- Global site tag (gtag.js) - Google Ads: 527465415 -->
-    <script
-      async
-      src="https://www.googletagmanager.com/gtag/js?id=AW-527465415"
-    ></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag() {
-        dataLayer.push(arguments);
-      }
-      gtag('js', new Date());
-      gtag('config', 'AW-527465415');
-    </script>
+  <!-- Global site tag (gtag.js) - Google Ads: 527465415 -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=AW-527465415"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag() {
+      dataLayer.push(arguments);
+    }
+    gtag('js', new Date());
+    gtag('config', 'AW-527465415');
+  </script>
 
-    <!-- Event snippet for Website traffic conversion page -->
-    <script>
-      gtag('event', 'conversion', {
-        send_to: 'AW-527465415/lRyqCM2a9-kBEMf3wfsB',
-      });
-    </script>
+  <!-- Global site tag (gtag.js) - Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-9883DK9DYY"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag() { dataLayer.push(arguments); }
+    gtag('js', new Date());
 
-    <noscript>
-      <img
-        height="1"
-        width="1"
-        src="https://www.facebook.com/tr?id=692591964861759&ev=PageView
-      &noscript=1"
-      />
-    </noscript>
-    <!-- End Facebook Pixel Code -->
-  </head>
+    gtag('config', 'G-9883DK9DYY');
+  </script>
 
-  <body>
-    <noscript>You need to enable JavaScript to run this app.</noscript>
-    <div id="root"></div>
-    <!--
+  <!-- Event snippet for Website traffic conversion page -->
+  <script>
+    gtag('event', 'conversion', {
+      send_to: 'AW-527465415/lRyqCM2a9-kBEMf3wfsB',
+    });
+  </script>
+
+  <noscript>
+    <img height="1" width="1" src="https://www.facebook.com/tr?id=692591964861759&ev=PageView
+      &noscript=1" />
+  </noscript>
+  <!-- End Facebook Pixel Code -->
+</head>
+
+<body>
+  <noscript>You need to enable JavaScript to run this app.</noscript>
+  <div id="root"></div>
+  <!--
       This HTML file is a template.
       If you open it directly in the browser, you will see an empty page.
 
@@ -184,5 +163,6 @@
       To begin the development, run `npm start` or `yarn start`.
       To create a production bundle, use `npm run build` or `yarn build`.
     -->
-  </body>
+</body>
+
 </html>


### PR DESCRIPTION
This PR adds a new GA4 property to our Google Analytics, which starts tracking our user data along side our UA property. Note that UA is currently not affected whatsoever. So our current tracking data is not affected.

This is part of our migration from UA to GA4, which involves the following:
- Create a new GA4 property from the UA property, as per instructions in [this documentation](https://support.google.com/analytics/answer/10312255).
- Add the property to our code in the same manner as what we implemented for Google Ads [here](https://github.com/covid-projections/covid-projections/blob/a146d7166c8cbc8956fcf0bf176bc2d82b31c634/public/index.html#L142-L154), as per "tagging instructions" (found through Google Analytics --> Admin --> Data Steams --> CoVidActNow - G4 --> Tagging Instructions).
![image](https://user-images.githubusercontent.com/46338131/166336155-d2696aa4-1fb0-46d6-87d3-f00d044d1659.png)

NOTE: This PR is actually tiny! The rest of the code is the same but I think our linter decided to shift the spacing slightly. The **only** change to this PR is the part I highlighted and commented below.

**How to test**
1. Open the preview link and navigate around the site however you want.
2. Visit our new [GA4 dashboard](https://analytics.google.com/analytics/web/#/p313668181/realtime/overview) and watch it tracks your actions.

Currently, I'm still figuring out how to track events in the exact same way as we currently do (if even possible). But for now, at least page views should be working.

[More info in this documentation here.](https://www.dropbox.com/scl/fi/44vsd18ki3mhg8t3m66jb/Upgrading-UA-to-GA4.paper?dl=0&rlkey=s1id1aoz9vl3widw3ap7z7swa)
