### PR TITLE
Fix chart margins

### DIFF
--- a/src/components/Charts/ChartVaccinations.tsx
+++ b/src/components/Charts/ChartVaccinations.tsx
@@ -162,7 +162,7 @@ const VaccinationLines: React.FC<{
   height,
   marginTop = 10,
   marginBottom = 30,
-  marginLeft = 32,
+  marginLeft = 38,
   marginRight = 20,
 }) => {
   const innerHeight = height - marginTop - marginBottom;

--- a/src/components/Charts/ChartWeeklyNewCasesPer100k.tsx
+++ b/src/components/Charts/ChartWeeklyNewCasesPer100k.tsx
@@ -59,7 +59,7 @@ const ChartWeeklyNewCasesPer100k: FunctionComponent<{
   height,
   marginTop = 6,
   marginBottom = 40,
-  marginLeft = 30,
+  marginLeft = 32,
   marginRight = 5,
 }) => {
   const chartWidth = width - marginLeft - marginRight;


### PR DESCRIPTION
Y-axis ticks on 2 charts (`% Vaccinated`, `Weekly New Reported Cases`) were getting cut off. This PR adjusts `marginLeft` for both charts to fix

**Before:**

<img width="202" alt="Screen Shot 2022-11-28 at 2 42 54 PM" src="https://user-images.githubusercontent.com/44076375/204366604-b8d7af3d-59c9-45f6-a413-dbb0ab791a3b.png">
<img width="268" alt="Screen Shot 2022-11-28 at 2 42 47 PM" src="https://user-images.githubusercontent.com/44076375/204366605-4cad38ba-dd75-480e-8470-89e376996041.png">

**After:** 

<img width="377" alt="Screen Shot 2022-11-28 at 2 42 37 PM" src="https://user-images.githubusercontent.com/44076375/204366649-deaa2ddc-38ec-4594-b6ef-72e0164265f2.png">
<img width="561" alt="Screen Shot 2022-11-28 at 2 42 21 PM" src="https://user-images.githubusercontent.com/44076375/204366647-d72ee9f0-eefa-452e-86f8-7277ac065f55.png">