### PR TITLE
Fix casing for event labels

### DIFF
--- a/src/components/Analytics/utils.ts
+++ b/src/components/Analytics/utils.ts
@@ -1,6 +1,5 @@
 import capitalize from 'lodash/capitalize';
 import words from 'lodash/words';
-import ReactGA from 'react-ga';
 import { amplitudeLogEvent } from './amplitude';
 import { fullStoryTrackEvent } from 'common/fullstory';
 import { trackGA4Event } from './gtag';
@@ -91,8 +90,15 @@ export enum EventAction {
   OPEN_TOOLTIP = 'open tooltip',
 }
 
+// Capitalize string (special characters are not kept)
 function toTitleCase(name: string) {
   return words(name).map(capitalize).join(' ');
+}
+
+// Capitalize string (special characters kept in place by not using "words" from lodash)
+function toTitleCaseWithSpecialCharacters(name: string) {
+  const words = name.split(' ');
+  return words.map(word => capitalize(word)).join(' ');
 }
 
 /**
@@ -108,19 +114,10 @@ export function trackEvent(
   transport: 'beacon' | 'xhr' | 'image' = 'beacon',
 ) {
   if (category !== EventCategory.NONE) {
-    ReactGA.event({
-      category,
-      action,
-      label,
-      value,
-      nonInteraction,
-      transport,
-    });
-
     trackGA4Event(
       toTitleCase(action),
       toTitleCase(category),
-      toTitleCase(label),
+      toTitleCaseWithSpecialCharacters(label),
       value,
     );
 

--- a/src/components/Analytics/utils.ts
+++ b/src/components/Analytics/utils.ts
@@ -97,8 +97,7 @@ function toTitleCase(name: string) {
 
 // Capitalize string (special characters kept in place by not using "words" from lodash)
 function toTitleCaseWithSpecialCharacters(name: string) {
-  const words = name.split(' ');
-  return words.map(word => capitalize(word)).join(' ');
+  return name.split(' ').map(capitalize).join(' ');
 }
 
 /**


### PR DESCRIPTION
This PR ensures each word for the event label is capitalized, matching how event labels were recorded in UA. Also, since GA4 is now automatically sharing data with UA, we no longer need to send data to both.