### PR TITLE
Skip chromatic daily deploys

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -9,15 +9,14 @@ on:
     # https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/
     branches-ignore:
       - 'dependabot/**'
+      - 'bump-snapshot-**'
 
 jobs:
   chromatic-deployment:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
+        uses: actions/checkout@v3
       - name: Install dependencies
         run: yarn
       - name: Publish to Chromatic

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: Install dependencies
         run: yarn
       - name: Publish to Chromatic


### PR DESCRIPTION
We don't really need to publish Chromatic for daily deploys. I also updated the `actions/checkout` action to v3 (they are compatible).