### PR TITLE
Split email recipient groups

### DIFF
--- a/scripts/alert_emails/template.html
+++ b/scripts/alert_emails/template.html
@@ -251,6 +251,17 @@
                                         </div>
                                     </div>
 
+                                    <!-- Donation -->
+                                    {{#if giveButterDonor}}
+                                    <div>
+                                        <!-- Donation content for GiveButter donation -->
+                                    </div>
+                                    {{else}}
+                                    <div>
+                                        <!-- Donation content for GiveMomentum donation -->
+                                    </div>
+                                    {{/if}}
+
                                     <!-- Alert Settings -->
                                     <div
                                         style="line-height:inherit;Margin-top:24px;Margin-left:20px;Margin-right:20px;Margin-bottom:8px">

--- a/scripts/alert_emails/template.html
+++ b/scripts/alert_emails/template.html
@@ -252,15 +252,9 @@
                                     </div>
 
                                     <!-- Donation -->
-                                    {{#if giveButterDonor}}
                                     <div>
-                                        <!-- Donation content for GiveButter donation -->
+                                        <!-- {{donationText}} -->
                                     </div>
-                                    {{else}}
-                                    <div>
-                                        <!-- Donation content for GiveMomentum donation -->
-                                    </div>
-                                    {{/if}}
 
                                     <!-- Alert Settings -->
                                     <div

--- a/scripts/alert_emails/utils.ts
+++ b/scripts/alert_emails/utils.ts
@@ -36,6 +36,7 @@ interface AlertTemplateData {
   unsubscribe_link: string;
   feedback_subject_line: string;
   disclaimer: Disclaimer | null;
+  giveButterDonor: boolean;
 }
 
 /* EXAMPLE of an alert disclaimer.
@@ -77,6 +78,13 @@ function generateAlertEmailContent(
     locationURL,
   } = locationAlert;
 
+  /**
+   * Split email recipients into two groups.
+   * Group with even email address length receives content linking to GiveButter donation page.
+   * Group with odd email address length receives content linking to GiveMomentum donation page.
+   */
+  const giveButterDonor = emailAddress.length % 2 == 0;
+
   const oldLevelText = LOCATION_SUMMARY_LEVELS[oldLevel].summary;
   const newLevelText = LOCATION_SUMMARY_LEVELS[newLevel].summary;
   const disclaimer = getDisclaimerText(locationAlert.fips);
@@ -95,6 +103,7 @@ function generateAlertEmailContent(
       `[Alert Feedback] Alert for ${locationName} on ${lastUpdated}`,
     ),
     disclaimer,
+    giveButterDonor,
   };
 
   return alertTemplate(data);

--- a/scripts/alert_emails/utils.ts
+++ b/scripts/alert_emails/utils.ts
@@ -36,7 +36,8 @@ interface AlertTemplateData {
   unsubscribe_link: string;
   feedback_subject_line: string;
   disclaimer: Disclaimer | null;
-  giveButterDonor: boolean;
+  donationUrl: string;
+  donationText: string;
 }
 
 /* EXAMPLE of an alert disclaimer.
@@ -66,6 +67,28 @@ function getDisclaimerText(fips: string): Disclaimer | null {
   return null;
 }
 
+interface DonationContent {
+  donationUrl: string;
+  donationText: string;
+}
+
+/**
+ * Split email recipients into two groups.
+ * Group with even email address length receives content linking to GiveButter donation page.
+ * Group with odd email address length receives content linking to GiveMomentum donation page.
+ */
+function getDonationContent(emailAddress: string): DonationContent {
+  return emailAddress.length % 2 == 0
+    ? {
+        donationUrl: 'https://covidactnow.org/donate',
+        donationText: 'hi',
+      }
+    : {
+        donationUrl: 'https://covidactnow.org/give_momentum_donate',
+        donationText: 'hello',
+      };
+}
+
 function generateAlertEmailContent(
   emailAddress: string,
   locationAlert: Alert,
@@ -78,16 +101,10 @@ function generateAlertEmailContent(
     locationURL,
   } = locationAlert;
 
-  /**
-   * Split email recipients into two groups.
-   * Group with even email address length receives content linking to GiveButter donation page.
-   * Group with odd email address length receives content linking to GiveMomentum donation page.
-   */
-  const giveButterDonor = emailAddress.length % 2 == 0;
-
   const oldLevelText = LOCATION_SUMMARY_LEVELS[oldLevel].summary;
   const newLevelText = LOCATION_SUMMARY_LEVELS[newLevel].summary;
   const disclaimer = getDisclaimerText(locationAlert.fips);
+  const donationContent = getDonationContent(emailAddress);
   const data: AlertTemplateData = {
     change: changeText(oldLevel, newLevel),
     location_name: locationName,
@@ -103,7 +120,8 @@ function generateAlertEmailContent(
       `[Alert Feedback] Alert for ${locationName} on ${lastUpdated}`,
     ),
     disclaimer,
-    giveButterDonor,
+    donationUrl: donationContent.donationUrl,
+    donationText: donationContent.donationText,
   };
 
   return alertTemplate(data);

--- a/scripts/alert_emails/utils.ts
+++ b/scripts/alert_emails/utils.ts
@@ -73,12 +73,31 @@ interface DonationContent {
 }
 
 /**
+ * Generate a hash from an email address to aid in
+ * splitting email recipients into two groups of roughly equal size.
+ *
+ * Source: https://stackoverflow.com/a/7616484
+ */
+function getEmailAddressHash(emailAddress: string): number {
+  var hash = 0,
+    i,
+    chr;
+  if (emailAddress.length === 0) return hash;
+  for (i = 0; i < emailAddress.length; i++) {
+    chr = emailAddress.charCodeAt(i);
+    hash = (hash << 5) - hash + chr;
+    hash |= 0; // Convert to 32bit integer
+  }
+  return hash;
+}
+
+/**
  * Split email recipients into two groups.
- * Group with even email address length receives content linking to GiveButter donation page.
- * Group with odd email address length receives content linking to GiveMomentum donation page.
+ * Email addresses with even hash receive content linking to GiveButter donation page.
+ * Email addresses with odd hash receive content linking to GiveMomentum donation page.
  */
 function getDonationContent(emailAddress: string): DonationContent {
-  return emailAddress.length % 2 == 0
+  return getEmailAddressHash(emailAddress) % 2 === 0
     ? {
         donationUrl: 'https://covidactnow.org/donate',
         donationText: '',

--- a/scripts/alert_emails/utils.ts
+++ b/scripts/alert_emails/utils.ts
@@ -81,11 +81,11 @@ function getDonationContent(emailAddress: string): DonationContent {
   return emailAddress.length % 2 == 0
     ? {
         donationUrl: 'https://covidactnow.org/donate',
-        donationText: 'hi',
+        donationText: '',
       }
     : {
         donationUrl: 'https://covidactnow.org/give_momentum_donate',
-        donationText: 'hello',
+        donationText: '',
       };
 }
 


### PR DESCRIPTION
Establish a way to split alert email recipients into two groups. So we can send one group content linking to the GiveButter donation page and the other group content linking to the GiveMomentum donation page.