### PR TITLE
Re-route sparkline click

### DIFF
--- a/src/components/LocationPage/ChartsHolder.tsx
+++ b/src/components/LocationPage/ChartsHolder.tsx
@@ -31,7 +31,7 @@ import { summaryToStats } from 'components/NewLocationPage/SummaryStat/utils';
 import AboveTheFold from 'components/NewLocationPage/AboveTheFold/AboveTheFold';
 import {
   SparkLineMetric,
-  SparkLineToExploreMetric,
+  SparkLineToMetric,
 } from 'components/NewLocationPage/SparkLineBlock/utils';
 import ChartBlock from 'components/Charts/ChartBlock';
 import {
@@ -149,13 +149,8 @@ const ChartsHolder = React.memo(({ region, chartId }: ChartsHolderProps) => {
     null,
   );
 
-  const onClickMetric = useCallback(
+  const scrollToMetricChart = useCallback(
     (metric: Metric) => {
-      trackEvent(
-        EventCategory.METRICS,
-        EventAction.CLICK,
-        `Location Header Stats: ${Metric[metric]}`,
-      );
       setClickedStatMetric(metric);
       const groupWithMetric = getChartGroupFromMetric(metric);
       const chartBlockRef = groupWithMetric
@@ -168,15 +163,24 @@ const ChartsHolder = React.memo(({ region, chartId }: ChartsHolderProps) => {
     [chartBlockRefs],
   );
 
-  const onClickSparkLine = useCallback((metric: SparkLineMetric) => {
+  const onClickMetric = (metric: Metric) => {
+    trackEvent(
+      EventCategory.METRICS,
+      EventAction.CLICK,
+      `Location Header Stats: ${Metric[metric]}`,
+    );
+    scrollToMetricChart(metric);
+  };
+
+  const onClickSparkLine = (metric: SparkLineMetric) => {
     trackEvent(
       EventCategory.METRICS,
       EventAction.CLICK,
       `Spark line: ${SparkLineMetric[metric]}`,
     );
-    setCurrentExploreMetric(SparkLineToExploreMetric[metric]);
-    scrollTo(exploreChartRef.current);
-  }, []);
+    const metricClicked = SparkLineToMetric[metric];
+    scrollToMetricChart(metricClicked);
+  };
 
   const onClickMasksCard = useCallback(() => {
     trackEvent(EventCategory.RECOMMENDATIONS, EventAction.CLICK, 'Masks card');

--- a/src/components/NewLocationPage/SparkLineBlock/utils.ts
+++ b/src/components/NewLocationPage/SparkLineBlock/utils.ts
@@ -1,6 +1,5 @@
 import { max as d3Max } from 'd3-array';
 import { cleanSeries } from 'components/Explore/utils';
-import { ExploreMetric } from 'components/Explore';
 import { Column, DatasetId, Projection } from 'common/models/Projection';
 import { fetchProjectionsRegion } from 'common/utils/model';
 import { Region } from 'common/regions';
@@ -27,13 +26,13 @@ export const SPARK_LINE_METRICS = [
   SparkLineMetric.RATIO_BEDS_WITH_COVID,
 ];
 
-// Used to select explore tab when clicking corresponding metric's spark line:
-export const SparkLineToExploreMetric: {
-  [metric in SparkLineMetric]: ExploreMetric;
+// Used to select chart tab when clicking corresponding metric's spark line:
+export const SparkLineToMetric: {
+  [metric in SparkLineMetric]: Metric;
 } = {
-  [SparkLineMetric.WEEKLY_CASES_PER_100K]: ExploreMetric.WEEKLY_CASES,
-  [SparkLineMetric.ADMISSIONS_PER_100K]: ExploreMetric.ADMISSIONS_PER_100K,
-  [SparkLineMetric.RATIO_BEDS_WITH_COVID]: ExploreMetric.RATIO_BEDS_WITH_COVID,
+  [SparkLineMetric.WEEKLY_CASES_PER_100K]: Metric.WEEKLY_CASES_PER_100K,
+  [SparkLineMetric.ADMISSIONS_PER_100K]: Metric.ADMISSIONS_PER_100K,
+  [SparkLineMetric.RATIO_BEDS_WITH_COVID]: Metric.RATIO_BEDS_WITH_COVID,
 };
 
 // TODO (chelsi) - fix need for all metrics as keys


### PR DESCRIPTION
When clicking spark lines, the page now scrolls to the corresponding metric's chart instead of to explore.

**Test on mobile** (the spark line block is now an independent component only on mobile -- desktop combines spark lines into summary stats)