### PR TITLE
Skip chromatic for dependabot PRs

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -2,7 +2,13 @@
 #
 # https://www.chromatic.com/docs/github-actions
 name: 'Chromatic'
-on: push
+on:
+  push:
+    # Workflows triggered by Dependabot don't have access to secrets, which
+    # will cause this workflow to fail. See
+    # https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/
+    branches-ignore:
+      - 'dependabot/**'
 
 jobs:
   chromatic-deployment:


### PR DESCRIPTION
Pull requests created by Dependabot are treated as if they were opened from a repository fork, which means that organization or repository secrets are not accessible by the workflows triggered by the PR. See https://github.com/covid-projections/covid-projections/pull/5894 for an example.

This PR disables the Chromatic workflow (which needs the `CHROMATIC_PROJECT_TOKEN` to publish to Chromatic) to prevent PRs created by Dependabot to fail the Chromatic check.

Once this is merged we can rebase https://github.com/covid-projections/covid-projections/pull/5894 and check that the Chromatic workflow is actually skipped.

See https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/