### PR TITLE
Remove Google Optimize Script (#7312)

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -61,9 +61,6 @@
   <link rel="stylesheet"
     href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;700&family=Roboto:wght@400;500;700&display=swap" />
 
-  <!-- Google Optimize for A/B testing: Uncomment when running experiments -->
-  <script async src="https://www.googleoptimize.com/optimize.js?id=OPT-WT27VPR"></script>
-
   <!-- Twitter universal website tag code -->
   <script async>
     !(function (e, t, n, s, u, a) {


### PR DESCRIPTION
Unnecessary since we aren't running any A/B testing. Currently throws a logged error in production.