### PR TITLE
Fix footer button bug

### DIFF
--- a/src/components/Analytics/utils.ts
+++ b/src/components/Analytics/utils.ts
@@ -97,7 +97,7 @@ function toTitleCase(name: string) {
 
 // Capitalize string (special characters kept in place by not using "words" from lodash)
 function toTitleCaseWithSpecialCharacters(name: string) {
-  return name.split(' ').map(capitalize).join(' ');
+  return name ? name.split(' ').map(capitalize).join(' ') : '';
 }
 
 /**


### PR DESCRIPTION
Currently buttons in our footer are broken due to the new way our event labels are parsed. Historically, we allowed event labels to be empty (by using `words` in `toTitleCase` function, which can return an empty string). But now that we're _not_ using `words` and are parsing event labels by simpler string manipulation (rationale was to ensure UA and GA4 event labels match up), our new `toTitleCaseWithSpecialCharacters` function was not allowing `undefined` as an argument although it should have. This causes our site to throw an error when the user clicks on a button inside the footer (where event labels are `undefined`).

This PR fixes the footer button bug by allowing `undefined` to be passed to `toTitleCaseWithSpecialCharacters`.