### PR TITLE
Remove 3rd-Party Slack Webhook for Email Alerts

### DIFF
--- a/.github/workflows/send-alert-emails.yml
+++ b/.github/workflows/send-alert-emails.yml
@@ -1,4 +1,4 @@
-name: Send Risk Alert Emails.
+name: Send Risk Alert Emails
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Remove 3rd-Party Slack Webhook specifically for the email alert. Functionality is being replaced with the 1st party slack/github app, which will post the action (and the status updates) directly to the #notifications-daily-deploys.

We are keeping the original slack bot to post more detailed commit messages (like the one for promoting the next api snapshot).