### PR TITLE
Reduce storage / billing costs for email alerts.

### DIFF
--- a/scripts/alert_emails/misc/.gitignore
+++ b/scripts/alert_emails/misc/.gitignore
@@ -1,0 +1,1 @@
+stats.json

--- a/scripts/alert_emails/misc/delete-historical-docs.ts
+++ b/scripts/alert_emails/misc/delete-historical-docs.ts
@@ -1,0 +1,39 @@
+/**
+ * Script to go through all the historical sent emails in Firestore and delete
+ * them to save space.
+ */
+
+import { getFirestore } from '../../common/firebase';
+
+// Number of documents to read and delete at once (500 is the max batch size in
+// Firestore).
+const BATCH_SIZE = 500;
+
+async function main() {
+  const db = getFirestore();
+
+  let moreToDelete = true;
+  let totalDeleted = 0;
+  while (moreToDelete) {
+    const querySnapshot = await db
+      .collectionGroup('emails')
+      .limit(BATCH_SIZE)
+      .get();
+
+    const batch = db.batch();
+    for (const doc of querySnapshot.docs) {
+      batch.delete(doc.ref);
+    }
+    await batch.commit();
+    const deleted = querySnapshot.docs.length;
+    totalDeleted += deleted;
+    moreToDelete = deleted > 0;
+  }
+
+  console.info(`Done. Deleted ${totalDeleted} documents.`);
+}
+
+main().catch(e => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/alert_emails/misc/generate-historical-stats.ts
+++ b/scripts/alert_emails/misc/generate-historical-stats.ts
@@ -1,0 +1,134 @@
+/**
+ * Script to go through all the historical sent emails and generate aggregated
+ * stats about emails sent. Stats are incrementally stored to a local file (to
+ * support resuming progress in case an error is reported) and then stored to
+ * Firestore at the end.
+ */
+
+import { getFirestore } from '../../common/firebase';
+import FirebaseFirestore from '@google-cloud/firestore';
+import path from 'path';
+import * as fs from 'fs';
+
+// File to store stats to. This is also used to support resuming in case there's an error.
+const STATS_FILE = path.join(__dirname, 'stats.json');
+
+// Number of documents to read at once.
+const BATCH_SIZE = 50000;
+
+interface SnapshotStats {
+  totalEmailsSent: number;
+}
+
+interface Stats {
+  totalEmailsSent: number;
+  resumePoint?: string;
+  alerts: {
+    [snapshot: string]: SnapshotStats;
+  };
+  vaccinationAlerts: {
+    [snapshot: string]: SnapshotStats;
+  };
+}
+
+async function main() {
+  const stats = readStatsFile();
+  const db = getFirestore();
+
+  let moreBatches = true;
+  while (moreBatches) {
+    moreBatches = await fetchNextBatch(db, stats);
+    console.log(
+      `Counted ${stats.totalEmailsSent} sent emails. Resume point: ${stats.resumePoint}`,
+    );
+    // Write stats file so far so we can resume if we encounter an error.
+    writeStatsFile(stats);
+  }
+
+  writeStatsToFirestore(db, stats);
+
+  console.info(`Done. Stats written to Firestore and to ${STATS_FILE}`);
+}
+
+async function fetchNextBatch(
+  db: FirebaseFirestore.Firestore,
+  stats: Stats,
+): Promise<boolean> {
+  let query = db
+    .collectionGroup('emails')
+    .orderBy(FirebaseFirestore.FieldPath.documentId());
+  if (stats.resumePoint) {
+    query = query.startAfter(stats.resumePoint);
+  }
+  query = query.limit(BATCH_SIZE);
+
+  const querySnapshot = await query.get();
+  let foundDocs = false;
+  for (const doc of querySnapshot.docs) {
+    stats.resumePoint = doc.ref.path;
+    foundDocs = true;
+    if (doc.get('sentAt') === null) {
+      // skip any entries that were never sent.
+      continue;
+    }
+
+    // Update snapshot stats.
+    // Extract snapshot from path: snapshots/{snapshot}/locations/{location}/emails/{email}.
+    const snapshotDoc = doc.ref.parent.parent?.parent.parent!;
+    const snapshotId = snapshotDoc.id;
+    // Get correct stats to update based on whether this was a vaccination alert or normal alert.
+    const snapshotStats =
+      snapshotDoc.parent.id === 'vaccination-alerts'
+        ? stats.vaccinationAlerts
+        : stats.alerts;
+    snapshotStats[snapshotId] = snapshotStats[snapshotId] ?? {
+      totalEmailsSent: 0,
+    };
+    snapshotStats[snapshotId].totalEmailsSent++;
+
+    // Update global stats.
+    stats.totalEmailsSent = stats.totalEmailsSent ?? 0;
+    stats.totalEmailsSent++;
+  }
+
+  return foundDocs;
+}
+
+function readStatsFile(): Stats {
+  if (fs.existsSync(STATS_FILE)) {
+    return JSON.parse(fs.readFileSync(STATS_FILE).toString());
+  } else {
+    return { totalEmailsSent: 0, alerts: {}, vaccinationAlerts: {} };
+  }
+}
+
+function writeStatsFile(stats: Stats) {
+  fs.writeFileSync(STATS_FILE, JSON.stringify(stats));
+}
+
+async function writeStatsToFirestore(
+  db: FirebaseFirestore.Firestore,
+  stats: Stats,
+) {
+  // Write vaccination alert email stats.
+  for (const snapshot in stats.vaccinationAlerts) {
+    db.doc(`vaccination-alert-stats/${snapshot}`).set(
+      stats.vaccinationAlerts[snapshot],
+    );
+  }
+
+  // Write alert email stats.
+  for (const snapshot in stats.alerts) {
+    db.doc(`alert-stats/${snapshot}`).set(stats.alerts[snapshot]);
+  }
+
+  // Write global stats.
+  db.doc('info/alert-stats').set({
+    totalEmailsSent: stats.totalEmailsSent,
+  });
+}
+
+main().catch(e => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/alert_emails/readme.md
+++ b/scripts/alert_emails/readme.md
@@ -42,12 +42,13 @@ The github action should complete in 20 minutes or so and list the number of ema
 ### To manually create the list of users to email
 
 1. Users sign up to the mailing list via the website and are stored in the alerts-subscriptions collection of firestore [dev](https://console.firebase.google.com/project/covidactnow-dev/database/firestore/data~2Falerts-subscriptions) with a field of locations that is an array of fips codes that the user has signed up to recieve alerts for.
-2. Run `yarn create-lists-to-email fipsToAlertFilename <snapshot>` which will write to firestore `snapshots/<snapshot>/locations/<fips>/emails` for all the users that need to recieve emails for each of the snapshots/fips.
+2. Run `yarn create-lists-to-email alerts.json <snapshot>` which will write to firestore `snapshots/<snapshot>/locations/<fips>/emails` for all the users that need to recieve emails for each of the snapshots/fips.
 
 ### Sending the email
 
-1. If you have run the above steps and have users signed up for emails in the following locations you can run `yarn send-emails alerts.json 497 true <youremail>` which will send the emails to those users on dev.
-2. You can also passin an extra param `yarn send-emails alerts.json 497 true <youremail>` which will send all the emails to one email address for testing.
+1. If you have run the above steps and have users signed up for emails in the following locations you can run `yarn send-emails alerts.json <snapshot> true` which will send the emails to those users on dev.
+
+NOTE: You can pass `false` instead of `true` to do a dry-run instead: `yarn send-emails alerts.json <snapshot> false`.
 
 ## Testing Email HTML
 


### PR DESCRIPTION
This PR reduces the amount of data we will store long-term for past email alerts. We will:

* Add a `deleteAt` field to the docs written to Firestore that will trigger a TTL policy to delete alert docs after 2 weeks.
* Write stats after sending emails since we'll no longer be able to calculate them once the docs are deleted. We write per-snapshot stats to `/alert-stats/[snapshot]` and global stats to `/info/alert-stats`.
* I'm also checking in a couple scripts I'm using to generate historical stats and delete historical documents. These will only be run once, but I'm checking them in for future reference.

I've tested everything on the [covidactnow-dev Firestore instance](https://console.firebase.google.com/project/covidactnow-dev/firestore/data/) (except the fact that the TTL policy runs, since that will take 2+ weeks to kick in, but it should be very straightforward).  If you look there you'll see:

1. Historical stats have been generated (by my generate-historical-stats) script for all past snapshots, e.g.: ![image](https://user-images.githubusercontent.com/206364/207523345-ffc04830-0b30-489e-8a81-a40f0248bf5c.png)
2. The past `snapshots/<snapshot>` and `/vaccination-alerts/<snapshot>` locations are gone because I ran the `delete-historical-docs` script to delete them.
3. I did a fresh email alert run for snapshot 4388 and it marked the generated docs with a `deleteAt` value 2 weeks in the future: ![image](https://user-images.githubusercontent.com/206364/207642023-26af9a18-94f1-4389-812d-9004370d898a.png)
4. And it generated appropriate stats: 
![image](https://user-images.githubusercontent.com/206364/207638514-92ac6e00-c536-460e-a0dc-a597ed926a95.png)

I have also run the `generate-historical-stats.ts` scripts on staging and prod so they have `alert-stats` documents for each snapshot, and `info/alert-stats` global stats populated. (Fun fact, we've sent 13.7M email alerts to date)

Once this is reviewed / merged, I will go ahead and run the `delete-historical-docs.ts` script on staging and prod to clean up the past documents.
