### PR TITLE
Fix smoothed cases in explore to match official case metric from backend.

### DIFF
--- a/src/common/models/Projection.ts
+++ b/src/common/models/Projection.ts
@@ -223,8 +223,14 @@ export class Projection {
     this.region = region;
 
     // Set up our series data exposed via getDataset().
+    this.caseDensityByCases = metricsTimeseries.map(
+      row => row && row.caseDensity,
+    );
+
     this.rawDailyCases = actualTimeseries.map(row => row && row.newCases);
-    this.smoothedDailyCases = this.smoothWithRollingAverage(this.rawDailyCases);
+    this.smoothedDailyCases = this.denormalizeByPopulation(
+      this.caseDensityByCases,
+    );
 
     this.rawDailyDeaths = actualTimeseries.map(row => row && row.newDeaths);
     this.smoothedDailyDeaths = this.smoothWithRollingAverage(
@@ -290,10 +296,6 @@ export class Projection {
     this.vaccinationsAdditionalDose =
       this.vaccinationsInfo?.ratioAdditionalDoseSeries ||
       this.dates.map(date => null);
-
-    this.caseDensityByCases = metricsTimeseries.map(
-      row => row && row.caseDensity,
-    );
 
     this.caseDensityRange = this.calcCaseDensityRange();
 
@@ -929,6 +931,13 @@ export class Projection {
       }
     }
     return result;
+  }
+
+  private denormalizeByPopulation(
+    data: Array<number | null>,
+  ): Array<number | null> {
+    const populationFactor = this.totalPopulation / 100000;
+    return data.map(d => (d == null ? null : d * populationFactor));
   }
 
   disaggregateHsaValue(hsaValue: number | null) {


### PR DESCRIPTION
Fixes https://trello.com/c/A4Gbquur/669-daily-new-cases-in-explore-is-inconsistent-with-weekly-new-cases-per-100k-metric-doesnt-handle-irregular-reporting-as-well

Rather than calculating `smoothedDailyCases` directly from `rawDailyCases`, we base it on the `caseDensity` metric which benefits from various smoothing done on the backend.

This is most notable for Florida explore metrics where the biweekly reporting causes issues.

**Before:**
![image](https://user-images.githubusercontent.com/206364/170099066-3824b6e6-9afa-4a5e-b0b5-52672fbc8438.png)

**After:**
![image](https://user-images.githubusercontent.com/206364/170099083-ad1cddaa-335f-4a5c-8a41-1c21534e897e.png)
