### PR TITLE
Add event tracking to GA4

### DIFF
--- a/package.json
+++ b/package.json
@@ -166,6 +166,7 @@
     "@types/d3-fetch": "^1.1.5",
     "@types/d3-scale": "^2.2.0",
     "@types/fs-extra": "^8.1.0",
+    "@types/gtag.js": "^0.0.10",
     "@types/js-yaml": "^4.0.0",
     "@types/lodash": "^4.14.149",
     "@types/luxon": "^1.26.1",

--- a/src/components/Analytics/gtag.ts
+++ b/src/components/Analytics/gtag.ts
@@ -1,0 +1,8 @@
+import { EventCategory } from './utils';
+
+// https://developers.google.com/analytics/devguides/collection/gtagjs/events
+export const event = (action: string, category: EventCategory) => {
+  gtag('event', action, {
+    event_category: category,
+  });
+};

--- a/src/components/Analytics/gtag.ts
+++ b/src/components/Analytics/gtag.ts
@@ -1,15 +1,15 @@
-import { EventCategory } from './utils';
-
 // https://developers.google.com/analytics/devguides/collection/gtagjs/events
-export const event = (
+export const trackGA4Event = (
   action: string,
-  category: EventCategory,
-  label?: string,
+  category: string,
+  label: string,
   value?: number,
 ) => {
-  gtag('event', action, {
-    event_category: category,
-    event_label: label,
-    event_value: value,
-  });
+  if (gtag) {
+    gtag('event', action, {
+      event_category: category,
+      event_label: label,
+      event_value: value,
+    });
+  }
 };

--- a/src/components/Analytics/gtag.ts
+++ b/src/components/Analytics/gtag.ts
@@ -1,8 +1,15 @@
 import { EventCategory } from './utils';
 
 // https://developers.google.com/analytics/devguides/collection/gtagjs/events
-export const event = (action: string, category: EventCategory) => {
+export const event = (
+  action: string,
+  category: EventCategory,
+  label?: string,
+  value?: number,
+) => {
   gtag('event', action, {
     event_category: category,
+    event_label: label,
+    event_value: value,
   });
 };

--- a/src/components/Analytics/utils.ts
+++ b/src/components/Analytics/utils.ts
@@ -3,6 +3,7 @@ import words from 'lodash/words';
 import ReactGA from 'react-ga';
 import { amplitudeLogEvent } from './amplitude';
 import { fullStoryTrackEvent } from 'common/fullstory';
+import * as gtag from './gtag';
 
 export interface Tracker {
   trackingId: string;
@@ -115,6 +116,8 @@ export function trackEvent(
       nonInteraction,
       transport,
     });
+
+    gtag.event(action, category);
 
     const labelProp = label ? { eventLabel: toTitleCase(label) } : {};
     const valueProp = Number.isFinite(value) ? { eventValue: value } : {};

--- a/src/components/Analytics/utils.ts
+++ b/src/components/Analytics/utils.ts
@@ -3,7 +3,7 @@ import words from 'lodash/words';
 import ReactGA from 'react-ga';
 import { amplitudeLogEvent } from './amplitude';
 import { fullStoryTrackEvent } from 'common/fullstory';
-import * as gtag from './gtag';
+import { trackGA4Event } from './gtag';
 
 export interface Tracker {
   trackingId: string;
@@ -102,7 +102,7 @@ function toTitleCase(name: string) {
 export function trackEvent(
   category: EventCategory,
   action: EventAction,
-  label?: string,
+  label: string,
   value?: number,
   nonInteraction?: boolean,
   transport: 'beacon' | 'xhr' | 'image' = 'beacon',
@@ -117,7 +117,12 @@ export function trackEvent(
       transport,
     });
 
-    gtag.event(action, category, label, value);
+    trackGA4Event(
+      toTitleCase(action),
+      toTitleCase(category),
+      toTitleCase(label),
+      value,
+    );
 
     const labelProp = label ? { eventLabel: toTitleCase(label) } : {};
     const valueProp = Number.isFinite(value) ? { eventValue: value } : {};

--- a/src/components/Analytics/utils.ts
+++ b/src/components/Analytics/utils.ts
@@ -117,7 +117,7 @@ export function trackEvent(
       transport,
     });
 
-    gtag.event(action, category);
+    gtag.event(action, category, label, value);
 
     const labelProp = label ? { eventLabel: toTitleCase(label) } : {};
     const valueProp = Number.isFinite(value) ? { eventValue: value } : {};

--- a/src/components/SharedComponents/ShareButtons.tsx
+++ b/src/components/SharedComponents/ShareButtons.tsx
@@ -65,7 +65,9 @@ const ShareButtons: React.FC<{
           <SocialButtonBlock
             onShareOnFacebook={() => trackShare(eventCategory, 'facebook')}
             onShareOnTwitter={() => trackShare(eventCategory, 'twitter')}
-            onCopyLink={() => trackEvent(eventCategory, EventAction.COPY_LINK)}
+            onCopyLink={() =>
+              trackEvent(eventCategory, EventAction.COPY_LINK, 'Copy link')
+            }
             hideSocialButton={() => hideSocialButtons()}
             region={region}
             isHeader={isLocationPageHeader}

--- a/src/screens/AlertUnsubscribe/AlertUnsubscribe.tsx
+++ b/src/screens/AlertUnsubscribe/AlertUnsubscribe.tsx
@@ -55,7 +55,11 @@ const AlertUnsubscribe = () => {
   }, [email]);
 
   async function unsubscribeFromAll() {
-    trackEvent(EventCategory.ENGAGEMENT, EventAction.ALERTS_UNSUBSCRIBE);
+    trackEvent(
+      EventCategory.ENGAGEMENT,
+      EventAction.ALERTS_UNSUBSCRIBE,
+      'Unsubscribe',
+    );
     const subscriptions = await getAlertsSubscriptions();
     await subscriptions.doc(email).delete();
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4389,6 +4389,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/gtag.js@^0.0.10":
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/@types/gtag.js/-/gtag.js-0.0.10.tgz#ac90d9b79c00daac447725a4b78ec1c398796760"
+  integrity sha512-98Hy7woUb3jMAMXkZQwfIOYNyfxmI0+U4m0PpCGdnd/FHk0tDpQFCqgXdNkdEoXsKkcGya/2Gew1cAJjKJspVw==
+
 "@types/hast@^2.0.0":
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/@types/hast/-/hast-2.3.1.tgz#b16872f2a6144c7025f296fb9636a667ebb79cd9"


### PR DESCRIPTION
This PR adds event tracking to our new GA4 property. This change _does not_ affect out current event tracking whatsoever. It merely tracks events _alongside_ our current tracking in UA. Once merged, we'll be able to compare numbers between UA and GA4.

Data models are different between UA and GA4. While UA tracks activities with event action, event category, event label, and event value, these do not translate directly to GA4. Instead, "event action" in UA is _automatically_ converted to "event name" in GA4, and the rest need to be translated to custom parameters in GA4. These custom parameters can be created through the UI, as done so [here](https://analytics.google.com/analytics/web/#/p313668181/customdefinitions/hub?params=_u..nav%3Dmaui%26_u..pageSize%3D25). Then the code needs to be adjusted to match these parameters. More info in this doc [here](https://support.google.com/analytics/answer/10075209#zippy=%2Cin-this-article).

**Note:** Some values in GA may still be "(not set)" as this code is not yet merged to prod. The values which may be showing are the ones that GA4 automatically detects (new GA4 stuff has some automated features) merely from changing which events translate to what in the GA4 UI. The only way to compare the numbers is after this PR is merged.

How to test:
1. Open the vercel preview link for this PR.
2. Visit [Events](https://analytics.google.com/analytics/web/#/p313668181/reports/explorer?r=top-events) in GA.
3. Add custom parameter (Event category, label, or value) to the dashboard, like in the following screenshot.
![image](https://user-images.githubusercontent.com/46338131/166837343-762d55a0-3be2-4a06-a232-0ef25052c02a.png)
4. Play around with the site through the preview link and refresh the analytics page to see if your interaction shows up.
