### PR TITLE
pin-node-16-for-storybook

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -19,6 +19,10 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - name: Use Node 16
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
       - name: Install dependencies
         run: yarn
       - name: Publish to Chromatic


### PR DESCRIPTION
The github action running the storybook deploy upgraded to node 19. I tried the happy path upgrade options for storybook, but they ran into some webpack 4/5 migrations I don't want to deal with right now.

So I'm following the GH recommended step to set node by following (https://github.com/actions/setup-node).

Node 16 is still good through Sept 11, 2023.