### PR TITLE
Bump CI github action runner from 18.04 -> 20.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   test:
     name: Test
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v1


### PR DESCRIPTION
The CI threw the following error due to Ubuntu 18 being deprecated:
<img width="1059" alt="image" src="https://user-images.githubusercontent.com/55333380/185943038-a818dd19-a161-40e9-b44c-f9e8f75b65a7.png">

See this run https://github.com/covid-projections/covid-projections/actions/runs/2904542192 for more context
