### PR TITLE
Fix RMSD internal compare option

### DIFF
--- a/src/common/models/ProjectionsPair.ts
+++ b/src/common/models/ProjectionsPair.ts
@@ -118,6 +118,12 @@ function getDataset(projection: Projection, metric: Metric): Column[] {
       return projection.getDataset('icuUtilization');
     case Metric.VACCINATIONS:
       return projection.getDataset('vaccinations');
+    case Metric.WEEKLY_CASES_PER_100K:
+      return projection.getDataset('weeklyNewCasesPer100k');
+    case Metric.RATIO_BEDS_WITH_COVID:
+      return projection.getDataset('bedsWithCovidPatientsRatio');
+    case Metric.ADMISSIONS_PER_100K:
+      return projection.getDataset('weeklyCovidAdmissionsPer100k');
     default:
       fail('Unknown metric: ' + metric);
   }


### PR DESCRIPTION
Add community risk metrics to `getDataset` helper function to fix RMSD/series compare tool. Without these changes the compare tool breaks when attempting to use the RMSD sort option for any of the new(ish) community risk metrics