### PR TITLE
Fix donate button bug in alert email

### DIFF
--- a/scripts/alert_emails/template.html
+++ b/scripts/alert_emails/template.html
@@ -11,6 +11,15 @@
     <!--<![endif]-->
     <meta name="viewport" content="width=device-width">
     <meta name="x-apple-disable-message-reformatting">
+    <style>
+        .donate-button {
+            font-size: 10px;
+        }
+        @media (min-width: 600px) {
+            .donate-button {
+                font-size: 15px;
+            }
+        }
     </style>
 </head>
 <!--[if mso]>
@@ -210,8 +219,8 @@
                                     <div
                                         style="line-height:inherit;Margin-top:24px;Margin-left:20px;Margin-right:20px;Margin-bottom:40px">
                                         <div align="center"
-                                            style="font-size:15px;font-style:normal;font-weight:bold;line-height:21px;Margin-bottom:4px;border-width:0!important;border-style:none!important;border-color:white!important;font-family:Arial,Helvetica,sans-serif;text-align:center;font-size:15px">
-                                            <a style="background: #3567FD;color:#ffffff;padding:18px 16px;border-radius:4px;text-decoration: none;" href="{{donationUrl}}">
+                                            style="font-style:normal;font-weight:bold;line-height:21px;Margin-bottom:4px;border-width:0!important;border-style:none!important;border-color:white!important;font-family:Arial,Helvetica,sans-serif;text-align:center">
+                                            <a class="donate-button" style="background: #3567FD;color:#ffffff;padding:18px 16px;border-radius:4px;text-decoration: none;" href="{{donationUrl}}">
                                                 {{donationText}}
                                             </a>
                                         </div>

--- a/scripts/alert_emails/template.html
+++ b/scripts/alert_emails/template.html
@@ -11,15 +11,6 @@
     <!--<![endif]-->
     <meta name="viewport" content="width=device-width">
     <meta name="x-apple-disable-message-reformatting">
-    <style>
-        .donate-button {
-            font-size: 10px;
-        }
-        @media (min-width: 600px) {
-            .donate-button {
-                font-size: 15px;
-            }
-        }
     </style>
 </head>
 <!--[if mso]>
@@ -219,8 +210,8 @@
                                     <div
                                         style="line-height:inherit;Margin-top:24px;Margin-left:20px;Margin-right:20px;Margin-bottom:40px">
                                         <div align="center"
-                                            style="font-style:normal;font-weight:bold;line-height:21px;Margin-bottom:4px;border-width:0!important;border-style:none!important;border-color:white!important;font-family:Arial,Helvetica,sans-serif;text-align:center">
-                                            <a class="donate-button" style="background: #3567FD;color:#ffffff;padding:18px 16px;border-radius:4px;text-decoration: none;" href="{{donationUrl}}">
+                                            style="font-size:10px;font-style:normal;font-weight:bold;line-height:21px;Margin-bottom:4px;border-width:0!important;border-style:none!important;border-color:white!important;font-family:Arial,Helvetica,sans-serif;text-align:center">
+                                            <a style="background: #3567FD;color:#ffffff;padding:18px 16px;border-radius:4px;text-decoration: none;" href="{{donationUrl}}">
                                                 {{donationText}}
                                             </a>
                                         </div>


### PR DESCRIPTION
Currently the donate link in our alert email is too wide on smaller screen sizes and would wrap. This PR adjusts the font size for smaller screen sizes so the button would not wrap.

**Note:** Since handlebars aren't aware of user screen sizes and since styling in `template.html` is inline, adding a media tag to inline styling is challenging (if even possible, [more info](https://stackoverflow.com/questions/9808233/is-it-possible-to-put-css-media-rules-inline)). So I added the style tag in the document head to handle different screen sizes.

Before:
![image](https://user-images.githubusercontent.com/46338131/180851603-f9d640eb-63ac-4096-8d3b-d2e643819649.png)

After:
![image](https://user-images.githubusercontent.com/46338131/180851638-14f053f8-f06f-427e-a366-e6ebc3376e4c.png)