### PR TITLE
Legal Copy Updates (#8104)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 > [!CAUTION]
-> This page is no longer being updated due to a lack of reliable data. While we continue to surface this content for archival purposes, we recommend that you visit more regularly updated resources, such as from the [CDC](https://www.cdc.gov/coronavirus/2019-ncov/index.html).
+> This page is no longer being updated due to limited data availability. We continue to surface this content for archival purposes.
 
 # Covid Act Now
 

--- a/src/cms-content/learn/metric-explainers.json
+++ b/src/cms-content/learn/metric-explainers.json
@@ -132,12 +132,12 @@
       "sectionHeader": " ICU capacity used",
       "sectionSubheader": "",
       "sectionId": "icu-capacity-used",
-      "sectionIntro": "**ICU capacity used measures the number of intensive care unit (ICU) beds that are currently in use.**",
+      "sectionIntro": "**ICU capacity used measured the number of intensive care unit (ICU) beds that were in use.**",
       "questions": [
         {
           "questionId": "icu-capacity-used-sources-methodology",
           "question": "Sources and methodology",
-          "answer": "We calculate ICU capacity by taking the number of staffed ICU beds that are occupied (by both COVID and Non-COVID patients) and dividing it by the total number of staffed ICU beds. We use data from the [Department of Health and Human Services (HHS)](https://healthdata.gov/Hospital/COVID-19-Reported-Patient-Impact-and-Hospital-Capa/g62h-syeh) to calculate the metric. This data is provided to the HHS via three sources: (1) HHS TeleTracking, (2) reporting provided directly to HHS Protect by state/territorial health departments on behalf of their healthcare facilities and (3) National Healthcare Safety Network (before July 15). For counties we aggregate the data for all counties in the health service area.\n\nFor more details, see the Trends module."
+          "answer": "We calculated ICU capacity by taking the number of staffed ICU beds that were occupied (by both COVID and Non-COVID patients) and dividing it by the total number of staffed ICU beds. We used data from the [Department of Health and Human Services (HHS)](https://healthdata.gov/Hospital/COVID-19-Reported-Patient-Impact-and-Hospital-Capa/g62h-syeh) to calculate the metric. This data was provided to the HHS via three sources: (1) HHS TeleTracking, (2) reporting provided directly to HHS Protect by state/territorial health departments on behalf of their healthcare facilities and (3) National Healthcare Safety Network (before July 15). For counties we aggregated the data for all counties in the health service area.\n\nFor more details, see the Trends module."
         },
         {
           "question": "Limitations",

--- a/src/cms-content/tooltips/info-tooltips.json
+++ b/src/cms-content/tooltips/info-tooltips.json
@@ -3,7 +3,7 @@
     {
       "title": "Location page header",
       "id": "location-page-header",
-      "body": "Our COVID assessment is based on the CDC’s Community Level framework. This looks at three primary things: weekly new reported cases per 100K, weekly COVID admissions per 100K, and the percent of staffed inpatient beds occupied by COVID patients.\n\nEach metric is graded on a three-color scale. If weekly new reported cases per 100K population is below 200, depending on the levels of the other two indicators, community risk level can range from Low to Medium to High. If weekly new reported cases per 100K population is equal to or above 200, depending on the levels of the other two indicators, community risk level is either Medium or High.\n\nRead more about our community risk level framework.\n\nNote that we updated our COVID scoring in April of 2022 to better reflect the rise in vaccinations and natural immunity.",
+      "body": "Our COVID assessment is based on the CDC's Community Level framework. This looks at three primary things: weekly new reported cases per 100K, weekly COVID admissions per 100K, and the percent of staffed inpatient beds occupied by COVID patients.\n\nEach metric is graded on a three-color scale. If weekly new reported cases per 100K population is below 200, depending on the levels of the other two indicators, community risk level can range from Low to Medium to High. If weekly new reported cases per 100K population is equal to or above 200, depending on the levels of the other two indicators, community risk level is either Medium or High.\n\nRead more about our community risk level framework.\n\nNote that we updated our COVID scoring in April of 2022 to better reflect the rise in vaccinations and natural immunity.",
       "cta": "Learn more about COVID risk levels."
     },
     {
@@ -27,7 +27,7 @@
     {
       "title": "Infection rate",
       "id": "infection-rate",
-      "body": "Infection rate represents how fast COVID is spreading in a given area right now by estimating the number of people that a newly infected person goes on to eventually infect.",
+      "body": "Infection rate represented how fast COVID was spreading in a given area by estimating the number of people that a newly infected person would go on to infect.",
       "cta": "Learn more about infection rate."
     },
     {
@@ -37,7 +37,7 @@
       "cta": "Learn more about positive test rate."
     },
     {
-      "body": "ICU capacity used is the percentage of staffed intensive care unit (ICU) beds in a location’s healthcare system that are currently in use by both COVID and non-COVID patients.\n\nExperts indicate that during pre-pandemic years, average ICU occupancy in U.S. hospitals ranged from 57% to 82%.",
+      "body": "ICU capacity used was the percentage of staffed intensive care unit (ICU) beds in a location's healthcare system that were in use by both COVID and non-COVID patients.\n\nExperts indicate that during pre-pandemic years, average ICU occupancy in U.S. hospitals ranged from 57% to 82%.",
       "cta": "Learn more about ICU capacity used.",
       "title": "ICU capacity used",
       "id": "icu-capacity-used"

--- a/src/common/metrics/admissions_per_100k.tsx
+++ b/src/common/metrics/admissions_per_100k.tsx
@@ -137,13 +137,12 @@ function renderStatus(projections: Projections): React.ReactElement {
 
   return (
     <Fragment>
-      Over the last week, {projections.isCounty ? hsaCopy : locationName} had{' '}
-      {weeklyNewCovidAdmissionsText} new COVID hospital admissions (
+      As of May 2024, {projections.isCounty ? hsaCopy : locationName} had{' '}
+      {weeklyNewCovidAdmissionsText} weekly COVID hospital admissions (
       <b>{formatDecimal(weeklyCovidAdmissionsPer100k, 1)}</b> for every 100,000
       residents). Grading is not applied to weekly COVID admissions prior to
       April 18, 2022, indicated by the dotted line. This date marks our change
-      to measure community risk levels, a framework that is only relevant for
-      the current phase of the pandemic.
+      to measure community risk levels.
     </Fragment>
   );
 }

--- a/src/common/metrics/case_density.tsx
+++ b/src/common/metrics/case_density.tsx
@@ -109,9 +109,9 @@ function renderStatus(projections: Projections): React.ReactElement {
 
   return (
     <Fragment>
-      Over the last week, {locationName} has averaged {newCasesPerDayText} new
-      confirmed cases per day (<b>{formatDecimal(currentCaseDensity, 1)}</b> for
-      every 100,000 residents).
+      As of May 2024, {locationName} averaged {newCasesPerDayText} new confirmed
+      cases per day (<b>{formatDecimal(currentCaseDensity, 1)}</b> for every
+      100,000 residents).
     </Fragment>
   );
 }

--- a/src/common/metrics/case_growth.tsx
+++ b/src/common/metrics/case_growth.tsx
@@ -106,9 +106,9 @@ function renderStatus(projections: Projections): React.ReactElement {
 
   return (
     <Fragment>
-      On average, each person in {locationName} with COVID is infecting{' '}
-      {formatDecimal(rt)} other people. If this number is over 1.0, it means
-      that the total number of COVID cases is growing.
+      As of May 2024, each person in {locationName} with COVID was infecting{' '}
+      {formatDecimal(rt)} other people on average. A number over 1.0 meant that
+      the total number of COVID cases was growing.
     </Fragment>
   );
 }

--- a/src/common/metrics/hospitalizations.tsx
+++ b/src/common/metrics/hospitalizations.tsx
@@ -91,7 +91,7 @@ function renderStatus(projections: Projections): React.ReactElement {
     );
   }
 
-  const hsaCopy = `The ${projections.primary.hsaName} Health Service Area`;
+  const hsaCopy = `the ${projections.primary.hsaName} Health Service Area`;
   const totalICUBeds = formatInteger(icu.totalBeds);
   const totalICUPatients = formatInteger(icu.totalPatients);
   if (icu.metricValue === null) {
@@ -102,9 +102,9 @@ function renderStatus(projections: Projections): React.ReactElement {
 
     return (
       <Fragment>
-        {isCounty ? hsaCopy : locationName} has reported having {totalICUBeds}{' '}
-        staffed adult ICU beds and {totalICUPatients} are currently filled. Due
-        to the low number of beds, we do not report{' '}
+        As of May 2024, {isCounty ? hsaCopy : locationName} had {totalICUBeds}{' '}
+        staffed adult ICU beds and {totalICUPatients} were filled. Due to the
+        low number of beds, we do not report{' '}
         {ICUCapacityUsed.extendedMetricName} data.
       </Fragment>
     );
@@ -118,14 +118,14 @@ function renderStatus(projections: Projections): React.ReactElement {
   if (icu.covidPatients !== null && icu.nonCovidPatients !== null) {
     const nonCovidICUPatients = formatInteger(icu.nonCovidPatients);
     const covidICUPatients = formatInteger(icu.covidPatients);
-    patientBreakdown = `${nonCovidICUPatients} are filled by non-COVID patients and ${covidICUPatients} are filled by COVID patients.`;
+    patientBreakdown = `${nonCovidICUPatients} were filled by non-COVID patients and ${covidICUPatients} were filled by COVID patients.`;
   }
 
   return (
     <Fragment>
-      {isCounty ? hsaCopy : locationName} has reported having {totalICUBeds}{' '}
+      As of May 2024, {isCounty ? hsaCopy : locationName} had {totalICUBeds}{' '}
       staffed adult ICU beds. {patientBreakdown} Overall, {totalICUPatients} out
-      of {totalICUBeds} ({icuCapacityUsed}) are filled.
+      of {totalICUBeds} ({icuCapacityUsed}) were filled.
     </Fragment>
   );
 }

--- a/src/common/metrics/positive_rate.tsx
+++ b/src/common/metrics/positive_rate.tsx
@@ -110,8 +110,8 @@ function renderStatus(projections: Projections) {
 
   return (
     <Fragment>
-      In {locationName} {percentage} of COVID tests were positive this past
-      week. The positive test rate does not include data on at-home positive
+      As of May 2024, {percentage} of COVID tests in {locationName} were
+      positive. The positive test rate does not include data on at-home positive
       tests.
     </Fragment>
   );

--- a/src/common/metrics/ratio_beds_with_covid_patients.tsx
+++ b/src/common/metrics/ratio_beds_with_covid_patients.tsx
@@ -108,12 +108,11 @@ function renderStatus(projections: Projections): React.ReactElement {
   const hsaCopy = `the ${projections.primary.hsaName} Health Service Area`;
   return (
     <Fragment>
-      {formatPercent(currentRatioBedsWithCovid)} of staffed inpatient beds in{' '}
-      {projections.isCounty ? hsaCopy : locationName} are occupied by COVID
-      patients. Grading is not applied to patients with COVID prior to April 18,
-      2022, indicated by the dotted line. This date marks our change to measure
-      community risk levels, a framework that is only relevant for the current
-      phase of the pandemic.
+      As of May 2024, {formatPercent(currentRatioBedsWithCovid)} of staffed
+      inpatient beds in {projections.isCounty ? hsaCopy : locationName} were
+      occupied by COVID patients. Grading is not applied to patients with COVID
+      prior to April 18, 2022, indicated by the dotted line. This date marks our
+      change to measure community risk levels.
     </Fragment>
   );
 }

--- a/src/common/metrics/vaccinations.tsx
+++ b/src/common/metrics/vaccinations.tsx
@@ -98,7 +98,7 @@ function renderStatus(projections: Projections): React.ReactElement {
   let ifNoAdditionalDoseAnd;
   if (peopleAdditionalDose != null && percentAdditionalDose != null) {
     additionalDoseText = ` ${peopleAdditionalDose} (${percentAdditionalDose})
-    have received a booster dose`;
+    had received a booster dose`;
     ifNoAdditionalDoseAnd = ``;
   } else {
     additionalDoseText = ``;
@@ -112,7 +112,7 @@ function renderStatus(projections: Projections): React.ReactElement {
     percentBivalentFall2022Booster != null
   ) {
     bivalentFall2022BoosterText = `, and ${peopleBivalentFall2022Booster} (${percentBivalentFall2022Booster})
-    have received an updated bivalent booster dose`;
+    had received an updated bivalent booster dose`;
     ifNoBivalentFall2022BoosterAnd = ``;
   } else {
     bivalentFall2022BoosterText = ``;
@@ -131,14 +131,14 @@ function renderStatus(projections: Projections): React.ReactElement {
 
   return (
     <Fragment>
-      In {locationName}, {peopleInitiated} people ({percentInitiated}) have
-      received at least one dose,{ifNoAdditionalDoseAnd} {peopleVaccinated} (
-      {percentVaccinated}) have received at least two doses or a single Johnson
-      & Johnson dose, {ifNoBivalentFall2022BoosterAnd}
+      As of May 2024, {peopleInitiated} people in {locationName} (
+      {percentInitiated}) had received at least one dose,{ifNoAdditionalDoseAnd}{' '}
+      {peopleVaccinated} ({percentVaccinated}) had received at least two doses
+      or a single Johnson & Johnson dose, {ifNoBivalentFall2022BoosterAnd}
       {additionalDoseText}
-      {bivalentFall2022BoosterText}. We do not yet have data available for the
+      {bivalentFall2022BoosterText}. We do not have data available for the
       2023/2024 updated boosters. <br /> <br /> Fewer than 0.001% of people who
-      have received a dose experienced a severe adverse reaction.{' '}
+      received a dose experienced a severe adverse reaction.{' '}
       {cappedVaccinatedCopy}
       <ExternalLink href="https://www.aap.org/en/patient-care/covid-19/covid-19-vaccine-frequently-asked-questions/">
         See more vaccine resources and FAQs

--- a/src/common/metrics/weekly_new_cases_per_100k.tsx
+++ b/src/common/metrics/weekly_new_cases_per_100k.tsx
@@ -121,13 +121,12 @@ function renderStatus(projections: Projections): React.ReactElement {
 
   return (
     <Fragment>
-      Over the last week, {locationName} had {newCasesPerWeekText} new reported
+      As of May 2024, {locationName} had {newCasesPerWeekText} weekly reported
       cases (<b>{formatDecimal(currentWeeklyReportedCases, 1)}</b> for every
       100,000 residents). Reported cases do not include all at-home positive
       tests. Grading is not applied to weekly new reported cases prior to April
       18, 2022, indicated by the dotted line. This date marks our change to
-      measure community risk levels, a framework that is only relevant for the
-      current phase of the pandemic.
+      measure community risk levels.
     </Fragment>
   );
 }

--- a/src/components/Banner/HiatusBanner.tsx
+++ b/src/components/Banner/HiatusBanner.tsx
@@ -19,7 +19,7 @@ export const HiatusBanner = ({ type = 'homepage' }: HiatusBannerProps) => {
     <Container>
       <InnerContainer>
         <Body>
-          This page is no longer being updated due to a lack of reliable data.
+          This page is no longer being updated due to limited data availability.
           While we continue to surface this content for archival purposes, we
           recommend that you visit more regularly updated resources, such as
           from the{' '}

--- a/src/components/Dialogs/utils.tsx
+++ b/src/components/Dialogs/utils.tsx
@@ -69,7 +69,7 @@ export const exploreMetricToFooterContentMap: {
     metricName: 'ICU hospitalizations',
     howItsCalculated: 'Our ICU hospitalizations number is a seven-day average.',
     metricDefinition:
-      'This is the number of patients currently hospitalized in the ICU with COVID.',
+      'This was the number of patients hospitalized in the ICU with COVID.',
     source: 'Department of Health and Human Services',
     statusTextMeasure: 'COVID patients hospitalized in ICUs',
   },
@@ -78,7 +78,7 @@ export const exploreMetricToFooterContentMap: {
     howItsCalculated:
       'Our hospitalizations number is a seven-day average. For counties, it is calculated for the health service area that contains the county, and then county-level data is estimated by disaggregating the data by population.',
     metricDefinition:
-      'This is the number of patients currently hospitalized with COVID.',
+      'This was the number of patients hospitalized with COVID.',
     source: 'Department of Health and Human Services',
     statusTextMeasure: 'COVID patients in hospitals',
   },

--- a/src/components/NewLocationPage/ChartFooter/utils.ts
+++ b/src/components/NewLocationPage/ChartFooter/utils.ts
@@ -23,10 +23,10 @@ export function getAddedMetricStatusText(
     ].includes(metric)
   ) {
     const hsaFormattedValue = formattedHsaCovidUsage(metric, projections);
-    return `Over the last week, the ${projections.primary.hsaName} Health Service Area has averaged ${hsaFormattedValue} ${exploreMetricToFooterContentMap[metric].statusTextMeasure}, for an estimated ${value} patients from ${region.shortName}.`;
+    return `As of May 2024, the ${projections.primary.hsaName} Health Service Area averaged ${hsaFormattedValue} ${exploreMetricToFooterContentMap[metric].statusTextMeasure}, for an estimated ${value} patients from ${region.shortName}.`;
   }
 
-  return `Over the last week, ${region.shortName} has averaged ${value} ${exploreMetricToFooterContentMap[metric].statusTextMeasure}.`;
+  return `As of May 2024, ${region.shortName} averaged ${value} ${exploreMetricToFooterContentMap[metric].statusTextMeasure}.`;
 }
 
 export interface DialogProps {

--- a/src/screens/Terms/Privacy.tsx
+++ b/src/screens/Terms/Privacy.tsx
@@ -11,7 +11,7 @@ const Privacy = ({ children }: { children: React.ReactNode }) => {
           Website Privacy Policy
         </Typography>
         <Typography variant="h6" component="h1" align="center">
-          Last updated: March 28, 2020
+          Last updated: January 27, 2026
         </Typography>
         <Typography variant="h5" component="h1">
           Introduction
@@ -26,6 +26,11 @@ const Privacy = ({ children }: { children: React.ReactNode }) => {
           or that you may provide when you visit the website CoVidActNow.org
           (our "<b>Website</b>") and our practices for collecting, using,
           maintaining, protecting, and disclosing that information.
+        </Typography>
+        <Typography variant="body1" component="p">
+          This Privacy Policy applies only to your use of the covidactnow.org
+          website, and not to other websites managed by the Act Now Coalition,
+          such as actnowcoalition.org.
         </Typography>
         <Typography variant="body1" component="p">
           This policy applies to information we collect:
@@ -200,7 +205,8 @@ const Privacy = ({ children }: { children: React.ReactNode }) => {
         <Typography variant="body1" component="p">
           We also may use these technologies to collect information about your
           online activities over time and across third-party websites or other
-          online services (behavioral tracking). Click here for information on
+          online services (behavioral tracking). See the "Choices About How We
+          Use and Disclose Your Information" section below for information on
           how you can opt out of behavioral tracking on this website and how we
           respond to web browser signals and other mechanisms that enable
           consumers to exercise choice about behavioral tracking.

--- a/src/screens/Terms/Terms.tsx
+++ b/src/screens/Terms/Terms.tsx
@@ -11,6 +11,14 @@ const Terms = ({ children }: { children: React.ReactNode }) => {
           Summary of Terms of Use
         </Typography>
         <Typography variant="body1" component="p">
+          <b>
+            Please note that this website is now maintained for historical and
+            archival purposes only. The data and information presented reflect
+            the COVID-19 pandemic as it was tracked during the period when the
+            site was actively updated.
+          </b>
+        </Typography>
+        <Typography variant="body1" component="p">
           For quick and easy reference, we’ve provided a summary below of our
           Terms of Use. We hope it’s helpful and saves you some time. That being
           said, we’re required to tell you that the full “Website Terms of Use”
@@ -32,14 +40,6 @@ const Terms = ({ children }: { children: React.ReactNode }) => {
               modeling approach, or other reasons.
             </li>
             <li>
-              There are known (and unknown) limitations of the model (known
-              limitations available{' '}
-              <a href="https://docs.google.com/document/d/1ETeXAfYOvArfLvlxExE0_xrO5M4ITC0_Am38CRusCko/preview#">
-                here
-              </a>
-              , as updated and amended from time to time). Please read them.
-            </li>
-            <li>
               Our website is intended to promote dissemination of information
               and data presently available and to enable public leaders and
               health officials to make fast decisions. Please use it for that
@@ -55,7 +55,7 @@ const Terms = ({ children }: { children: React.ReactNode }) => {
           Website Terms of Use
         </Typography>
         <Typography variant="h6" component="h1" align="center">
-          Last updated: October 26, 2022
+          Last updated: January 27, 2026
         </Typography>
         <Typography variant="h5" component="h1">
           Acceptance of the Terms of Use
@@ -88,6 +88,11 @@ const Terms = ({ children }: { children: React.ReactNode }) => {
           are of legal age to form a binding contract with the Company and meet
           all of the foregoing eligibility requirements. If you do not meet all
           of these requirements, you must not access or use the Website.
+        </Typography>
+        <Typography variant="body1" component="p">
+          These Terms of Use apply only to your use of the covidactnow.org
+          website, and not to other websites managed by the Act Now Coalition,
+          such as actnowcoalition.org.
         </Typography>
 
         <Typography variant="h5" component="h1">
@@ -209,7 +214,7 @@ const Terms = ({ children }: { children: React.ReactNode }) => {
           Under a non-commercial license, you may use our data without
           requesting permission, provided that you give proper attribution.
           However, if your use case falls within the list of "Prohibited Uses”,
-          please cease all use of our product and trademarks.
+          you must cease all use of our product and trademarks.
         </Typography>
 
         <Typography variant="h5" component="h1">
@@ -298,11 +303,11 @@ const Terms = ({ children }: { children: React.ReactNode }) => {
           User Contributions
         </Typography>
         <Typography variant="body1" component="p">
-          The Website may contain message boards, chat rooms, personal web pages
-          or profiles, forums, bulletin boards, and other interactive features
-          (collectively, "<b>Interactive Services</b>") that allow users to
-          post, submit, publish, display or transmit to other users or other
-          persons (hereinafter, "<b>post</b>") content or materials
+          The Website may have previously contained message boards, personal web
+          pages or profiles, forums, bulletin boards, and other interactive
+          features (collectively, "<b>Interactive Services</b>") that allowed
+          users to post, submit, publish, display or transmit to other users or
+          other persons (hereinafter, "<b>post</b>") content or materials
           (collectively, "<b>User Contributions</b>") on or through the Website.
         </Typography>
         <Typography variant="body1" component="p">
@@ -496,18 +501,19 @@ const Terms = ({ children }: { children: React.ReactNode }) => {
         </Typography>
         <Typography variant="body1" component="p">
           This Website includes content provided by third parties, including but
-          not limited to materials provided by US Center for Disease Control
-          (CDC), Johns Hopkins University, World Health Organization, Kaiser
-          Family Foundation, Corona Data Scraper, Covid Tracking Project,
-          American Hospital Association, Wikipedia, and other users, third-party
-          licensors, syndicators, aggregators and/or reporting services. All
-          statements and/or opinions expressed in these materials, and all
-          articles and responses to questions and other content, other than the
-          content provided by the Company, are solely the opinions and the
-          responsibility of the person or entity providing those materials.
-          These materials do not necessarily reflect the opinion of the Company.
-          We are not responsible, or liable to you or any third party, for the
-          content or accuracy of any materials provided by any third parties.
+          not limited to materials provided by the Centers for Disease Control
+          and Prevention (CDC), Johns Hopkins University, World Health
+          Organization, Kaiser Family Foundation, Corona Data Scraper, Covid
+          Tracking Project, American Hospital Association, Wikipedia, and other
+          users, third-party licensors, syndicators, aggregators and/or
+          reporting services. All statements and/or opinions expressed in these
+          materials, and all articles and responses to questions and other
+          content, other than the content provided by the Company, are solely
+          the opinions and the responsibility of the person or entity providing
+          those materials. These materials do not necessarily reflect the
+          opinion of the Company. We are not responsible, or liable to you or
+          any third party, for the content or accuracy of any materials provided
+          by any third parties.
         </Typography>
         <Typography variant="body1" component="p">
           The information provided on this Website is subject to various
@@ -523,10 +529,13 @@ const Terms = ({ children }: { children: React.ReactNode }) => {
           Changes to the Website
         </Typography>
         <Typography variant="body1" component="p">
-          We may update the content on this Website from time to time, but its
-          content is not necessarily complete or up-to-date. Any of the material
-          on the Website may be out of date at any given time, and we are under
-          no obligation to update such material.
+          This website is now maintained for historical and archival purposes
+          only. The data and information presented reflect the COVID-19 pandemic
+          as it was tracked during the period when the site was actively
+          updated. We may update the content on this Website from time to time,
+          but its content is not necessarily complete or up-to-date. Any of the
+          material on the Website may be out of date at any given time, and we
+          are under no obligation to update such material.
         </Typography>
 
         <Typography variant="h5" component="h1">
@@ -772,10 +781,10 @@ const Terms = ({ children }: { children: React.ReactNode }) => {
           Waiver and Severability
         </Typography>
         <Typography variant="body1" component="p">
-          No waiver of by the Company of any term or condition set forth in
-          these Terms of Use shall be deemed a further or continuing waiver of
-          such term or condition or a waiver of any other term or condition, and
-          any failure of the Company to assert a right or provision under these
+          No waiver by the Company of any term or condition set forth in these
+          Terms of Use shall be deemed a further or continuing waiver of such
+          term or condition or a waiver of any other term or condition, and any
+          failure of the Company to assert a right or provision under these
           Terms of Use shall not constitute a waiver of such right or provision.
         </Typography>
         <Typography variant="body1" component="p">


### PR DESCRIPTION
Overview
Updates site-wide copy to reflect an archival/hiatus state and reframe metrics as historical.

Rewords the README caution and HiatusBanner messaging around limited data availability, and updates multiple metric status/tooltip strings to use past tense plus an explicit "As of May 2024" timestamp (including chart footers and metric dialogs), removing language implying current guidance.

Refreshes legal pages (Terms, Privacy) with a new last-updated date (Jan 27, 2026) and adds clarifications about archival purpose and scope limited to covidactnow.org (not other Act Now Coalition sites), plus minor wording cleanups.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Primarily copy-only changes, but they update legal Terms/Privacy language and user-facing metric guidance text, so reviewers should verify wording accuracy and consistency across the site.
> 
> **Overview**
> Updates site-wide messaging to reflect an archival/hiatus state, including revised README and `HiatusBanner` wording around limited data availability.
> 
> Rephrases multiple metric status strings, tooltips, and chart footer text to past tense and adds an explicit "As of May 2024" timestamp, removing language that implied current guidance (e.g., admissions/cases/ICU/positive rate/vaccinations and explore-metric dialogs).
> 
> Refreshes the Terms and Privacy pages with a new last-updated date (Jan 27, 2026), adds scope clarifications limited to `covidactnow.org`, and includes additional archival-purpose language plus minor wording cleanups.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f10c86822d45e492689282ddd27b4003a08e7ec7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->